### PR TITLE
ci: replace setup-miniconda with setup-micromamba

### DIFF
--- a/.github/workflows/ci-log-summarizer.yml
+++ b/.github/workflows/ci-log-summarizer.yml
@@ -9,6 +9,9 @@ on:
     types:
       - completed
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   summarize-logs:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-ci-example.yml.template
+++ b/.github/workflows/docs-ci-example.yml.template
@@ -23,6 +23,9 @@ on:
       - '**.md'
       - '**.rst'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   build-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -20,6 +20,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   docs-pr:
     name: Docs build and smoke checks

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -27,7 +27,7 @@ jobs:
     timeout-minutes: 45
     defaults:
       run:
-        shell: bash -el {0}
+        shell: bash -leo pipefail {0}
     env:
       PYTHONFAULTHANDLER: "1"
       NBS_EXECUTE: never
@@ -37,15 +37,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: gwexpy
-          auto-activate: false
-          channels: conda-forge
-          conda-remove-defaults: "true"
-          miniforge-version: latest
-          python-version: "3.11"
+          environment-file: environment.yml
+          environment-name: gwexpy
+          create-args: >-
+            python=3.11
+          init-shell: bash
 
       - name: Install system dependencies
         run: |
@@ -54,7 +53,6 @@ jobs:
 
       - name: Provision gwexpy docs environment
         run: |
-          conda env update -n gwexpy -f environment.yml
           python -m pip install --upgrade pip
           python -m pip install -e . --no-deps
           python -m pip install -r docs/requirements.txt

--- a/.github/workflows/extended-nightly.yml
+++ b/.github/workflows/extended-nightly.yml
@@ -22,7 +22,7 @@ jobs:
         python-version: ["3.11", "3.12"]
     defaults:
       run:
-        shell: bash -el {0}
+        shell: bash -leo pipefail {0}
     env:
       PYTHONFAULTHANDLER: "1"
     steps:
@@ -31,19 +31,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: gwexpy
-          auto-activate: false
-          channels: conda-forge
-          conda-remove-defaults: "true"
-          miniforge-version: latest
-          python-version: ${{ matrix.python-version }}
+          environment-file: environment.yml
+          environment-name: gwexpy
+          create-args: >-
+            python=${{ matrix.python-version }}
+          init-shell: bash
 
       - name: Provision gwexpy environment
         run: |
-          conda env update -n gwexpy -f environment.yml
           python -m pip install -e . --no-deps
 
       - name: Install extended test dependencies
@@ -64,26 +62,24 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -el {0}
+        shell: bash -leo pipefail {0}
     env:
       PYTHONFAULTHANDLER: "1"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: gwexpy
-          auto-activate: false
-          channels: conda-forge
-          conda-remove-defaults: "true"
-          miniforge-version: latest
-          python-version: "3.11"
+          environment-name: gwexpy
+          create-args: >-
+            python=3.11
+            pip
+          init-shell: bash
 
       - name: Provision compatibility environment
         run: |
-          conda install -n gwexpy -y pip
           python -m pip install --upgrade pip
           python -m pip install "numpy<2.0" "scipy<1.14" "astropy<7.0" pandas matplotlib h5py "gwpy>=4.0.0,<5.0.0"
           python -m pip install pytest pytest-forked
@@ -105,26 +101,24 @@ jobs:
     timeout-minutes: 45
     defaults:
       run:
-        shell: bash -el {0}
+        shell: bash -leo pipefail {0}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: gwexpy
-          auto-activate: false
-          channels: conda-forge
-          conda-remove-defaults: "true"
-          miniforge-version: latest
-          python-version: "3.11"
+          environment-file: environment.yml
+          environment-name: gwexpy
+          create-args: >-
+            python=3.11
+          init-shell: bash
 
       - name: Provision gwexpy environment
         run: |
-          conda env update -n gwexpy -f environment.yml
           python -m pip install papermill nbformat nbclient nbconvert
           python -m pip install -e ".[all]"
 
@@ -191,26 +185,24 @@ jobs:
         os: [macos-latest]
     defaults:
       run:
-        shell: bash -el {0}
+        shell: bash -leo pipefail {0}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: gwexpy
-          auto-activate: false
-          channels: conda-forge
-          conda-remove-defaults: "true"
-          miniforge-version: latest
-          python-version: "3.11"
+          environment-file: environment.yml
+          environment-name: gwexpy
+          create-args: >-
+            python=3.11
+          init-shell: bash
 
       - name: Provision gwexpy environment
         run: |
-          conda env update -n gwexpy -f environment.yml
           python -m pip install -e . --no-deps
 
       - name: Run import smoke test
@@ -235,26 +227,24 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: gwexpy
-          auto-activate: false
-          channels: conda-forge
-          conda-remove-defaults: "true"
-          miniforge-version: latest
-          python-version: "3.11"
+          environment-file: environment.yml
+          environment-name: gwexpy
+          create-args: >-
+            python=3.11
+          init-shell: powershell
 
       - name: Provision gwexpy environment
         shell: pwsh
         run: |
-          conda env update -n gwexpy -f environment.yml
-          conda activate gwexpy
+          micromamba activate gwexpy
           python -m pip install -e . --no-deps
           python -c "import sys; print(sys.executable)"
 
       - name: Run import smoke test
         shell: pwsh
         run: |
-          conda activate gwexpy
+          micromamba activate gwexpy
           python -c "import gwexpy, numpy as np; from gwexpy import TimeSeries, FrequencySeries, Spectrogram; ts = TimeSeries(np.random.randn(100), sample_rate=1); fs = FrequencySeries(np.abs(np.random.randn(100)), df=1); sg = Spectrogram(np.random.randn(10, 10), dt=1, df=1); print(gwexpy.__version__, ts.duration, fs.f0, sg.shape)"

--- a/.github/workflows/extended-nightly.yml
+++ b/.github/workflows/extended-nightly.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   ubuntu-validation:
     name: Ubuntu validation (Python ${{ matrix.python-version }})

--- a/.github/workflows/nds-live.yml
+++ b/.github/workflows/nds-live.yml
@@ -24,6 +24,9 @@ on:
         required: true
         default: "30000"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   nds-live:
     runs-on: ubuntu-latest

--- a/.github/workflows/ops-weekly.yml
+++ b/.github/workflows/ops-weekly.yml
@@ -20,22 +20,21 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -el {0}
+        shell: bash -leo pipefail {0}
     env:
       NBS_EXECUTE: never
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: gwexpy
-          auto-activate: false
-          channels: conda-forge
-          conda-remove-defaults: "true"
-          miniforge-version: latest
-          python-version: "3.11"
+          environment-file: environment.yml
+          environment-name: gwexpy
+          create-args: >-
+            python=3.11
+          init-shell: bash
 
       - name: Install system dependencies
         run: |
@@ -44,7 +43,6 @@ jobs:
 
       - name: Provision gwexpy docs environment
         run: |
-          conda env update -n gwexpy -f environment.yml
           python -m pip install --upgrade pip
           python -m pip install -e . --no-deps
           python -m pip install requests -r docs/requirements.txt
@@ -63,24 +61,22 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -el {0}
+        shell: bash -leo pipefail {0}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: gwexpy
-          auto-activate: false
-          channels: conda-forge
-          conda-remove-defaults: "true"
-          miniforge-version: latest
-          python-version: "3.11"
+          environment-file: environment.yml
+          environment-name: gwexpy
+          create-args: >-
+            python=3.11
+          init-shell: bash
 
       - name: Provision gwexpy audit environment
         run: |
-          conda env update -n gwexpy -f environment.yml
           python -m pip install --upgrade pip
           python -m pip install -e . --no-deps
           python -m pip install pip-audit bandit

--- a/.github/workflows/ops-weekly.yml
+++ b/.github/workflows/ops-weekly.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   docs-health:
     name: Docs health

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -19,6 +19,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   validate:
     name: Ruff, mypy, pytest, and smoke build

--- a/.github/workflows/pr-fast.yml
+++ b/.github/workflows/pr-fast.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash -el {0}
+        shell: bash -leo pipefail {0}
     env:
       PYTHONFAULTHANDLER: "1"
     steps:
@@ -34,19 +34,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up Miniconda
-        uses: conda-incubator/setup-miniconda@v3
+      - name: Set up micromamba
+        uses: mamba-org/setup-micromamba@v2
         with:
-          activate-environment: gwexpy
-          auto-activate: false
-          channels: conda-forge
-          conda-remove-defaults: "true"
-          miniforge-version: latest
-          python-version: "3.11"
+          environment-file: environment.yml
+          environment-name: gwexpy
+          create-args: >-
+            python=3.11
+          init-shell: bash
 
       - name: Provision gwexpy environment
         run: |
-          conda env update -n gwexpy -f environment.yml
           python -m pip install --upgrade pip build
           python -m pip install -e . --no-deps
           python -m pip install PyQt5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   verify-metadata:
     name: Verify version metadata consistency


### PR DESCRIPTION
## Summary
- replace `conda-incubator/setup-miniconda@v3` with `mamba-org/setup-micromamba@v2` in active validation workflows
- move environment creation into the action and remove redundant `conda env update` / `conda install` bootstrap steps
- align Unix shells with `bash -leo pipefail {0}` and use explicit `micromamba activate gwexpy` in Windows smoke steps

## Why
`setup-miniconda@v3` still runs on Node 20 and is the remaining source of the GitHub Actions deprecation warning. `setup-micromamba@v2` is the maintained alternative for conda-forge-based environments.

## Validation
- parsed the modified workflow YAML files locally with `yaml.safe_load`
- confirmed the edited workflows no longer reference `setup-miniconda@v3`, `conda env update`, or `conda activate gwexpy`
- branch pushed to GitHub for full workflow validation
