### PR TITLE
Fix gwpy-injected kwargs handling in Zarr IO reader/writer

### DIFF
--- a/gwexpy/timeseries/io/zarr_.py
+++ b/gwexpy/timeseries/io/zarr_.py
@@ -24,6 +24,14 @@ from gwexpy.io.utils import apply_unit, filter_by_channels, set_provenance
 from .. import TimeSeries, TimeSeriesDict, TimeSeriesMatrix
 
 
+_GWPY_INJECTED_KEYS = {"start", "end", "pad", "gap", "nproc", "scaled"}
+
+
+def _strip_gwpy_kwargs(kwargs: dict) -> dict:
+    """Drop gwpy registry kwargs that are invalid for zarr.open_group."""
+    return {k: v for k, v in kwargs.items() if k not in _GWPY_INJECTED_KEYS}
+
+
 def _import_zarr():
     try:
         import zarr
@@ -63,7 +71,8 @@ def read_timeseriesdict_zarr(
     # directly so that in-memory / remote stores work unchanged.
     if isinstance(source, (str, os.PathLike)):
         source = str(source)
-    store = zarr.open_group(source, mode="r", **kwargs)
+    zarr_kwargs = _strip_gwpy_kwargs(kwargs)
+    store = zarr.open_group(source, mode="r", **zarr_kwargs)
 
     tsd = TimeSeriesDict()
 
@@ -141,7 +150,8 @@ def write_timeseriesdict_zarr(tsd, target, **kwargs):
 
     if isinstance(target, (str, os.PathLike)):
         target = str(target)
-    store = zarr.open_group(target, mode="w", **kwargs)
+    zarr_kwargs = _strip_gwpy_kwargs(kwargs)
+    store = zarr.open_group(target, mode="w", **zarr_kwargs)
 
     for key, ts in tsd.items():
         data = np.asarray(ts.value, dtype=np.float64)

--- a/gwexpy/timeseries/io/zarr_.py
+++ b/gwexpy/timeseries/io/zarr_.py
@@ -15,6 +15,7 @@ Directory stores, zip stores, and any other backend supported by the
 from __future__ import annotations
 
 import os
+from collections.abc import Mapping
 
 import numpy as np
 from gwpy.io.registry import default_registry as io_registry
@@ -27,7 +28,7 @@ from .. import TimeSeries, TimeSeriesDict, TimeSeriesMatrix
 _GWPY_INJECTED_KEYS = {"start", "end", "pad", "gap", "nproc", "scaled"}
 
 
-def _strip_gwpy_kwargs(kwargs: dict) -> dict:
+def _strip_gwpy_kwargs(kwargs: Mapping[str, object]) -> dict[str, object]:
     """Drop gwpy registry kwargs that are invalid for zarr.open_group."""
     return {k: v for k, v in kwargs.items() if k not in _GWPY_INJECTED_KEYS}
 

--- a/tests/timeseries/test_zarr_io_kwargs.py
+++ b/tests/timeseries/test_zarr_io_kwargs.py
@@ -1,0 +1,88 @@
+import numpy as np
+
+from gwexpy.timeseries import TimeSeries, TimeSeriesDict
+from gwexpy.timeseries.io import zarr_ as zarr_io
+
+
+class _FakeArray:
+    def __init__(self, data, attrs):
+        self._data = np.asarray(data)
+        self.attrs = attrs
+        self.shape = self._data.shape
+
+    def __getitem__(self, item):
+        if isinstance(item, slice):
+            return self._data
+        return self._data[item]
+
+
+class _FakeReadStore(dict):
+    pass
+
+
+class _FakeWriteStore:
+    def __init__(self):
+        self.arrays = {}
+
+    def create_array(self, key, data, overwrite=True):
+        arr = _FakeArray(data, {})
+        self.arrays[key] = {"data": np.asarray(data), "overwrite": overwrite, "arr": arr}
+        return arr
+
+
+class _FakeZarr:
+    def __init__(self):
+        self.calls = []
+        self.read_store = _FakeReadStore(
+            {
+                "ch0": _FakeArray([1.0, 2.0, 3.0], {"sample_rate": 10.0, "t0": 123.0, "unit": "m"})
+            }
+        )
+        self.write_store = _FakeWriteStore()
+
+    def open_group(self, source, mode="r", **kwargs):
+        self.calls.append({"source": source, "mode": mode, "kwargs": kwargs})
+        if mode == "r":
+            return self.read_store
+        return self.write_store
+
+
+def test_read_timeseriesdict_zarr_strips_gwpy_kwargs(monkeypatch):
+    fake_zarr = _FakeZarr()
+    monkeypatch.setattr(zarr_io, "_import_zarr", lambda: fake_zarr)
+
+    out = zarr_io.read_timeseriesdict_zarr(
+        object(),
+        start=1,
+        end=2,
+        pad=np.nan,
+        gap="pad",
+        nproc=2,
+        scaled=True,
+        foo="bar",
+    )
+
+    assert "ch0" in out
+    assert fake_zarr.calls[0]["mode"] == "r"
+    assert fake_zarr.calls[0]["kwargs"] == {"foo": "bar"}
+
+
+def test_write_timeseriesdict_zarr_strips_gwpy_kwargs(monkeypatch):
+    fake_zarr = _FakeZarr()
+    monkeypatch.setattr(zarr_io, "_import_zarr", lambda: fake_zarr)
+
+    tsd = TimeSeriesDict({"ch0": TimeSeries([1.0, 2.0], t0=0, sample_rate=4, unit="m")})
+    zarr_io.write_timeseriesdict_zarr(
+        tsd,
+        object(),
+        start=1,
+        end=2,
+        pad=np.nan,
+        gap="pad",
+        nproc=2,
+        scaled=True,
+        compressor="zstd",
+    )
+
+    assert fake_zarr.calls[0]["mode"] == "w"
+    assert fake_zarr.calls[0]["kwargs"] == {"compressor": "zstd"}

--- a/tests/timeseries/test_zarr_io_kwargs.py
+++ b/tests/timeseries/test_zarr_io_kwargs.py
@@ -26,7 +26,11 @@ class _FakeWriteStore:
 
     def create_array(self, key, data, overwrite=True):
         arr = _FakeArray(data, {})
-        self.arrays[key] = {"data": np.asarray(data), "overwrite": overwrite, "arr": arr}
+        self.arrays[key] = {
+            "data": np.asarray(data),
+            "overwrite": overwrite,
+            "arr": arr,
+        }
         return arr
 
 
@@ -35,7 +39,10 @@ class _FakeZarr:
         self.calls = []
         self.read_store = _FakeReadStore(
             {
-                "ch0": _FakeArray([1.0, 2.0, 3.0], {"sample_rate": 10.0, "t0": 123.0, "unit": "m"})
+                "ch0": _FakeArray(
+                    [1.0, 2.0, 3.0],
+                    {"sample_rate": 10.0, "t0": 123.0, "unit": "m"},
+                )
             }
         )
         self.write_store = _FakeWriteStore()
@@ -47,12 +54,13 @@ class _FakeZarr:
         return self.write_store
 
 
-def test_read_timeseriesdict_zarr_strips_gwpy_kwargs(monkeypatch):
+def test_high_level_zarr_read_strips_gwpy_kwargs(monkeypatch):
     fake_zarr = _FakeZarr()
     monkeypatch.setattr(zarr_io, "_import_zarr", lambda: fake_zarr)
 
-    out = zarr_io.read_timeseriesdict_zarr(
+    out = TimeSeriesDict.read(
         object(),
+        format="zarr",
         start=1,
         end=2,
         pad=np.nan,
@@ -71,7 +79,9 @@ def test_write_timeseriesdict_zarr_strips_gwpy_kwargs(monkeypatch):
     fake_zarr = _FakeZarr()
     monkeypatch.setattr(zarr_io, "_import_zarr", lambda: fake_zarr)
 
-    tsd = TimeSeriesDict({"ch0": TimeSeries([1.0, 2.0], t0=0, sample_rate=4, unit="m")})
+    tsd = TimeSeriesDict(
+        {"ch0": TimeSeries([1.0, 2.0], t0=0, sample_rate=4, unit="m")}
+    )
     zarr_io.write_timeseriesdict_zarr(
         tsd,
         object(),


### PR DESCRIPTION
### Motivation
- A high-priority bug was reported where gwpy-injected registry kwargs (`start`, `end`, `pad`, `gap`, `nproc`, `scaled`) were forwarded to `zarr.open_group`, causing `TypeError` for non-path Zarr backends when reading via the gwpy high-level API. 
- The change aims to make the Zarr reader/writer tolerant of gwpy's registry call signature while preserving user-supplied backend kwargs.

### Description
- Add `_GWPY_INJECTED_KEYS` and helper `_strip_gwpy_kwargs` to `gwexpy/timeseries/io/zarr_.py` to drop gwpy-specific keys from kwargs before calling `zarr.open_group`.
- Use `_strip_gwpy_kwargs` in both `read_timeseriesdict_zarr` and `write_timeseriesdict_zarr` so read and write paths no longer forward invalid kwargs to `zarr.open_group`.
- Add unit tests `tests/timeseries/test_zarr_io_kwargs.py` that use a fake `zarr` backend to assert that gwpy-injected keys are stripped and that non-gwpy kwargs are forwarded unchanged.

### Testing
- Ran `pytest -q tests/timeseries/test_zarr_io_kwargs.py` and observed `2 passed` (with one pytest config warning), confirming the read and write code paths filter kwargs as intended.
- Confirmed the modified file is `gwexpy/timeseries/io/zarr_.py` and the new tests are in `tests/timeseries/test_zarr_io_kwargs.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69acf2aa53ec8331a6587c627c9d2af1)