### PR TITLE
[codex] docs normalize EN experimental wording

### DIFF
--- a/docs/web/en/user_guide/cli.md
+++ b/docs/web/en/user_guide/cli.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-**Status:** Experimental / prototype-stage interface
+**Status:** Experimental
 
-The GWexpy CLI is currently a **minimal placeholder interface** and should be treated as a **prototype-stage feature**. At present, GWexpy is intended to be used primarily through the **Python API** for interactive analysis and scripting.
+The GWexpy CLI is currently a **minimal placeholder interface** and should be treated as an **experimental, prototype-stage feature**. At present, GWexpy is intended to be used primarily through the **Python API** for interactive analysis and scripting.
 
 ## Current Status
 

--- a/docs/web/en/user_guide/gui.md
+++ b/docs/web/en/user_guide/gui.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-**Status:** Experimental / prototype-stage interface
+**Status:** Experimental
 
-GWexpy includes a **PyQt5-based GUI** for interactive data exploration and visualization. However, the GUI should currently be treated as a **prototype-stage / experimental interface**, not as a finalized end-user product. For reproducible and fully supported workflows, the **Python API** remains the primary interface.
+GWexpy includes a **PyQt5-based GUI** for interactive data exploration and visualization. However, the GUI should currently be treated as an **experimental, prototype-stage interface**, not as a finalized end-user product. For reproducible and fully supported workflows, the **Python API** remains the primary interface.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- align the EN CLI and GUI guide status lines with the existing `Stability: Experimental` vocabulary used elsewhere in the docs
- keep `prototype-stage` wording in the explanatory prose instead of duplicating it inside the status label
- limit the change to the two EN user-guide pages touched by the earlier experimental-label batch

## Files
- `docs/web/en/user_guide/cli.md`
- `docs/web/en/user_guide/gui.md`

## Why
- the previous CLI/GUI labeling batch left the EN pages with `Experimental / prototype-stage interface` as a mixed status label
- the JA follow-up normalized wording for terminology checks, and the EN pages should use a cleaner parallel phrasing as well
- the reference API pages already use `Stability: Experimental`, so this keeps the user-guide wording closer to the existing docs vocabulary

## Validation
- `sphinx-build -E -b html -W --keep-going -D nbsphinx_execute=never docs /tmp/gwexpy-en-wording-fix`
  - `build succeeded`

## Notes
- local untracked `EN` remains intentionally excluded
