### PR TITLE
fix(docs): Remove horizontal rule from Markdown display to fix Sphinx…

### DIFF
--- a/docs/web/en/user_guide/tutorials/time_frequency_analysis_comparison.ipynb
+++ b/docs/web/en/user_guide/tutorials/time_frequency_analysis_comparison.ipynb
@@ -45,10 +45,10 @@
    "execution_count": 1,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-13T05:57:57.530244Z",
-     "iopub.status.busy": "2026-02-13T05:57:57.530130Z",
-     "iopub.status.idle": "2026-02-13T05:57:59.485068Z",
-     "shell.execute_reply": "2026-02-13T05:57:59.484345Z"
+     "iopub.execute_input": "2026-02-13T06:10:01.153778Z",
+     "iopub.status.busy": "2026-02-13T06:10:01.153643Z",
+     "iopub.status.idle": "2026-02-13T06:10:03.080688Z",
+     "shell.execute_reply": "2026-02-13T06:10:03.079856Z"
     }
    },
    "outputs": [
@@ -113,10 +113,10 @@
    "execution_count": 2,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-13T05:57:59.512351Z",
-     "iopub.status.busy": "2026-02-13T05:57:59.511602Z",
-     "iopub.status.idle": "2026-02-13T05:57:59.842452Z",
-     "shell.execute_reply": "2026-02-13T05:57:59.841978Z"
+     "iopub.execute_input": "2026-02-13T06:10:03.113079Z",
+     "iopub.status.busy": "2026-02-13T06:10:03.112195Z",
+     "iopub.status.idle": "2026-02-13T06:10:03.447347Z",
+     "shell.execute_reply": "2026-02-13T06:10:03.446646Z"
     }
    },
    "outputs": [
@@ -231,10 +231,10 @@
    "execution_count": 3,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-13T05:57:59.845053Z",
-     "iopub.status.busy": "2026-02-13T05:57:59.844925Z",
-     "iopub.status.idle": "2026-02-13T05:58:00.133109Z",
-     "shell.execute_reply": "2026-02-13T05:58:00.132404Z"
+     "iopub.execute_input": "2026-02-13T06:10:03.450498Z",
+     "iopub.status.busy": "2026-02-13T06:10:03.450370Z",
+     "iopub.status.idle": "2026-02-13T06:10:03.745747Z",
+     "shell.execute_reply": "2026-02-13T06:10:03.744992Z"
     }
    },
    "outputs": [
@@ -300,10 +300,10 @@
    "execution_count": 4,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-13T05:58:00.135084Z",
-     "iopub.status.busy": "2026-02-13T05:58:00.134940Z",
-     "iopub.status.idle": "2026-02-13T05:58:00.574131Z",
-     "shell.execute_reply": "2026-02-13T05:58:00.573527Z"
+     "iopub.execute_input": "2026-02-13T06:10:03.748317Z",
+     "iopub.status.busy": "2026-02-13T06:10:03.748190Z",
+     "iopub.status.idle": "2026-02-13T06:10:04.193577Z",
+     "shell.execute_reply": "2026-02-13T06:10:04.192845Z"
     }
    },
    "outputs": [
@@ -382,10 +382,10 @@
    "execution_count": 5,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-13T05:58:00.575719Z",
-     "iopub.status.busy": "2026-02-13T05:58:00.575600Z",
-     "iopub.status.idle": "2026-02-13T05:58:01.962989Z",
-     "shell.execute_reply": "2026-02-13T05:58:01.961727Z"
+     "iopub.execute_input": "2026-02-13T06:10:04.195898Z",
+     "iopub.status.busy": "2026-02-13T06:10:04.195763Z",
+     "iopub.status.idle": "2026-02-13T06:10:05.611016Z",
+     "shell.execute_reply": "2026-02-13T06:10:05.610395Z"
     }
    },
    "outputs": [
@@ -550,10 +550,10 @@
    "execution_count": 6,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-13T05:58:01.965204Z",
-     "iopub.status.busy": "2026-02-13T05:58:01.964871Z",
-     "iopub.status.idle": "2026-02-13T05:58:02.886357Z",
-     "shell.execute_reply": "2026-02-13T05:58:02.885736Z"
+     "iopub.execute_input": "2026-02-13T06:10:05.613155Z",
+     "iopub.status.busy": "2026-02-13T06:10:05.613018Z",
+     "iopub.status.idle": "2026-02-13T06:10:06.537159Z",
+     "shell.execute_reply": "2026-02-13T06:10:06.536412Z"
     }
    },
    "outputs": [
@@ -733,10 +733,10 @@
    "execution_count": 7,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-13T05:58:02.888742Z",
-     "iopub.status.busy": "2026-02-13T05:58:02.888608Z",
-     "iopub.status.idle": "2026-02-13T05:58:03.454270Z",
-     "shell.execute_reply": "2026-02-13T05:58:03.453438Z"
+     "iopub.execute_input": "2026-02-13T06:10:06.541310Z",
+     "iopub.status.busy": "2026-02-13T06:10:06.541182Z",
+     "iopub.status.idle": "2026-02-13T06:10:07.107458Z",
+     "shell.execute_reply": "2026-02-13T06:10:07.106681Z"
     }
    },
    "outputs": [
@@ -947,10 +947,10 @@
    "execution_count": 8,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-13T05:58:03.455992Z",
-     "iopub.status.busy": "2026-02-13T05:58:03.455861Z",
-     "iopub.status.idle": "2026-02-13T05:58:04.106397Z",
-     "shell.execute_reply": "2026-02-13T05:58:04.105776Z"
+     "iopub.execute_input": "2026-02-13T06:10:07.110598Z",
+     "iopub.status.busy": "2026-02-13T06:10:07.110465Z",
+     "iopub.status.idle": "2026-02-13T06:10:07.758502Z",
+     "shell.execute_reply": "2026-02-13T06:10:07.757694Z"
     }
    },
    "outputs": [
@@ -1090,10 +1090,10 @@
    "execution_count": 9,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-13T05:58:04.107698Z",
-     "iopub.status.busy": "2026-02-13T05:58:04.107571Z",
-     "iopub.status.idle": "2026-02-13T05:58:04.839312Z",
-     "shell.execute_reply": "2026-02-13T05:58:04.838454Z"
+     "iopub.execute_input": "2026-02-13T06:10:07.763683Z",
+     "iopub.status.busy": "2026-02-13T06:10:07.763558Z",
+     "iopub.status.idle": "2026-02-13T06:10:08.492498Z",
+     "shell.execute_reply": "2026-02-13T06:10:08.491926Z"
     }
    },
    "outputs": [
@@ -1221,10 +1221,10 @@
    "execution_count": 10,
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-02-13T05:58:04.842472Z",
-     "iopub.status.busy": "2026-02-13T05:58:04.842347Z",
-     "iopub.status.idle": "2026-02-13T05:58:04.893125Z",
-     "shell.execute_reply": "2026-02-13T05:58:04.892454Z"
+     "iopub.execute_input": "2026-02-13T06:10:08.495520Z",
+     "iopub.status.busy": "2026-02-13T06:10:08.495379Z",
+     "iopub.status.idle": "2026-02-13T06:10:08.551384Z",
+     "shell.execute_reply": "2026-02-13T06:10:08.550860Z"
     }
    },
    "outputs": [
@@ -1244,99 +1244,99 @@
      "data": {
       "text/html": [
        "<style type=\"text/css\">\n",
-       "#T_b90aa th {\n",
+       "#T_89d91 th {\n",
        "  background-color: #f0f0f0;\n",
        "  font-weight: bold;\n",
        "}\n",
-       "#T_b90aa td {\n",
+       "#T_89d91 td {\n",
        "  padding: 5px;\n",
        "}\n",
-       "#T_b90aa_row0_col0, #T_b90aa_row0_col1, #T_b90aa_row0_col2, #T_b90aa_row0_col3, #T_b90aa_row0_col4, #T_b90aa_row0_col5, #T_b90aa_row1_col0, #T_b90aa_row1_col1, #T_b90aa_row1_col2, #T_b90aa_row1_col3, #T_b90aa_row1_col4, #T_b90aa_row1_col5, #T_b90aa_row2_col0, #T_b90aa_row2_col1, #T_b90aa_row2_col2, #T_b90aa_row2_col3, #T_b90aa_row2_col4, #T_b90aa_row2_col5, #T_b90aa_row3_col0, #T_b90aa_row3_col1, #T_b90aa_row3_col2, #T_b90aa_row3_col3, #T_b90aa_row3_col4, #T_b90aa_row3_col5, #T_b90aa_row4_col0, #T_b90aa_row4_col1, #T_b90aa_row4_col2, #T_b90aa_row4_col3, #T_b90aa_row4_col4, #T_b90aa_row4_col5, #T_b90aa_row5_col0, #T_b90aa_row5_col1, #T_b90aa_row5_col2, #T_b90aa_row5_col3, #T_b90aa_row5_col4, #T_b90aa_row5_col5, #T_b90aa_row6_col0, #T_b90aa_row6_col1, #T_b90aa_row6_col2, #T_b90aa_row6_col3, #T_b90aa_row6_col4, #T_b90aa_row6_col5 {\n",
+       "#T_89d91_row0_col0, #T_89d91_row0_col1, #T_89d91_row0_col2, #T_89d91_row0_col3, #T_89d91_row0_col4, #T_89d91_row0_col5, #T_89d91_row1_col0, #T_89d91_row1_col1, #T_89d91_row1_col2, #T_89d91_row1_col3, #T_89d91_row1_col4, #T_89d91_row1_col5, #T_89d91_row2_col0, #T_89d91_row2_col1, #T_89d91_row2_col2, #T_89d91_row2_col3, #T_89d91_row2_col4, #T_89d91_row2_col5, #T_89d91_row3_col0, #T_89d91_row3_col1, #T_89d91_row3_col2, #T_89d91_row3_col3, #T_89d91_row3_col4, #T_89d91_row3_col5, #T_89d91_row4_col0, #T_89d91_row4_col1, #T_89d91_row4_col2, #T_89d91_row4_col3, #T_89d91_row4_col4, #T_89d91_row4_col5, #T_89d91_row5_col0, #T_89d91_row5_col1, #T_89d91_row5_col2, #T_89d91_row5_col3, #T_89d91_row5_col4, #T_89d91_row5_col5, #T_89d91_row6_col0, #T_89d91_row6_col1, #T_89d91_row6_col2, #T_89d91_row6_col3, #T_89d91_row6_col4, #T_89d91_row6_col5 {\n",
        "  text-align: left;\n",
        "  border: 1px solid black;\n",
        "}\n",
        "</style>\n",
-       "<table id=\"T_b90aa\">\n",
+       "<table id=\"T_89d91\">\n",
        "  <thead>\n",
        "    <tr>\n",
        "      <th class=\"blank level0\" >&nbsp;</th>\n",
-       "      <th id=\"T_b90aa_level0_col0\" class=\"col_heading level0 col0\" >Method</th>\n",
-       "      <th id=\"T_b90aa_level0_col1\" class=\"col_heading level0 col1\" >Time Resolution</th>\n",
-       "      <th id=\"T_b90aa_level0_col2\" class=\"col_heading level0 col2\" >Frequency Resolution</th>\n",
-       "      <th id=\"T_b90aa_level0_col3\" class=\"col_heading level0 col3\" >Computational Cost</th>\n",
-       "      <th id=\"T_b90aa_level0_col4\" class=\"col_heading level0 col4\" >Best For</th>\n",
-       "      <th id=\"T_b90aa_level0_col5\" class=\"col_heading level0 col5\" >Key Advantage</th>\n",
+       "      <th id=\"T_89d91_level0_col0\" class=\"col_heading level0 col0\" >Method</th>\n",
+       "      <th id=\"T_89d91_level0_col1\" class=\"col_heading level0 col1\" >Time Resolution</th>\n",
+       "      <th id=\"T_89d91_level0_col2\" class=\"col_heading level0 col2\" >Frequency Resolution</th>\n",
+       "      <th id=\"T_89d91_level0_col3\" class=\"col_heading level0 col3\" >Computational Cost</th>\n",
+       "      <th id=\"T_89d91_level0_col4\" class=\"col_heading level0 col4\" >Best For</th>\n",
+       "      <th id=\"T_89d91_level0_col5\" class=\"col_heading level0 col5\" >Key Advantage</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th id=\"T_b90aa_level0_row0\" class=\"row_heading level0 row0\" >0</th>\n",
-       "      <td id=\"T_b90aa_row0_col0\" class=\"data row0 col0\" >STFT</td>\n",
-       "      <td id=\"T_b90aa_row0_col1\" class=\"data row0 col1\" >Medium</td>\n",
-       "      <td id=\"T_b90aa_row0_col2\" class=\"data row0 col2\" >Medium</td>\n",
-       "      <td id=\"T_b90aa_row0_col3\" class=\"data row0 col3\" >Low</td>\n",
-       "      <td id=\"T_b90aa_row0_col4\" class=\"data row0 col4\" >General purpose</td>\n",
-       "      <td id=\"T_b90aa_row0_col5\" class=\"data row0 col5\" >Fast & well-understood</td>\n",
+       "      <th id=\"T_89d91_level0_row0\" class=\"row_heading level0 row0\" >0</th>\n",
+       "      <td id=\"T_89d91_row0_col0\" class=\"data row0 col0\" >STFT</td>\n",
+       "      <td id=\"T_89d91_row0_col1\" class=\"data row0 col1\" >Medium</td>\n",
+       "      <td id=\"T_89d91_row0_col2\" class=\"data row0 col2\" >Medium</td>\n",
+       "      <td id=\"T_89d91_row0_col3\" class=\"data row0 col3\" >Low</td>\n",
+       "      <td id=\"T_89d91_row0_col4\" class=\"data row0 col4\" >General purpose</td>\n",
+       "      <td id=\"T_89d91_row0_col5\" class=\"data row0 col5\" >Fast & well-understood</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_b90aa_level0_row1\" class=\"row_heading level0 row1\" >1</th>\n",
-       "      <td id=\"T_b90aa_row1_col0\" class=\"data row1 col0\" >Q-transform</td>\n",
-       "      <td id=\"T_b90aa_row1_col1\" class=\"data row1 col1\" >High (f>100Hz)</td>\n",
-       "      <td id=\"T_b90aa_row1_col2\" class=\"data row1 col2\" >High (f<50Hz)</td>\n",
-       "      <td id=\"T_b90aa_row1_col3\" class=\"data row1 col3\" >Medium</td>\n",
-       "      <td id=\"T_b90aa_row1_col4\" class=\"data row1 col4\" >Transients/bursts</td>\n",
-       "      <td id=\"T_b90aa_row1_col5\" class=\"data row1 col5\" >Adaptive resolution</td>\n",
+       "      <th id=\"T_89d91_level0_row1\" class=\"row_heading level0 row1\" >1</th>\n",
+       "      <td id=\"T_89d91_row1_col0\" class=\"data row1 col0\" >Q-transform</td>\n",
+       "      <td id=\"T_89d91_row1_col1\" class=\"data row1 col1\" >High (f>100Hz)</td>\n",
+       "      <td id=\"T_89d91_row1_col2\" class=\"data row1 col2\" >High (f<50Hz)</td>\n",
+       "      <td id=\"T_89d91_row1_col3\" class=\"data row1 col3\" >Medium</td>\n",
+       "      <td id=\"T_89d91_row1_col4\" class=\"data row1 col4\" >Transients/bursts</td>\n",
+       "      <td id=\"T_89d91_row1_col5\" class=\"data row1 col5\" >Adaptive resolution</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_b90aa_level0_row2\" class=\"row_heading level0 row2\" >2</th>\n",
-       "      <td id=\"T_b90aa_row2_col0\" class=\"data row2 col0\" >Wavelet (CWT)</td>\n",
-       "      <td id=\"T_b90aa_row2_col1\" class=\"data row2 col1\" >Scale-adaptive</td>\n",
-       "      <td id=\"T_b90aa_row2_col2\" class=\"data row2 col2\" >Scale-adaptive</td>\n",
-       "      <td id=\"T_b90aa_row2_col3\" class=\"data row2 col3\" >Medium-High</td>\n",
-       "      <td id=\"T_b90aa_row2_col4\" class=\"data row2 col4\" >Chirps & multi-scale</td>\n",
-       "      <td id=\"T_b90aa_row2_col5\" class=\"data row2 col5\" >Natural scale matching</td>\n",
+       "      <th id=\"T_89d91_level0_row2\" class=\"row_heading level0 row2\" >2</th>\n",
+       "      <td id=\"T_89d91_row2_col0\" class=\"data row2 col0\" >Wavelet (CWT)</td>\n",
+       "      <td id=\"T_89d91_row2_col1\" class=\"data row2 col1\" >Scale-adaptive</td>\n",
+       "      <td id=\"T_89d91_row2_col2\" class=\"data row2 col2\" >Scale-adaptive</td>\n",
+       "      <td id=\"T_89d91_row2_col3\" class=\"data row2 col3\" >Medium-High</td>\n",
+       "      <td id=\"T_89d91_row2_col4\" class=\"data row2 col4\" >Chirps & multi-scale</td>\n",
+       "      <td id=\"T_89d91_row2_col5\" class=\"data row2 col5\" >Natural scale matching</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_b90aa_level0_row3\" class=\"row_heading level0 row3\" >3</th>\n",
-       "      <td id=\"T_b90aa_row3_col0\" class=\"data row3 col0\" >HHT</td>\n",
-       "      <td id=\"T_b90aa_row3_col1\" class=\"data row3 col1\" >Excellent</td>\n",
-       "      <td id=\"T_b90aa_row3_col2\" class=\"data row3 col2\" >Excellent</td>\n",
-       "      <td id=\"T_b90aa_row3_col3\" class=\"data row3 col3\" >Very High</td>\n",
-       "      <td id=\"T_b90aa_row3_col4\" class=\"data row3 col4\" >Instantaneous frequency</td>\n",
-       "      <td id=\"T_b90aa_row3_col5\" class=\"data row3 col5\" >No time-freq tradeoff</td>\n",
+       "      <th id=\"T_89d91_level0_row3\" class=\"row_heading level0 row3\" >3</th>\n",
+       "      <td id=\"T_89d91_row3_col0\" class=\"data row3 col0\" >HHT</td>\n",
+       "      <td id=\"T_89d91_row3_col1\" class=\"data row3 col1\" >Excellent</td>\n",
+       "      <td id=\"T_89d91_row3_col2\" class=\"data row3 col2\" >Excellent</td>\n",
+       "      <td id=\"T_89d91_row3_col3\" class=\"data row3 col3\" >Very High</td>\n",
+       "      <td id=\"T_89d91_row3_col4\" class=\"data row3 col4\" >Instantaneous frequency</td>\n",
+       "      <td id=\"T_89d91_row3_col5\" class=\"data row3 col5\" >No time-freq tradeoff</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_b90aa_level0_row4\" class=\"row_heading level0 row4\" >4</th>\n",
-       "      <td id=\"T_b90aa_row4_col0\" class=\"data row4 col0\" >STLT</td>\n",
-       "      <td id=\"T_b90aa_row4_col1\" class=\"data row4 col1\" >Medium</td>\n",
-       "      <td id=\"T_b90aa_row4_col2\" class=\"data row4 col2\" >Medium</td>\n",
-       "      <td id=\"T_b90aa_row4_col3\" class=\"data row4 col3\" >High</td>\n",
-       "      <td id=\"T_b90aa_row4_col4\" class=\"data row4 col4\" >Damped oscillations</td>\n",
-       "      <td id=\"T_b90aa_row4_col5\" class=\"data row4 col5\" >Reveals decay rates σ</td>\n",
+       "      <th id=\"T_89d91_level0_row4\" class=\"row_heading level0 row4\" >4</th>\n",
+       "      <td id=\"T_89d91_row4_col0\" class=\"data row4 col0\" >STLT</td>\n",
+       "      <td id=\"T_89d91_row4_col1\" class=\"data row4 col1\" >Medium</td>\n",
+       "      <td id=\"T_89d91_row4_col2\" class=\"data row4 col2\" >Medium</td>\n",
+       "      <td id=\"T_89d91_row4_col3\" class=\"data row4 col3\" >High</td>\n",
+       "      <td id=\"T_89d91_row4_col4\" class=\"data row4 col4\" >Damped oscillations</td>\n",
+       "      <td id=\"T_89d91_row4_col5\" class=\"data row4 col5\" >Reveals decay rates σ</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_b90aa_level0_row5\" class=\"row_heading level0 row5\" >5</th>\n",
-       "      <td id=\"T_b90aa_row5_col0\" class=\"data row5 col0\" >Cepstrum</td>\n",
-       "      <td id=\"T_b90aa_row5_col1\" class=\"data row5 col1\" >N/A</td>\n",
-       "      <td id=\"T_b90aa_row5_col2\" class=\"data row5 col2\" >Excellent</td>\n",
-       "      <td id=\"T_b90aa_row5_col3\" class=\"data row5 col3\" >Medium</td>\n",
-       "      <td id=\"T_b90aa_row5_col4\" class=\"data row5 col4\" >Echo detection</td>\n",
-       "      <td id=\"T_b90aa_row5_col5\" class=\"data row5 col5\" >Quefrency peaks</td>\n",
+       "      <th id=\"T_89d91_level0_row5\" class=\"row_heading level0 row5\" >5</th>\n",
+       "      <td id=\"T_89d91_row5_col0\" class=\"data row5 col0\" >Cepstrum</td>\n",
+       "      <td id=\"T_89d91_row5_col1\" class=\"data row5 col1\" >N/A</td>\n",
+       "      <td id=\"T_89d91_row5_col2\" class=\"data row5 col2\" >Excellent</td>\n",
+       "      <td id=\"T_89d91_row5_col3\" class=\"data row5 col3\" >Medium</td>\n",
+       "      <td id=\"T_89d91_row5_col4\" class=\"data row5 col4\" >Echo detection</td>\n",
+       "      <td id=\"T_89d91_row5_col5\" class=\"data row5 col5\" >Quefrency peaks</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th id=\"T_b90aa_level0_row6\" class=\"row_heading level0 row6\" >6</th>\n",
-       "      <td id=\"T_b90aa_row6_col0\" class=\"data row6 col0\" >DCT</td>\n",
-       "      <td id=\"T_b90aa_row6_col1\" class=\"data row6 col1\" >N/A</td>\n",
-       "      <td id=\"T_b90aa_row6_col2\" class=\"data row6 col2\" >N/A</td>\n",
-       "      <td id=\"T_b90aa_row6_col3\" class=\"data row6 col3\" >Low</td>\n",
-       "      <td id=\"T_b90aa_row6_col4\" class=\"data row6 col4\" >Compression</td>\n",
-       "      <td id=\"T_b90aa_row6_col5\" class=\"data row6 col5\" >Sparse representation</td>\n",
+       "      <th id=\"T_89d91_level0_row6\" class=\"row_heading level0 row6\" >6</th>\n",
+       "      <td id=\"T_89d91_row6_col0\" class=\"data row6 col0\" >DCT</td>\n",
+       "      <td id=\"T_89d91_row6_col1\" class=\"data row6 col1\" >N/A</td>\n",
+       "      <td id=\"T_89d91_row6_col2\" class=\"data row6 col2\" >N/A</td>\n",
+       "      <td id=\"T_89d91_row6_col3\" class=\"data row6 col3\" >Low</td>\n",
+       "      <td id=\"T_89d91_row6_col4\" class=\"data row6 col4\" >Compression</td>\n",
+       "      <td id=\"T_89d91_row6_col5\" class=\"data row6 col5\" >Sparse representation</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7ba4649f6600>"
+       "<pandas.io.formats.style.Styler at 0x7722fdf21400>"
       ]
      },
      "metadata": {},
@@ -1358,69 +1358,69 @@
      "data": {
       "text/html": [
        "<style type=\"text/css\">\n",
-       "#T_afe34 th {\n",
+       "#T_0c1fb th {\n",
        "  background-color: #e8f4f8;\n",
        "  font-weight: bold;\n",
        "}\n",
-       "#T_afe34 td {\n",
+       "#T_0c1fb td {\n",
        "  padding: 5px;\n",
        "}\n",
-       "#T_afe34_row0_col0, #T_afe34_row0_col1, #T_afe34_row0_col2, #T_afe34_row0_col3, #T_afe34_row0_col4, #T_afe34_row1_col0, #T_afe34_row1_col1, #T_afe34_row1_col2, #T_afe34_row1_col3, #T_afe34_row1_col4, #T_afe34_row2_col0, #T_afe34_row2_col1, #T_afe34_row2_col2, #T_afe34_row2_col3, #T_afe34_row2_col4, #T_afe34_row3_col0, #T_afe34_row3_col1, #T_afe34_row3_col2, #T_afe34_row3_col3, #T_afe34_row3_col4, #T_afe34_row4_col0, #T_afe34_row4_col1, #T_afe34_row4_col2, #T_afe34_row4_col3, #T_afe34_row4_col4 {\n",
+       "#T_0c1fb_row0_col0, #T_0c1fb_row0_col1, #T_0c1fb_row0_col2, #T_0c1fb_row0_col3, #T_0c1fb_row0_col4, #T_0c1fb_row1_col0, #T_0c1fb_row1_col1, #T_0c1fb_row1_col2, #T_0c1fb_row1_col3, #T_0c1fb_row1_col4, #T_0c1fb_row2_col0, #T_0c1fb_row2_col1, #T_0c1fb_row2_col2, #T_0c1fb_row2_col3, #T_0c1fb_row2_col4, #T_0c1fb_row3_col0, #T_0c1fb_row3_col1, #T_0c1fb_row3_col2, #T_0c1fb_row3_col3, #T_0c1fb_row3_col4, #T_0c1fb_row4_col0, #T_0c1fb_row4_col1, #T_0c1fb_row4_col2, #T_0c1fb_row4_col3, #T_0c1fb_row4_col4 {\n",
        "  text-align: left;\n",
        "  border: 1px solid black;\n",
        "}\n",
        "</style>\n",
-       "<table id=\"T_afe34\">\n",
+       "<table id=\"T_0c1fb\">\n",
        "  <thead>\n",
        "    <tr>\n",
-       "      <th id=\"T_afe34_level0_col0\" class=\"col_heading level0 col0\" >Method</th>\n",
-       "      <th id=\"T_afe34_level0_col1\" class=\"col_heading level0 col1\" >Test Signal</th>\n",
-       "      <th id=\"T_afe34_level0_col2\" class=\"col_heading level0 col2\" >Metric</th>\n",
-       "      <th id=\"T_afe34_level0_col3\" class=\"col_heading level0 col3\" >Value</th>\n",
-       "      <th id=\"T_afe34_level0_col4\" class=\"col_heading level0 col4\" >Comparison</th>\n",
+       "      <th id=\"T_0c1fb_level0_col0\" class=\"col_heading level0 col0\" >Method</th>\n",
+       "      <th id=\"T_0c1fb_level0_col1\" class=\"col_heading level0 col1\" >Test Signal</th>\n",
+       "      <th id=\"T_0c1fb_level0_col2\" class=\"col_heading level0 col2\" >Metric</th>\n",
+       "      <th id=\"T_0c1fb_level0_col3\" class=\"col_heading level0 col3\" >Value</th>\n",
+       "      <th id=\"T_0c1fb_level0_col4\" class=\"col_heading level0 col4\" >Comparison</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <td id=\"T_afe34_row0_col0\" class=\"data row0 col0\" >Wavelet (CWT)</td>\n",
-       "      <td id=\"T_afe34_row0_col1\" class=\"data row0 col1\" >Chirp (20→150 Hz)</td>\n",
-       "      <td id=\"T_afe34_row0_col2\" class=\"data row0 col2\" >Frequency Tracking RMSE</td>\n",
-       "      <td id=\"T_afe34_row0_col3\" class=\"data row0 col3\" >35.91 Hz</td>\n",
-       "      <td id=\"T_afe34_row0_col4\" class=\"data row0 col4\" >vs STFT smearing ~15 Hz</td>\n",
+       "      <td id=\"T_0c1fb_row0_col0\" class=\"data row0 col0\" >Wavelet (CWT)</td>\n",
+       "      <td id=\"T_0c1fb_row0_col1\" class=\"data row0 col1\" >Chirp (20→150 Hz)</td>\n",
+       "      <td id=\"T_0c1fb_row0_col2\" class=\"data row0 col2\" >Frequency Tracking RMSE</td>\n",
+       "      <td id=\"T_0c1fb_row0_col3\" class=\"data row0 col3\" >35.91 Hz</td>\n",
+       "      <td id=\"T_0c1fb_row0_col4\" class=\"data row0 col4\" >vs STFT smearing ~15 Hz</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <td id=\"T_afe34_row1_col0\" class=\"data row1 col0\" >HHT</td>\n",
-       "      <td id=\"T_afe34_row1_col1\" class=\"data row1 col1\" >AM-FM (80±20 Hz)</td>\n",
-       "      <td id=\"T_afe34_row1_col2\" class=\"data row1 col2\" >Instantaneous Freq. RMSE</td>\n",
-       "      <td id=\"T_afe34_row1_col3\" class=\"data row1 col3\" >20.12 Hz</td>\n",
-       "      <td id=\"T_afe34_row1_col4\" class=\"data row1 col4\" >vs STFT 40 Hz wide band</td>\n",
+       "      <td id=\"T_0c1fb_row1_col0\" class=\"data row1 col0\" >HHT</td>\n",
+       "      <td id=\"T_0c1fb_row1_col1\" class=\"data row1 col1\" >AM-FM (80±20 Hz)</td>\n",
+       "      <td id=\"T_0c1fb_row1_col2\" class=\"data row1 col2\" >Instantaneous Freq. RMSE</td>\n",
+       "      <td id=\"T_0c1fb_row1_col3\" class=\"data row1 col3\" >20.12 Hz</td>\n",
+       "      <td id=\"T_0c1fb_row1_col4\" class=\"data row1 col4\" >vs STFT 40 Hz wide band</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <td id=\"T_afe34_row2_col0\" class=\"data row2 col0\" >STLT</td>\n",
-       "      <td id=\"T_afe34_row2_col1\" class=\"data row2 col1\" >3-mode ringdown</td>\n",
-       "      <td id=\"T_afe34_row2_col2\" class=\"data row2 col2\" >Decay Rate MAE</td>\n",
-       "      <td id=\"T_afe34_row2_col3\" class=\"data row2 col3\" >7.25 s⁻¹</td>\n",
-       "      <td id=\"T_afe34_row2_col4\" class=\"data row2 col4\" >STFT cannot estimate σ</td>\n",
+       "      <td id=\"T_0c1fb_row2_col0\" class=\"data row2 col0\" >STLT</td>\n",
+       "      <td id=\"T_0c1fb_row2_col1\" class=\"data row2 col1\" >3-mode ringdown</td>\n",
+       "      <td id=\"T_0c1fb_row2_col2\" class=\"data row2 col2\" >Decay Rate MAE</td>\n",
+       "      <td id=\"T_0c1fb_row2_col3\" class=\"data row2 col3\" >7.25 s⁻¹</td>\n",
+       "      <td id=\"T_0c1fb_row2_col4\" class=\"data row2 col4\" >STFT cannot estimate σ</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <td id=\"T_afe34_row3_col0\" class=\"data row3 col0\" >Cepstrum</td>\n",
-       "      <td id=\"T_afe34_row3_col1\" class=\"data row3 col1\" >Echo (80ms delay)</td>\n",
-       "      <td id=\"T_afe34_row3_col2\" class=\"data row3 col2\" >Delay Detection Error</td>\n",
-       "      <td id=\"T_afe34_row3_col3\" class=\"data row3 col3\" >0.41 ms</td>\n",
-       "      <td id=\"T_afe34_row3_col4\" class=\"data row3 col4\" >Delay invisible in STFT</td>\n",
+       "      <td id=\"T_0c1fb_row3_col0\" class=\"data row3 col0\" >Cepstrum</td>\n",
+       "      <td id=\"T_0c1fb_row3_col1\" class=\"data row3 col1\" >Echo (80ms delay)</td>\n",
+       "      <td id=\"T_0c1fb_row3_col2\" class=\"data row3 col2\" >Delay Detection Error</td>\n",
+       "      <td id=\"T_0c1fb_row3_col3\" class=\"data row3 col3\" >0.41 ms</td>\n",
+       "      <td id=\"T_0c1fb_row3_col4\" class=\"data row3 col4\" >Delay invisible in STFT</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <td id=\"T_afe34_row4_col0\" class=\"data row4 col0\" >DCT</td>\n",
-       "      <td id=\"T_afe34_row4_col1\" class=\"data row4 col1\" >Smooth + bumps</td>\n",
-       "      <td id=\"T_afe34_row4_col2\" class=\"data row4 col2\" >Compression (50 coeffs)</td>\n",
-       "      <td id=\"T_afe34_row4_col3\" class=\"data row4 col3\" >>99% energy</td>\n",
-       "      <td id=\"T_afe34_row4_col4\" class=\"data row4 col4\" >~30× compression ratio</td>\n",
+       "      <td id=\"T_0c1fb_row4_col0\" class=\"data row4 col0\" >DCT</td>\n",
+       "      <td id=\"T_0c1fb_row4_col1\" class=\"data row4 col1\" >Smooth + bumps</td>\n",
+       "      <td id=\"T_0c1fb_row4_col2\" class=\"data row4 col2\" >Compression (50 coeffs)</td>\n",
+       "      <td id=\"T_0c1fb_row4_col3\" class=\"data row4 col3\" >>99% energy</td>\n",
+       "      <td id=\"T_0c1fb_row4_col4\" class=\"data row4 col4\" >~30× compression ratio</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7ba464563980>"
+       "<pandas.io.formats.style.Styler at 0x7722fd89f9b0>"
       ]
      },
      "metadata": {},
@@ -1429,8 +1429,6 @@
     {
      "data": {
       "text/markdown": [
-       "\n",
-       "---\n",
        "\n",
        "### Key Takeaways\n",
        "\n",
@@ -1569,8 +1567,6 @@
     "    ]).hide(axis='index'))\n",
     "\n",
     "display(Markdown(\"\"\"\n",
-    "---\n",
-    "\n",
     "### Key Takeaways\n",
     "\n",
     "**Choose your method based on what information you need:**\n",


### PR DESCRIPTION
… build

Fixed AssertionError in Sphinx/Docutils processing:
- Removed '---' (horizontal rule) from display(Markdown(...))
- The '---' inside IPython Markdown display caused Docutils transition node to be placed under incorrect parent, triggering AssertionError
- Sphinx expects transition nodes only at document level, not nested

Error was:
  File "docutils/transforms/misc.py", line 108, in visit_transition assert (isinstance(node.parent, nodes.document) AssertionError

This fix allows Sphinx build to complete successfully.