### PR TITLE
[AGENT:workflow] Remove shallow-clone noise from weekly docs health

### DIFF
--- a/.github/workflows/docs-weekly-health.yml
+++ b/.github/workflows/docs-weekly-health.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # sphinx-last-updated-by-git needs full history to avoid git.too_shallow noise.
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Root Cause

`Documentation Weekly Health Check` still used the default shallow checkout, while `docs/conf.py` enables `sphinx-last-updated-by-git`. That extension needs repository history and emits `Git clone too shallow [git.too_shallow]` warnings when the checkout depth is too small, which polluted the weekly health-check output.

## Why `fetch-depth: 0`

Setting `fetch-depth: 0` is the direct fix because it gives `sphinx-last-updated-by-git` the full commit history it expects. That removes the shallow-clone warning at the source instead of suppressing it.

## Why Weekly Only

The history requirement is specific to the weekly docs health workflow because that job runs Sphinx with `sphinx-last-updated-by-git` enabled and is intended to surface documentation health findings clearly. Broader CI jobs do not need this extra checkout cost for the purpose of this change, so the fix is scoped to `.github/workflows/docs-weekly-health.yml` only.

## Fixes

- Added `fetch-depth: 0` to the `actions/checkout@v4` step in `Documentation Weekly Health Check`.
- Kept the rest of the workflow unchanged so the fix stays limited to the shallow-clone noise source.

## Verification

- `python -c "import yaml, pathlib; data=yaml.safe_load(pathlib.Path('.github/workflows/docs-weekly-health.yml').read_text()); step=data['jobs']['weekly-health']['steps'][0]; print(step['name']); print(step['with']['fetch-depth'])"`
- `git diff --check -- .github/workflows/docs-weekly-health.yml`
- `gh workflow run docs-weekly-health.yml --repo tatsuki-washimi/gwexpy --ref fix/docs-weekly-health-fetch-depth`
- `gh run watch 24337972095 --repo tatsuki-washimi/gwexpy`
- `gh run view 24337972095 --repo tatsuki-washimi/gwexpy --log-failed | rg -n "git.too_shallow|Git clone too shallow|broken    |404 Client Error|Process completed with exit code 1"`

## Validation Result

- Workflow YAML parses correctly and the checkout step now resolves to `fetch-depth: 0`.
- Validation run `24337972095` reached and executed `Sphinx Linkcheck`.
- The failed log for `24337972095` no longer contains `git.too_shallow` / `Git clone too shallow`.
- The remaining failures are real docs/link issues (for example GitHub 404s and broken local references), which is the intended post-fix behavior.

## Impact

- Affects only `Documentation Weekly Health Check`.
- Increases checkout cost for that workflow only, in exchange for removing history-related warning noise and making the weekly report easier to triage.
