### PR TITLE
[codex] docs_internal extend A0 implemented ledger entries

### DIFF
--- a/docs_internal/analysis/webpage/A0_再基準化台帳.md
+++ b/docs_internal/analysis/webpage/A0_再基準化台帳.md
@@ -34,6 +34,16 @@
 | `17-24` | `Needs Revalidation` | coverage / 品質可視化の実体はあるが、公開 docs 導線が不足している。 |
 | `17-29` | `Implemented` | `troubleshooting.md` が既に存在する。 |
 
+## 追加の Implemented 候補（2026-04-19）
+
+| ID | status | evidence path | 根拠要約 |
+|---|---|---|---|
+| `7-6` | `Implemented` | `docs/web/ja/user_guide/interop.md`, `docs/web/en/user_guide/interop.md` | `interop.md` JA/EN の A/B/C/D 全表に詳細列を追加し、公開連携先への API 導線が docs 側で補完されている。 |
+| `16-12` | `Implemented` | `docs/_intersphinx/` | vendored inventory を同梱しており、依存先 API への外部リンク解決を repo 内証跡で確認できる。 |
+| `17-14` | `Implemented` | `docs/_static/copybutton.js`, `docs/_static/custom.css` | コード例のコピーボタン追加は具体ファイルまで repo 上で確認でき、docs-only の完了項目として扱える。 |
+| `17-16` | `Implemented` | `docs/_static/images/favicon.svg`, `docs/conf.py` | ファビコン追加と `html_favicon` 設定反映を repo 上で確認できる。 |
+| `17-20` | `Implemented` | `docs/web/ja/index.rst`, `docs/web/en/index.rst` | `Visual Examples` のカード群に `:img-alt:` を追加済みで、alt 出力の根拠が docs ソース側に残っている。 |
+
 ## 47-49 吸収メモ
 
 - `47`: `installation` は `a0-edit`、`troubleshooting` は `a0-edit-high`。


### PR DESCRIPTION
## Summary
- extend the A0 rebaseline ledger with the next set of implemented docs-only candidates
- record evidence paths for 7-6, 16-12, 17-14, 17-16, and 17-20
- keep the change scoped to docs_internal tracking only

## Validation
- git diff --check -- docs_internal/analysis/webpage/A0_再基準化台帳.md

## Notes
- only docs_internal/analysis/webpage/A0_再基準化台帳.md is included
- local untracked EN remains intentionally excluded