### PR TITLE
Follow-up: restore positional inplace crop semantics for spectrogram collections

### DIFF
--- a/gwexpy/spectrogram/collections.py
+++ b/gwexpy/spectrogram/collections.py
@@ -158,7 +158,7 @@ class SpectrogramList(PhaseMethodsMixin, UserList):
         else:
             raise NotImplementedError(f"Format {format} not supported")
 
-    def crop(self, start=None, end=None, copy=True, **kwargs):
+    def crop(self, start=None, end=None, *args, copy=True, **kwargs):
         """Crop each spectrogram in time.
 
         Parameters
@@ -173,6 +173,15 @@ class SpectrogramList(PhaseMethodsMixin, UserList):
             Deprecated: ``t0``/``t1``/``inplace`` are accepted for
             backwards compatibility but will be removed in a future release.
         """
+        if args:
+            if len(args) > 1:
+                raise TypeError(f"crop() takes at most 4 positional arguments but {2 + len(args)} were given")
+            warnings.warn(
+                "Positional inplace argument is deprecated, use copy keyword",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            copy = not args[0]
         if "t0" in kwargs:
             warnings.warn("t0 is deprecated, use start", DeprecationWarning, stacklevel=2)
             start = kwargs.pop("t0")
@@ -523,7 +532,7 @@ class SpectrogramDict(PlotMixin, PhaseMethodsMixin, UserDict):
         else:
             raise NotImplementedError(f"Format {format} not supported")
 
-    def crop(self, start=None, end=None, copy=True, **kwargs):
+    def crop(self, start=None, end=None, *args, copy=True, **kwargs):
         """Crop each spectrogram in time.
 
         Parameters
@@ -542,6 +551,15 @@ class SpectrogramDict(PlotMixin, PhaseMethodsMixin, UserDict):
         -------
         SpectrogramDict
         """
+        if args:
+            if len(args) > 1:
+                raise TypeError(f"crop() takes at most 4 positional arguments but {2 + len(args)} were given")
+            warnings.warn(
+                "Positional inplace argument is deprecated, use copy keyword",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            copy = not args[0]
         if "t0" in kwargs:
             warnings.warn("t0 is deprecated, use start", DeprecationWarning, stacklevel=2)
             start = kwargs.pop("t0")

--- a/tests/test_verify_spectrogram_containers.py
+++ b/tests/test_verify_spectrogram_containers.py
@@ -94,3 +94,33 @@ def test_spectrogram_dict():
     # Matrix - crop returns a copy, so sd is unchanged
     mat = sd.to_matrix()
     assert mat.shape == (2, 10, 10)
+
+
+def test_spectrogram_list_crop_third_positional_arg_preserves_inplace():
+    s1 = create_mock_spectrogram("s1")
+    s2 = create_mock_spectrogram("s2")
+    sl = SpectrogramList([s1, s2])
+
+    out = sl.crop(2, 8, True)
+    assert out is sl
+    assert sl[0].times[0].value >= 2
+
+    sl2 = SpectrogramList([create_mock_spectrogram("s3"), create_mock_spectrogram("s4")])
+    out2 = sl2.crop(2, 8, False)
+    assert out2 is not sl2
+    assert out2[0].times[0].value >= 2
+
+
+def test_spectrogram_dict_crop_third_positional_arg_preserves_inplace():
+    s1 = create_mock_spectrogram("s1")
+    s2 = create_mock_spectrogram("s2")
+    sd = SpectrogramDict({"a": s1, "b": s2})
+
+    out = sd.crop(2, 8, True)
+    assert out is sd
+    assert sd["a"].times[0].value >= 2
+
+    sd2 = SpectrogramDict({"a": create_mock_spectrogram("s3"), "b": create_mock_spectrogram("s4")})
+    out2 = sd2.crop(2, 8, False)
+    assert out2 is not sd2
+    assert out2["a"].times[0].value >= 2


### PR DESCRIPTION
### Motivation
- A P1 regression inverted legacy positional semantics of `crop(t0, t1, inplace)` in spectrogram containers after refactor, causing third positional boolean to map to `copy` instead of `inplace`.

### Description
- Restore backward compatibility by changing `SpectrogramList.crop` and `SpectrogramDict.crop` signatures to accept a third positional argument via `*args` and map it to legacy `inplace` semantics with `copy = not inplace`.
- Emit a `DeprecationWarning` when callers use the third positional `inplace` argument and preserve existing keyword-based deprecations (`t0`/`t1`/`inplace`).
- Add regression tests in `tests/test_verify_spectrogram_containers.py` verifying that `crop(2, 8, True)` mutates in place (returns same container) and `crop(2, 8, False)` returns a new container for both `SpectrogramList` and `SpectrogramDict`.
- Files changed: `gwexpy/spectrogram/collections.py` and `tests/test_verify_spectrogram_containers.py`.

### Testing
- Ran the focused test suite: `pytest -q tests/test_verify_spectrogram_containers.py -k 'third_positional_arg_preserves_inplace or test_spectrogram_list or test_spectrogram_dict'` and all selected tests passed (`4 passed`).
- Warnings for deprecated usages are emitted as expected during tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69acf1038e8c8331a08d772cf3473870)