### PR TITLE
fix: global future imports and remove missing decorate_registered_reader

### DIFF
--- a/gwexpy/table/io/cwb.py
+++ b/gwexpy/table/io/cwb.py
@@ -7,7 +7,6 @@ from gwpy.table.io.cwb import (
     EventTable,
     Table,
     core,
-    decorate_registered_reader,
     registry,
     table_from_cwb,
 )
@@ -19,7 +18,6 @@ __all__ = [
     "EventTable",
     "Table",
     "core",
-    "decorate_registered_reader",
     "registry",
     "table_from_cwb",
 ]

--- a/gwexpy/table/io/omega.py
+++ b/gwexpy/table/io/omega.py
@@ -7,7 +7,6 @@ from gwpy.table.io.omega import (
     OmegaHeader,
     Table,
     core,
-    decorate_registered_reader,
     registry,
 )
 
@@ -18,6 +17,5 @@ __all__ = [
     "OmegaHeader",
     "Table",
     "core",
-    "decorate_registered_reader",
     "registry",
 ]

--- a/gwexpy/table/io/utils.py
+++ b/gwexpy/table/io/utils.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from gwpy.table.io.utils import (
     EventTable,
-    decorate_registered_reader,
     filter_table,
     functools,
     read_with_columns,
@@ -13,7 +12,6 @@ from gwpy.table.io.utils import (
 
 __all__ = [
     "EventTable",
-    "decorate_registered_reader",
     "filter_table",
     "functools",
     "read_with_columns",


### PR DESCRIPTION
This PR completes the global __future__ import positions fix and removes imports of 'decorate_registered_reader' which were removed in recent GWpy versions, causing CI failures.