### PR TITLE
Follow-up: fix zarr>=3 TimeSeriesDict writer regression

### DIFF
--- a/gwexpy/timeseries/io/zarr_.py
+++ b/gwexpy/timeseries/io/zarr_.py
@@ -159,10 +159,6 @@ def write_timeseriesdict_zarr(tsd, target, **kwargs):
             except TypeError:
                 # Some implementations infer shape from data.
                 arr = store.create_array(key, data=data, overwrite=True)
-            except ValueError:
-                # zarr v3 rejects calls that include both ``data`` and ``shape``.
-                # Fall back to data-only creation for backends with stricter validation.
-                arr = store.create_array(key, data=data, overwrite=True)
         else:
             arr = store.create_dataset(key, data=data, overwrite=True)
         arr.attrs["sample_rate"] = float(ts.sample_rate.value)

--- a/gwexpy/timeseries/io/zarr_.py
+++ b/gwexpy/timeseries/io/zarr_.py
@@ -151,12 +151,17 @@ def write_timeseriesdict_zarr(tsd, target, **kwargs):
             try:
                 arr = store.create_array(
                     key,
-                    data=data,
                     shape=data.shape,
+                    dtype=data.dtype,
                     overwrite=True,
                 )
+                arr[...] = data
             except TypeError:
                 # Some implementations infer shape from data.
+                arr = store.create_array(key, data=data, overwrite=True)
+            except ValueError:
+                # zarr v3 rejects calls that include both ``data`` and ``shape``.
+                # Fall back to data-only creation for backends with stricter validation.
                 arr = store.create_array(key, data=data, overwrite=True)
         else:
             arr = store.create_dataset(key, data=data, overwrite=True)

--- a/gwexpy/timeseries/io/zarr_.py
+++ b/gwexpy/timeseries/io/zarr_.py
@@ -145,10 +145,21 @@ def write_timeseriesdict_zarr(tsd, target, **kwargs):
 
     for key, ts in tsd.items():
         data = np.asarray(ts.value, dtype=np.float64)
-        # zarr>=3 uses create_array(data=...) and removed create_dataset.
-        # zarr<3 has create_dataset; fall back for compatibility.
-        creator = getattr(store, "create_array", None) or store.create_dataset
-        arr = creator(key, data=data, overwrite=True)
+        # zarr>=3 prefers ``create_array`` and requires explicit ``shape``.
+        # zarr<3 exposes ``create_dataset`` with ``data=...``.
+        if hasattr(store, "create_array"):
+            try:
+                arr = store.create_array(
+                    key,
+                    data=data,
+                    shape=data.shape,
+                    overwrite=True,
+                )
+            except TypeError:
+                # Some implementations infer shape from data.
+                arr = store.create_array(key, data=data, overwrite=True)
+        else:
+            arr = store.create_dataset(key, data=data, overwrite=True)
         arr.attrs["sample_rate"] = float(ts.sample_rate.value)
         arr.attrs["t0"] = float(ts.t0.value)
         arr.attrs["dt"] = float(ts.dt.value)

--- a/tests/timeseries/test_io_zarr_writer.py
+++ b/tests/timeseries/test_io_zarr_writer.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+from gwexpy.timeseries import TimeSeries, TimeSeriesDict
+from gwexpy.timeseries.io import zarr_
+
+
+class _FakeArray:
+    def __init__(self, data):
+        self.data = data
+        self.attrs = {}
+
+
+class _FakeGroupV3:
+    def __init__(self):
+        self.created = {}
+
+    def create_array(self, name, *, data, shape, overwrite=False):
+        if shape != data.shape:
+            raise ValueError("shape mismatch")
+        arr = _FakeArray(data)
+        self.created[name] = arr
+        return arr
+
+
+class _FakeZarrV3:
+    def __init__(self, group):
+        self._group = group
+
+    def open_group(self, target, mode="r", **kwargs):
+        return self._group
+
+
+def test_write_timeseriesdict_zarr_uses_shape_for_zarr_v3(monkeypatch):
+    group = _FakeGroupV3()
+    fake_zarr = _FakeZarrV3(group)
+    monkeypatch.setattr(zarr_, "_import_zarr", lambda: fake_zarr)
+
+    ts = TimeSeries(np.arange(8, dtype=float), dt=0.25, t0=100.0, unit="m")
+    tsd = TimeSeriesDict({"chan": ts})
+
+    zarr_.write_timeseriesdict_zarr(tsd, "unused-target")
+
+    assert "chan" in group.created
+    arr = group.created["chan"]
+    assert np.allclose(arr.data, ts.value)
+    assert arr.attrs["sample_rate"] == float(ts.sample_rate.value)
+    assert arr.attrs["t0"] == float(ts.t0.value)
+    assert arr.attrs["dt"] == float(ts.dt.value)
+    assert arr.attrs["unit"] == str(ts.unit)

--- a/tests/timeseries/test_io_zarr_writer.py
+++ b/tests/timeseries/test_io_zarr_writer.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from gwexpy.timeseries import TimeSeries, TimeSeriesDict
 from gwexpy.timeseries.io import zarr_
@@ -57,3 +58,23 @@ def test_write_timeseriesdict_zarr_uses_shape_for_zarr_v3(monkeypatch):
     assert arr.attrs["t0"] == float(ts.t0.value)
     assert arr.attrs["dt"] == float(ts.dt.value)
     assert arr.attrs["unit"] == str(ts.unit)
+
+
+class _FakeGroupShapeError:
+    def create_array(self, name, *, shape=None, dtype=None, data=None, overwrite=False):
+        raise ValueError("shape mismatch")
+
+
+class _FakeZarrShapeError:
+    def open_group(self, target, mode="r", **kwargs):
+        return _FakeGroupShapeError()
+
+
+def test_write_timeseriesdict_zarr_does_not_swallow_value_error(monkeypatch):
+    monkeypatch.setattr(zarr_, "_import_zarr", lambda: _FakeZarrShapeError())
+
+    ts = TimeSeries(np.arange(4, dtype=float), dt=1.0, t0=0.0)
+    tsd = TimeSeriesDict({"chan": ts})
+
+    with pytest.raises(ValueError, match="shape mismatch"):
+        zarr_.write_timeseriesdict_zarr(tsd, "unused-target")

--- a/tests/timeseries/test_io_zarr_writer.py
+++ b/tests/timeseries/test_io_zarr_writer.py
@@ -5,19 +5,29 @@ from gwexpy.timeseries.io import zarr_
 
 
 class _FakeArray:
-    def __init__(self, data):
-        self.data = data
+    def __init__(self, shape, dtype):
+        self.data = np.empty(shape, dtype=dtype)
         self.attrs = {}
+
+    def __setitem__(self, key, value):
+        self.data[key] = value
 
 
 class _FakeGroupV3:
     def __init__(self):
         self.created = {}
 
-    def create_array(self, name, *, data, shape, overwrite=False):
-        if shape != data.shape:
-            raise ValueError("shape mismatch")
-        arr = _FakeArray(data)
+    def create_array(self, name, *, shape=None, dtype=None, data=None, overwrite=False):
+        if data is not None and shape is not None:
+            raise ValueError(
+                "Either use the data parameter, or the shape parameter, but not both."
+            )
+        if shape is None:
+            shape = data.shape
+            dtype = data.dtype
+        arr = _FakeArray(shape, dtype)
+        if data is not None:
+            arr[...] = data
         self.created[name] = arr
         return arr
 


### PR DESCRIPTION
### Motivation
- Address a high-priority regression where `write_timeseriesdict_zarr` raised `TypeError` under `zarr>=3` because the v3 API requires an explicit `shape` when creating arrays. 

### Description
- Updated `gwexpy/timeseries/io/zarr_.py` to prefer `create_array(...)` and pass `shape=data.shape` for zarr v3-compatible backends, with a `TypeError` fallback to the shape-inferred call and a `create_dataset(...)` fallback for older zarr versions. 
- Preserve and write per-array attributes (`sample_rate`, `t0`, `dt`, and `unit`) unchanged after creating the array. 
- Added a focused regression test `tests/timeseries/test_io_zarr_writer.py` that simulates a zarr-v3-like group API requiring `shape` and verifies data and metadata are written. 

### Testing
- Ran `pytest -q tests/timeseries/test_io_zarr_writer.py` and the new test passed (1 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69acf2abb31c8331ad86d0dca3f93867)