### PR TITLE
[codex] docs_internal extend A0 implemented ledger entries batch 2

### DIFF
--- a/docs_internal/analysis/webpage/A0_再基準化台帳.md
+++ b/docs_internal/analysis/webpage/A0_再基準化台帳.md
@@ -43,6 +43,9 @@
 | `17-14` | `Implemented` | `docs/_static/copybutton.js`, `docs/_static/custom.css` | コード例のコピーボタン追加は具体ファイルまで repo 上で確認でき、docs-only の完了項目として扱える。 |
 | `17-16` | `Implemented` | `docs/_static/images/favicon.svg`, `docs/conf.py` | ファビコン追加と `html_favicon` 設定反映を repo 上で確認できる。 |
 | `17-20` | `Implemented` | `docs/web/ja/index.rst`, `docs/web/en/index.rst` | `Visual Examples` のカード群に `:img-alt:` を追加済みで、alt 出力の根拠が docs ソース側に残っている。 |
+| `17-22` | `Implemented` | `docs/_templates/layout.html`, `docs/web/ja/user_guide/license.md`, `docs/web/en/user_guide/license.md` | フッターに `License / Disclaimer` 導線と無保証文言を常設しており、JA/EN の公開ページにも対応先がある。 |
+| `17-23` | `Implemented` | `docs/_templates/layout.html`, `docs/web/ja/user_guide/roadmap.md`, `docs/web/en/user_guide/roadmap.md` | フッターから JA/EN の公開 roadmap ページへ到達でき、監査項目の「roadmap.html を日英で新設」に相当する公開導線が実装済み。 |
+| `17-33` | `Implemented` | `.github/workflows/ops-weekly.yml`, `scripts/check_external_links.py` | 週次 Ops workflow で外部リンク検査と `sphinx-build -b linkcheck` を実行しており、リンク健全性の継続チェックが CI 側に実装済み。 |
 
 ## 47-49 吸収メモ
 


### PR DESCRIPTION
## Summary
- add the next A0 ledger batch for recently verified docs and CI items
- mark 17-22, 17-23, and 17-33 as Implemented with concrete repo evidence
- keep 15-3 in Needs Revalidation and avoid re-adding already-synced items

## Why
- the A0 ledger should stay ahead of docs-only follow-up work so later batches do not re-open already implemented audit items
- tmux workers 46-49 converged on these items as the next low-risk ledger sync slice

## Validation
- `git diff --check -- docs_internal/analysis/webpage/A0_再基準化台帳.md`

## Notes
- local untracked `EN` remains intentionally excluded
- this PR changes only `docs_internal/analysis/webpage/A0_再基準化台帳.md`
