### PR TITLE
[AGENT:executing-plans] Fix notebook regressions for #191 and #192

### DIFF
--- a/docs/web/en/user_guide/tutorials/intro_interop.ipynb
+++ b/docs/web/en/user_guide/tutorials/intro_interop.ipynb
@@ -302,9 +302,10 @@
     "    s_pd = ts.to_pandas(index=\"datetime\")\n",
     "    print(\"\\n--- Converted to Pandas Series ---\")\n",
     "    display(s_pd)\n",
-    "    s_pd.plot(title=\"Pandas Series\")\n",
+    "    fig, ax = plt.subplots()\n",
+    "    s_pd.plot(ax=ax, title=\"Pandas Series\")\n",
     "    plt.show()\n",
-    "    plt.close()\n",
+    "    plt.close(fig)\n",
     "\n",
     "    # Restore TimeSeries from Pandas Series\n",
     "    ts_restored = TimeSeries.from_pandas(s_pd, unit=\"V\")\n",
@@ -314,7 +315,7 @@
     "    del s_pd, ts_restored\n",
     "\n",
     "except ImportError:\n",
-    "    print(\"Pandas is not installed.\")"
+    "    print(\"Pandas is not installed.\")\n"
    ]
   },
   {

--- a/docs/web/ja/user_guide/tutorials/intro_interop.ipynb
+++ b/docs/web/ja/user_guide/tutorials/intro_interop.ipynb
@@ -312,9 +312,10 @@
     "    s_pd = ts.to_pandas(index=\"datetime\")\n",
     "    print(\"\\n--- Converted to Pandas Series ---\")\n",
     "    display(s_pd)\n",
-    "    s_pd.plot(title=\"Pandas Series\")\n",
+    "    fig, ax = plt.subplots()\n",
+    "    s_pd.plot(ax=ax, title=\"Pandas Series\")\n",
     "    plt.show()\n",
-    "    plt.close()\n",
+    "    plt.close(fig)\n",
     "\n",
     "    # Pandas Series from TimeSeries\n",
     "    ts_restored = TimeSeries.from_pandas(s_pd, unit=\"V\")\n",
@@ -324,7 +325,7 @@
     "    del s_pd, ts_restored\n",
     "\n",
     "except ImportError:\n",
-    "    print(\"Pandas is not installed.\")"
+    "    print(\"Pandas is not installed.\")\n"
    ]
   },
   {

--- a/examples/basic-new-methods/intro_Interop.ipynb
+++ b/examples/basic-new-methods/intro_Interop.ipynb
@@ -264,9 +264,10 @@
     "    s_pd = ts.to_pandas(index=\"datetime\")\n",
     "    print(\"\\n--- Converted to Pandas Series ---\")\n",
     "    display(s_pd)\n",
-    "    s_pd.plot(title=\"Pandas Series\")\n",
+    "    fig, ax = plt.subplots()\n",
+    "    s_pd.plot(ax=ax, title=\"Pandas Series\")\n",
     "    plt.show()\n",
-    "    plt.close()\n",
+    "    plt.close(fig)\n",
     "\n",
     "    # Pandas Series から TimeSeries への復元\n",
     "    ts_restored = TimeSeries.from_pandas(s_pd, unit=\"V\")\n",
@@ -276,7 +277,7 @@
     "    del s_pd, ts_restored\n",
     "\n",
     "except ImportError:\n",
-    "    print(\"Pandas is not installed.\")"
+    "    print(\"Pandas is not installed.\")\n"
    ]
   },
   {

--- a/tests/docs/test_tutorial_notebook_quality.py
+++ b/tests/docs/test_tutorial_notebook_quality.py
@@ -90,6 +90,31 @@ def test_tutorial_outputs_do_not_expose_local_paths_or_raw_warnings():
     assert not offenders, "Forbidden notebook output found:\n" + "\n".join(offenders)
 
 
+@pytest.mark.parametrize(
+    "relative_path",
+    [
+        Path("en/user_guide/tutorials/intro_interop.ipynb"),
+        Path("ja/user_guide/tutorials/intro_interop.ipynb"),
+    ],
+)
+def test_intro_interop_uses_explicit_axes_for_pandas_plot(relative_path: Path):
+    nb = _read_notebook(TUTORIAL_ROOT / relative_path)
+    source = _code_cell_source_containing(nb, 's_pd = ts.to_pandas(index="datetime")')
+
+    assert "fig, ax = plt.subplots()" in source
+    assert 's_pd.plot(ax=ax, title="Pandas Series")' in source
+    assert "plt.close(fig)" in source
+
+
+def test_example_intro_interop_uses_explicit_axes_for_pandas_plot():
+    nb = _read_notebook(ROOT / "examples" / "basic-new-methods" / "intro_Interop.ipynb")
+    source = _code_cell_source_containing(nb, 's_pd = ts.to_pandas(index="datetime")')
+
+    assert "fig, ax = plt.subplots()" in source
+    assert 's_pd.plot(ax=ax, title="Pandas Series")' in source
+    assert "plt.close(fig)" in source
+
+
 def test_ja_advanced_coupling_mentions_frequency_range_restriction():
     nb = _read_notebook(
         TUTORIAL_ROOT / "ja" / "user_guide" / "tutorials" / "advanced_coupling.ipynb"

--- a/tests/io/test_dttxml_common.py
+++ b/tests/io/test_dttxml_common.py
@@ -12,6 +12,7 @@ from gwexpy.io.dttxml_common import (
     ChannelInfo,
     _decode_dtt_stream,
     extract_xml_channels,
+    load_dttxml_products,
 )
 
 # ---------------------------------------------------------------------------
@@ -189,3 +190,77 @@ class TestDecodeDttStream:
         encoded = "  " + _base64_float32(values) + "\n"
         result = _decode_dtt_stream(encoded, "LittleEndian,base64", "float")
         np.testing.assert_allclose(result, values, rtol=1e-5)
+
+
+def _make_xml_with_string_typed_spectrum_params(tmp_path) -> str:
+    """Create a minimal DTT XML file where numeric params are stored as strings."""
+
+    n_points = 4
+
+    def block(attrs: dict[str, str], data_b64: str, dtype: str) -> str:
+        lines = ['  <LIGO_LW Type="Spectrum">']
+        for key, value in attrs.items():
+            lines.append(f'    <Param Name="{key}" Type="string">{value}</Param>')
+        lines += [
+            "    <Time Name=\"t0\">1300000000</Time>",
+            f'    <Array Type="{dtype}">',
+            f"      <Dim>{n_points}</Dim>",
+            f'      <Stream Encoding="LittleEndian,base64">{data_b64}</Stream>',
+            "    </Array>",
+            "  </LIGO_LW>",
+        ]
+        return "\n".join(lines)
+
+    psd = _base64_float32([1e-10, 1e-10, 1e-10, 1e-10])
+    tf = _base64_complex64([1 + 0j, 0.5 + 0.1j, 0.25 + 0.2j, 0.125 + 0.3j])
+
+    xml = [
+        "<?xml version='1.0' encoding='utf-8'?>",
+        "<LIGO_LW>",
+        block(
+            {
+                "ChannelA": "K1:SUS-ITMX_EXCITATION",
+                "Subtype": "1",
+                "f0": "0.0",
+                "df": "1.0",
+                "N": str(n_points),
+            },
+            psd,
+            "float",
+        ),
+        block(
+            {
+                "ChannelA": "K1:SUS-ITMX_EXCITATION",
+                "ChannelB[0]": "K1:SUS-ITMX_DISPLACEMENT",
+                "Subtype": "4",
+                "f0": "0.0",
+                "df": "1.0",
+                "N": str(n_points),
+            },
+            tf,
+            "floatComplex",
+        ),
+        "</LIGO_LW>",
+    ]
+    path = tmp_path / "string_typed_spectrum.xml"
+    path.write_text("\n".join(xml))
+    return str(path)
+
+
+class TestLoadDttxmlProducts:
+    def test_native_parser_accepts_string_typed_numeric_params(self, tmp_path):
+        path = _make_xml_with_string_typed_spectrum_params(tmp_path)
+
+        products = load_dttxml_products(path, native=True)
+
+        assert {"PSD", "ASD", "TF"} <= set(products)
+
+        psd = products["PSD"]["K1:SUS-ITMX_EXCITATION"]
+        assert psd["frequencies"].dtype.kind == "f"
+        np.testing.assert_allclose(psd["frequencies"], np.arange(4, dtype=float))
+
+        tf = products["TF"][
+            ("K1:SUS-ITMX_DISPLACEMENT", "K1:SUS-ITMX_EXCITATION")
+        ]
+        assert tf["frequencies"].dtype.kind == "f"
+        assert tf["data"].dtype.kind == "c"


### PR DESCRIPTION
## Background
This PR resolves the two notebook follow-ups split out after the path-exposure work.

- `#191`: the current repo parser already handles string-typed DTT XML numeric params, so the repo-side action here is to lock that behavior in with a regression test.
- `#192`: the pandas plotting cell in the interop notebook fails with `OverflowError` unless it uses an explicit Matplotlib axes.

## Summary
- add a native DTT XML regression test for string-typed numeric spectrum params
- update the pandas plotting cell in the example and docs EN/JA intro interop notebooks to use explicit axes
- add notebook-quality tests to keep the explicit-axes pattern from regressing

## Scope
Included:
- `tests/io/test_dttxml_common.py`
- `tests/docs/test_tutorial_notebook_quality.py`
- `examples/basic-new-methods/intro_Interop.ipynb`
- `docs/web/en/user_guide/tutorials/intro_interop.ipynb`
- `docs/web/ja/user_guide/tutorials/intro_interop.ipynb`

Explicitly excluded:
- production parser code changes in `gwexpy/io/dttxml_common.py`
- unrelated local fixture changes in `tests/fixtures/data/*`

## Risk / Compatibility
- low risk: no public API changes
- `#191` adds regression coverage only
- `#192` keeps the same notebook flow and conversion example, and only changes plotting to avoid the overflow path

## Validation
- `git diff --check`
- `ruff check tests/io/test_dttxml_common.py tests/docs/test_tutorial_notebook_quality.py`
- direct parser regression script: `native parser regression ok`
- direct `intro_Interop` cell execution check: `intro_Interop pandas cell ok`
- attempted focused `pytest` runs in the local `gwexpy` env timed out after 30s with no output in this harness, so this PR does not claim fresh `pytest` pass evidence from this session

## Audit
Skills used:
- `executing-plans`
- `verification-before-completion`
- `pr-writer`

Files changed:
- `tests/io/test_dttxml_common.py`
- `tests/docs/test_tutorial_notebook_quality.py`
- `examples/basic-new-methods/intro_Interop.ipynb`
- `docs/web/en/user_guide/tutorials/intro_interop.ipynb`
- `docs/web/ja/user_guide/tutorials/intro_interop.ipynb`

Commands run:
- `git diff --check`
- `ruff check tests/io/test_dttxml_common.py tests/docs/test_tutorial_notebook_quality.py`
- direct Python verification scripts for the parser regression case and the interop notebook plotting cell

Closes #191
Closes #192
