### PR TITLE
feat(io): add ndscope HDF5 format support for TimeSeries read/write

### DIFF
--- a/gwexpy/timeseries/io/__init__.py
+++ b/gwexpy/timeseries/io/__init__.py
@@ -13,6 +13,7 @@ from . import (
     audio,  # noqa: F401
     dttxml,  # noqa: F401
     gbd,  # noqa: F401
+    ndscope_hdf5,  # noqa: F401
     netcdf4_,  # noqa: F401
     sdb,  # noqa: F401
     seismic,  # noqa: F401

--- a/gwexpy/timeseries/io/ndscope_hdf5.py
+++ b/gwexpy/timeseries/io/ndscope_hdf5.py
@@ -1,0 +1,236 @@
+"""
+ndscope HDF5 format reader/writer for gwexpy.
+
+ndscope (https://git.ligo.org/cds/software/ndscope) saves time-series data
+in HDF5 files with a specific schema:
+
+    File attrs: t0, window, ...
+    ├── <channel_name> (Group)
+    │   ├── attrs: rate_hz, gps_start, unit
+    │   ├── "raw" (Dataset)            # full-rate data
+    │   ├── "mean" (Dataset, optional)  # trend data
+    │   ├── "min"  (Dataset, optional)
+    │   └── "max"  (Dataset, optional)
+
+This module registers the ``"ndscope-hdf5"`` format so that
+``TimeSeries.read()`` / ``TimeSeriesDict.read()`` can auto-detect and
+read these files, and ``.write(..., format="ndscope-hdf5")`` can produce
+ndscope-compatible output.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import h5py
+import numpy as np
+
+from .. import TimeSeries, TimeSeriesDict
+from ._registration import register_timeseries_format
+
+# Dataset names recognised as ndscope data fields.
+_NDSCOPE_DATA_KEYS = frozenset({"raw", "mean", "min", "max"})
+
+
+# ---------------------------------------------------------------------------
+# Identifier
+# ---------------------------------------------------------------------------
+
+
+def identify_ndscope_hdf5(
+    origin: type,
+    filepath: str | Path | None,
+    fileobj: Any,
+    *args: Any,
+    **kwargs: Any,
+) -> bool:
+    """Identify an ndscope HDF5 file by its internal structure.
+
+    Returns ``True`` when *filepath* points to an HDF5 file whose root
+    contains at least one Group with ``rate_hz`` and ``gps_start``
+    attributes and at least one dataset named ``raw``, ``mean``, ``min``,
+    or ``max``.
+    """
+    if filepath is None:
+        return False
+    path = str(filepath)
+    if not (path.lower().endswith(".hdf5") or path.lower().endswith(".h5")):
+        return False
+    try:
+        with h5py.File(path, "r") as f:
+            for key in f:
+                item = f[key]
+                if not isinstance(item, h5py.Group):
+                    continue
+                attrs = item.attrs
+                if "rate_hz" not in attrs or "gps_start" not in attrs:
+                    continue
+                if any(ds_name in item for ds_name in _NDSCOPE_DATA_KEYS):
+                    return True
+    except Exception:
+        return False
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Reader
+# ---------------------------------------------------------------------------
+
+
+def _resolve_source(source: Any) -> str:
+    """Extract a file path string from *source*.
+
+    gwpy's I/O registry may pass an open file object rather than a plain
+    path string.  This helper normalises both cases.
+    """
+    if isinstance(source, (str, Path)):
+        return str(source)
+    # file-like object (e.g. _io.FileIO opened by gwpy)
+    if hasattr(source, "name"):
+        return str(source.name)
+    return str(source)
+
+
+def read_timeseriesdict_ndscope_hdf5(
+    source: str | Path,
+    *,
+    channels: Iterable[str] | None = None,
+    start: float | None = None,
+    end: float | None = None,
+    **kwargs: Any,
+) -> TimeSeriesDict:
+    """Read an ndscope HDF5 file into a `TimeSeriesDict`.
+
+    Parameters
+    ----------
+    source : str or Path
+        Path to the HDF5 file.
+    channels : iterable of str, optional
+        Channel names to read.  If ``None``, all channels are read.
+    start : float, optional
+        GPS start time for cropping.
+    end : float, optional
+        GPS end time for cropping.
+
+    Returns
+    -------
+    TimeSeriesDict
+    """
+    wanted = set(channels) if channels is not None else None
+    out = TimeSeriesDict()
+
+    with h5py.File(_resolve_source(source), "r") as f:
+        for grp_name in f:
+            item = f[grp_name]
+            if not isinstance(item, h5py.Group):
+                continue
+            attrs = item.attrs
+            if "rate_hz" not in attrs or "gps_start" not in attrs:
+                continue
+
+            # Skip if not in the requested channel set.
+            if wanted is not None and grp_name not in wanted:
+                continue
+
+            sample_rate = float(attrs["rate_hz"])
+            gps_start = float(attrs["gps_start"])
+            unit = str(attrs.get("unit", ""))
+
+            ds_names = sorted(set(item.keys()) & _NDSCOPE_DATA_KEYS)
+            if not ds_names:
+                continue
+
+            for ds_name in ds_names:
+                data = np.asarray(item[ds_name])
+                # Build the channel key: append .stat for trend datasets
+                if ds_name == "raw" and len(ds_names) == 1:
+                    ch_key = grp_name
+                else:
+                    ch_key = f"{grp_name}.{ds_name}"
+
+                ts = TimeSeries(
+                    data,
+                    sample_rate=sample_rate,
+                    t0=gps_start,
+                    name=ch_key,
+                    channel=ch_key,
+                    unit=unit or None,
+                )
+
+                # Crop to [start, end] if requested.
+                if start is not None or end is not None:
+                    s = max(start, ts.span[0]) if start is not None else ts.span[0]
+                    e = min(end, ts.span[1]) if end is not None else ts.span[1]
+                    if s < e:
+                        ts = ts.crop(s, e)
+                    else:
+                        continue
+
+                out[ch_key] = ts
+
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Writer
+# ---------------------------------------------------------------------------
+
+
+def write_timeseriesdict_ndscope_hdf5(
+    tsdict: TimeSeriesDict,
+    target: str | Path,
+    *,
+    overwrite: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Write a `TimeSeriesDict` in ndscope-compatible HDF5 format.
+
+    Parameters
+    ----------
+    tsdict : TimeSeriesDict
+        Data to write.
+    target : str or Path
+        Output file path.
+    overwrite : bool, optional
+        If ``True``, overwrite an existing file.  Default: ``False``.
+    """
+    mode = "w" if overwrite else "w-"
+    with h5py.File(_resolve_source(target), mode) as f:
+        groups: dict[str, h5py.Group] = {}
+        for key, ts in tsdict.items():
+            name = str(key)
+            # Determine group name and dataset name.
+            # If the channel key contains a ".raw"/".mean"/".min"/".max"
+            # suffix, split it to reconstruct the ndscope group structure.
+            ds_name = "raw"
+            grp_name = name
+            for suffix in ("raw", "mean", "min", "max"):
+                if name.endswith(f".{suffix}"):
+                    grp_name = name[: -(len(suffix) + 1)]
+                    ds_name = suffix
+                    break
+
+            if grp_name not in groups:
+                grp = f.create_group(grp_name)
+                groups[grp_name] = grp
+            grp = groups[grp_name]
+
+            grp.create_dataset(ds_name, data=ts.value)
+            grp.attrs["rate_hz"] = float(ts.sample_rate.value)
+            grp.attrs["gps_start"] = float(ts.t0.value)
+            grp.attrs["unit"] = str(ts.unit) if ts.unit else ""
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+register_timeseries_format(
+    "ndscope-hdf5",
+    reader_dict=read_timeseriesdict_ndscope_hdf5,
+    writer_dict=write_timeseriesdict_ndscope_hdf5,
+    magic_identifier=identify_ndscope_hdf5,
+    extension="hdf5",
+)

--- a/gwexpy/timeseries/io/ndscope_hdf5.py
+++ b/gwexpy/timeseries/io/ndscope_hdf5.py
@@ -144,8 +144,10 @@ def read_timeseriesdict_ndscope_hdf5(
 
             for ds_name in ds_names:
                 data = np.asarray(item[ds_name])
-                # Build the channel key: append .stat for trend datasets
-                if ds_name == "raw" and len(ds_names) == 1:
+                # "raw" always maps to the bare channel name (grp_name).
+                # Trend datasets (mean/min/max) are always suffixed so they
+                # are unambiguous regardless of what other datasets are present.
+                if ds_name == "raw":
                     ch_key = grp_name
                 else:
                     ch_key = f"{grp_name}.{ds_name}"
@@ -197,6 +199,9 @@ def write_timeseriesdict_ndscope_hdf5(
         If ``True``, overwrite an existing file.  Default: ``False``.
     """
     mode = "w" if overwrite else "w-"
+    # group_meta tracks the first-seen metadata for each group so that
+    # subsequent series in the same group can be validated for consistency.
+    group_meta: dict[str, dict[str, float | str]] = {}
     with h5py.File(_resolve_source(target), mode) as f:
         groups: dict[str, h5py.Group] = {}
         for key, ts in tsdict.items():
@@ -212,15 +217,42 @@ def write_timeseriesdict_ndscope_hdf5(
                     ds_name = suffix
                     break
 
+            rate_hz = float(ts.sample_rate.value)
+            gps_start = float(ts.t0.value)
+            unit = str(ts.unit) if ts.unit else ""
+
             if grp_name not in groups:
                 grp = f.create_group(grp_name)
                 groups[grp_name] = grp
-            grp = groups[grp_name]
+                group_meta[grp_name] = {
+                    "rate_hz": rate_hz,
+                    "gps_start": gps_start,
+                    "unit": unit,
+                }
+                grp.attrs["rate_hz"] = rate_hz
+                grp.attrs["gps_start"] = gps_start
+                grp.attrs["unit"] = unit
+            else:
+                # Validate consistency with the first series in this group.
+                meta = group_meta[grp_name]
+                if rate_hz != meta["rate_hz"]:
+                    raise ValueError(
+                        f"Inconsistent sample_rate for group {grp_name!r}: "
+                        f"expected {meta['rate_hz']} Hz, got {rate_hz} Hz"
+                    )
+                if gps_start != meta["gps_start"]:
+                    raise ValueError(
+                        f"Inconsistent gps_start for group {grp_name!r}: "
+                        f"expected {meta['gps_start']}, got {gps_start}"
+                    )
+                if unit != meta["unit"]:
+                    raise ValueError(
+                        f"Inconsistent unit for group {grp_name!r}: "
+                        f"expected {meta['unit']!r}, got {unit!r}"
+                    )
 
+            grp = groups[grp_name]
             grp.create_dataset(ds_name, data=ts.value)
-            grp.attrs["rate_hz"] = float(ts.sample_rate.value)
-            grp.attrs["gps_start"] = float(ts.t0.value)
-            grp.attrs["unit"] = str(ts.unit) if ts.unit else ""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/timeseries/test_io_ndscope_hdf5.py
+++ b/tests/timeseries/test_io_ndscope_hdf5.py
@@ -1,0 +1,262 @@
+"""Tests for ndscope HDF5 I/O (gwexpy.timeseries.io.ndscope_hdf5)."""
+
+from __future__ import annotations
+
+import h5py
+import numpy as np
+import pytest
+
+from gwexpy.timeseries import TimeSeries, TimeSeriesDict
+from gwexpy.timeseries.io.ndscope_hdf5 import (
+    identify_ndscope_hdf5,
+    read_timeseriesdict_ndscope_hdf5,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers to create synthetic ndscope HDF5 files
+# ---------------------------------------------------------------------------
+
+
+def _make_ndscope_raw(path, channels=None):
+    """Create a minimal ndscope HDF5 file with raw data."""
+    if channels is None:
+        channels = {"K1:TEST-CHANNEL": np.arange(256, dtype=np.float64)}
+    with h5py.File(str(path), "w") as f:
+        for ch_name, data in channels.items():
+            grp = f.create_group(ch_name)
+            grp.create_dataset("raw", data=data)
+            grp.attrs["rate_hz"] = 256.0
+            grp.attrs["gps_start"] = 1_000_000_000.0
+            grp.attrs["unit"] = "m"
+
+
+def _make_ndscope_trend(path):
+    """Create an ndscope HDF5 file with trend data (mean/min/max)."""
+    n = 100
+    with h5py.File(str(path), "w") as f:
+        grp = f.create_group("K1:TREND-CHANNEL")
+        grp.create_dataset("mean", data=np.ones(n))
+        grp.create_dataset("min", data=np.zeros(n))
+        grp.create_dataset("max", data=np.ones(n) * 2)
+        grp.attrs["rate_hz"] = 1.0
+        grp.attrs["gps_start"] = 1_000_000_000.0
+        grp.attrs["unit"] = "ct"
+
+
+def _make_gwpy_hdf5(path):
+    """Create a gwpy-native HDF5 file (flat datasets, not groups)."""
+    from astropy import units as u
+
+    ts = TimeSeries(np.arange(10.0), sample_rate=1.0, t0=0, unit="m", name="test")
+    ts.write(str(path), format="hdf5")
+
+
+# ---------------------------------------------------------------------------
+# Identifier tests
+# ---------------------------------------------------------------------------
+
+
+class TestIdentify:
+    def test_identifies_ndscope_raw(self, tmp_path):
+        p = tmp_path / "ndscope_raw.hdf5"
+        _make_ndscope_raw(p)
+        assert identify_ndscope_hdf5(TimeSeriesDict, str(p), None) is True
+
+    def test_identifies_ndscope_h5_extension(self, tmp_path):
+        p = tmp_path / "ndscope_raw.h5"
+        _make_ndscope_raw(p)
+        assert identify_ndscope_hdf5(TimeSeriesDict, str(p), None) is True
+
+    def test_rejects_gwpy_hdf5(self, tmp_path):
+        p = tmp_path / "gwpy_native.hdf5"
+        _make_gwpy_hdf5(p)
+        assert identify_ndscope_hdf5(TimeSeriesDict, str(p), None) is False
+
+    def test_rejects_non_hdf5(self, tmp_path):
+        p = tmp_path / "not_hdf5.txt"
+        p.write_text("hello")
+        assert identify_ndscope_hdf5(TimeSeriesDict, str(p), None) is False
+
+    def test_rejects_none_filepath(self):
+        assert identify_ndscope_hdf5(TimeSeriesDict, None, None) is False
+
+    def test_rejects_wrong_extension(self, tmp_path):
+        p = tmp_path / "ndscope.dat"
+        _make_ndscope_raw(tmp_path / "temp.hdf5")
+        # copy with wrong extension
+        import shutil
+
+        shutil.copy(tmp_path / "temp.hdf5", p)
+        assert identify_ndscope_hdf5(TimeSeriesDict, str(p), None) is False
+
+
+# ---------------------------------------------------------------------------
+# Reader tests
+# ---------------------------------------------------------------------------
+
+
+class TestRead:
+    def test_read_raw(self, tmp_path):
+        p = tmp_path / "raw.hdf5"
+        data = np.arange(256, dtype=np.float64)
+        _make_ndscope_raw(p, {"K1:TEST-CHANNEL": data})
+
+        tsd = read_timeseriesdict_ndscope_hdf5(p)
+        assert "K1:TEST-CHANNEL" in tsd
+        ts = tsd["K1:TEST-CHANNEL"]
+        np.testing.assert_allclose(ts.value, data)
+        assert float(ts.sample_rate.value) == 256.0
+        assert float(ts.t0.value) == 1_000_000_000.0
+
+    def test_read_trend(self, tmp_path):
+        p = tmp_path / "trend.hdf5"
+        _make_ndscope_trend(p)
+
+        tsd = read_timeseriesdict_ndscope_hdf5(p)
+        assert "K1:TREND-CHANNEL.max" in tsd
+        assert "K1:TREND-CHANNEL.mean" in tsd
+        assert "K1:TREND-CHANNEL.min" in tsd
+        np.testing.assert_allclose(tsd["K1:TREND-CHANNEL.min"].value, 0.0)
+        np.testing.assert_allclose(tsd["K1:TREND-CHANNEL.max"].value, 2.0)
+
+    def test_read_multi_channel(self, tmp_path):
+        p = tmp_path / "multi.hdf5"
+        _make_ndscope_raw(
+            p,
+            {
+                "K1:CH_A": np.ones(100),
+                "K1:CH_B": np.zeros(100),
+            },
+        )
+        tsd = read_timeseriesdict_ndscope_hdf5(p)
+        assert len(tsd) == 2
+        assert "K1:CH_A" in tsd
+        assert "K1:CH_B" in tsd
+
+    def test_read_channel_filter(self, tmp_path):
+        p = tmp_path / "filter.hdf5"
+        _make_ndscope_raw(
+            p,
+            {
+                "K1:CH_A": np.ones(100),
+                "K1:CH_B": np.zeros(100),
+            },
+        )
+        tsd = read_timeseriesdict_ndscope_hdf5(p, channels=["K1:CH_A"])
+        assert list(tsd.keys()) == ["K1:CH_A"]
+
+    def test_read_with_crop(self, tmp_path):
+        p = tmp_path / "crop.hdf5"
+        n = 1024
+        with h5py.File(str(p), "w") as f:
+            grp = f.create_group("K1:TEST")
+            grp.create_dataset("raw", data=np.arange(n, dtype=np.float64))
+            grp.attrs["rate_hz"] = 256.0
+            grp.attrs["gps_start"] = 1_000_000_000.0
+            grp.attrs["unit"] = "m"
+
+        # Full span: 1e9 to 1e9 + 1024/256 = 1e9 + 4.0
+        tsd = read_timeseriesdict_ndscope_hdf5(
+            p, start=1_000_000_001.0, end=1_000_000_003.0
+        )
+        ts = tsd["K1:TEST"]
+        assert float(ts.t0.value) == pytest.approx(1_000_000_001.0)
+        duration = float(ts.duration.value)
+        assert duration == pytest.approx(2.0)
+
+    def test_read_via_timeseriesdict(self, tmp_path):
+        """Test that TimeSeriesDict.read auto-detects ndscope format."""
+        p = tmp_path / "autodetect.hdf5"
+        _make_ndscope_raw(p)
+        tsd = TimeSeriesDict.read(str(p), format="ndscope-hdf5")
+        assert "K1:TEST-CHANNEL" in tsd
+
+    def test_read_via_timeseries(self, tmp_path):
+        """Test that TimeSeries.read works with ndscope format."""
+        p = tmp_path / "single.hdf5"
+        _make_ndscope_raw(p)
+        ts = TimeSeries.read(str(p), format="ndscope-hdf5")
+        assert ts.name == "K1:TEST-CHANNEL"
+        assert len(ts) == 256
+
+
+# ---------------------------------------------------------------------------
+# Writer tests
+# ---------------------------------------------------------------------------
+
+
+class TestWrite:
+    def test_write_basic(self, tmp_path):
+        p = tmp_path / "out.hdf5"
+        ts = TimeSeries(
+            np.arange(100, dtype=np.float64),
+            sample_rate=100.0,
+            t0=1_000_000_000.0,
+            name="K1:WRITE-TEST",
+            unit="m",
+        )
+        tsd = TimeSeriesDict({"K1:WRITE-TEST": ts})
+        tsd.write(str(p), format="ndscope-hdf5")
+
+        # Verify HDF5 structure
+        with h5py.File(str(p), "r") as f:
+            assert "K1:WRITE-TEST" in f
+            grp = f["K1:WRITE-TEST"]
+            assert isinstance(grp, h5py.Group)
+            assert "raw" in grp
+            assert float(grp.attrs["rate_hz"]) == 100.0
+            assert float(grp.attrs["gps_start"]) == 1_000_000_000.0
+            assert grp.attrs["unit"] == "m"
+            np.testing.assert_allclose(grp["raw"][:], np.arange(100, dtype=np.float64))
+
+    def test_roundtrip(self, tmp_path):
+        p = tmp_path / "roundtrip.hdf5"
+        data = np.random.default_rng(42).standard_normal(512)
+        ts = TimeSeries(
+            data,
+            sample_rate=256.0,
+            t0=1_000_000_000.0,
+            name="K1:ROUNDTRIP",
+            unit="V",
+        )
+        tsd_orig = TimeSeriesDict({"K1:ROUNDTRIP": ts})
+        tsd_orig.write(str(p), format="ndscope-hdf5")
+
+        tsd_read = TimeSeriesDict.read(str(p), format="ndscope-hdf5")
+        assert "K1:ROUNDTRIP" in tsd_read
+        np.testing.assert_allclose(tsd_read["K1:ROUNDTRIP"].value, data)
+        assert float(tsd_read["K1:ROUNDTRIP"].sample_rate.value) == 256.0
+        assert float(tsd_read["K1:ROUNDTRIP"].t0.value) == 1_000_000_000.0
+
+    def test_write_trend_roundtrip(self, tmp_path):
+        """Trend-style keys (ch.mean, ch.min, ch.max) roundtrip correctly."""
+        p = tmp_path / "trend_rt.hdf5"
+        n = 60
+        tsd = TimeSeriesDict(
+            {
+                "K1:CH.mean": TimeSeries(
+                    np.ones(n), sample_rate=1.0, t0=1e9, name="K1:CH.mean", unit="ct"
+                ),
+                "K1:CH.min": TimeSeries(
+                    np.zeros(n), sample_rate=1.0, t0=1e9, name="K1:CH.min", unit="ct"
+                ),
+                "K1:CH.max": TimeSeries(
+                    np.ones(n) * 2,
+                    sample_rate=1.0,
+                    t0=1e9,
+                    name="K1:CH.max",
+                    unit="ct",
+                ),
+            }
+        )
+        tsd.write(str(p), format="ndscope-hdf5")
+
+        # Verify internal structure: single group with 3 datasets
+        with h5py.File(str(p), "r") as f:
+            assert "K1:CH" in f
+            grp = f["K1:CH"]
+            assert set(grp.keys()) == {"mean", "min", "max"}
+
+        tsd2 = TimeSeriesDict.read(str(p), format="ndscope-hdf5")
+        assert set(tsd2.keys()) == {"K1:CH.max", "K1:CH.mean", "K1:CH.min"}
+        np.testing.assert_allclose(tsd2["K1:CH.min"].value, 0.0)

--- a/tests/timeseries/test_io_ndscope_hdf5.py
+++ b/tests/timeseries/test_io_ndscope_hdf5.py
@@ -260,3 +260,75 @@ class TestWrite:
         tsd2 = TimeSeriesDict.read(str(p), format="ndscope-hdf5")
         assert set(tsd2.keys()) == {"K1:CH.max", "K1:CH.mean", "K1:CH.min"}
         np.testing.assert_allclose(tsd2["K1:CH.min"].value, 0.0)
+
+    def test_write_inconsistent_rate_raises(self, tmp_path):
+        """Writer must reject series with mismatched sample_rate in same group."""
+        p = tmp_path / "bad_rate.hdf5"
+        tsd = TimeSeriesDict(
+            {
+                "K1:CH.mean": TimeSeries(
+                    np.ones(60), sample_rate=1.0, t0=1e9, name="K1:CH.mean", unit="ct"
+                ),
+                "K1:CH.min": TimeSeries(
+                    np.zeros(120),
+                    sample_rate=2.0,  # different!
+                    t0=1e9,
+                    name="K1:CH.min",
+                    unit="ct",
+                ),
+            }
+        )
+        with pytest.raises(ValueError, match="sample_rate"):
+            tsd.write(str(p), format="ndscope-hdf5")
+
+    def test_write_inconsistent_t0_raises(self, tmp_path):
+        """Writer must reject series with mismatched gps_start in same group."""
+        p = tmp_path / "bad_t0.hdf5"
+        tsd = TimeSeriesDict(
+            {
+                "K1:CH.mean": TimeSeries(
+                    np.ones(60), sample_rate=1.0, t0=1e9, name="K1:CH.mean", unit="ct"
+                ),
+                "K1:CH.min": TimeSeries(
+                    np.zeros(60),
+                    sample_rate=1.0,
+                    t0=1e9 + 1,  # different!
+                    name="K1:CH.min",
+                    unit="ct",
+                ),
+            }
+        )
+        with pytest.raises(ValueError, match="gps_start"):
+            tsd.write(str(p), format="ndscope-hdf5")
+
+
+# ---------------------------------------------------------------------------
+# Regression tests (covering PR review findings)
+# ---------------------------------------------------------------------------
+
+
+class TestRegressions:
+    def test_raw_always_uses_bare_channel_name(self, tmp_path):
+        """raw dataset key must always be grp_name, even when mean/min/max co-exist."""
+        p = tmp_path / "mixed.hdf5"
+        n = 64
+        with h5py.File(str(p), "w") as f:
+            grp = f.create_group("K1:CH")
+            grp.create_dataset("raw", data=np.ones(n))
+            grp.create_dataset("mean", data=np.ones(n) * 0.5)
+            grp.create_dataset("min", data=np.zeros(n))
+            grp.create_dataset("max", data=np.ones(n) * 2)
+            grp.attrs["rate_hz"] = 16.0
+            grp.attrs["gps_start"] = 1e9
+            grp.attrs["unit"] = "ct"
+
+        tsd = read_timeseriesdict_ndscope_hdf5(p)
+
+        # raw must always be accessible as the bare channel name
+        assert "K1:CH" in tsd, "raw dataset must map to bare grp_name 'K1:CH'"
+        # trend datasets must have suffixes
+        assert "K1:CH.mean" in tsd
+        assert "K1:CH.min" in tsd
+        assert "K1:CH.max" in tsd
+        # raw must NOT appear with a .raw suffix
+        assert "K1:CH.raw" not in tsd, "raw must not be renamed to 'K1:CH.raw'"


### PR DESCRIPTION
## Summary

- ndscope (https://git.ligo.org/cds/software/ndscope) が保存する HDF5 ファイルを `TimeSeries.read()` / `TimeSeriesDict.read()` で読み込めるようにした
- ndscope 互換形式での `.write(..., format="ndscope-hdf5")` も実装
- magic identifier による自動検出に対応（gwpy ネイティブ HDF5 形式との区別も正しく動作）
- トレンドデータ (mean/min/max) は別チャンネルとして展開（例: `K1:CH.mean`, `K1:CH.min`, `K1:CH.max`）

### ndscope HDF5 スキーマ
```
├── <channel_name> (Group)
│   ├── attrs: rate_hz, gps_start, unit
│   ├── "raw" (Dataset)
│   ├── "mean" / "min" / "max" (Dataset, optional)
```

### 変更ファイル
- `gwexpy/timeseries/io/ndscope_hdf5.py` — 新規: reader, writer, identifier
- `gwexpy/timeseries/io/__init__.py` — ndscope_hdf5 インポート追加
- `tests/timeseries/test_io_ndscope_hdf5.py` — 新規: 16テスト

## Test plan
- [x] `ruff check` パス
- [x] `mypy` パス
- [x] `pytest tests/timeseries/test_io_ndscope_hdf5.py` — 16/16 パス
  - 識別関数テスト (ndscope検出、gwpy HDF5拒否、非HDF5拒否)
  - raw データ読み込み
  - トレンドデータ (mean/min/max) 読み込み
  - 複数チャンネル、チャンネルフィルタ、GPS時間クロップ
  - write → read ラウンドトリップ
  - トレンドデータのラウンドトリップ

https://claude.ai/code/session_01JRkwdxNbWjZzyaW2sQEGUn