### PR TITLE
[codex] docs_internal extend A0 implemented ledger entries batch 3

### DIFF
--- a/docs_internal/analysis/webpage/A0_再基準化台帳.md
+++ b/docs_internal/analysis/webpage/A0_再基準化台帳.md
@@ -46,6 +46,11 @@
 | `17-22` | `Implemented` | `docs/_templates/layout.html`, `docs/web/ja/user_guide/license.md`, `docs/web/en/user_guide/license.md` | フッターに `License / Disclaimer` 導線と無保証文言を常設しており、JA/EN の公開ページにも対応先がある。 |
 | `17-23` | `Implemented` | `docs/_templates/layout.html`, `docs/web/ja/user_guide/roadmap.md`, `docs/web/en/user_guide/roadmap.md` | フッターから JA/EN の公開 roadmap ページへ到達でき、監査項目の「roadmap.html を日英で新設」に相当する公開導線が実装済み。 |
 | `17-33` | `Implemented` | `.github/workflows/ops-weekly.yml`, `scripts/check_external_links.py` | 週次 Ops workflow で外部リンク検査と `sphinx-build -b linkcheck` を実行しており、リンク健全性の継続チェックが CI 側に実装済み。 |
+| `16-10` | `Implemented` | `docs/web/ja/reference/index.rst`, `docs/web/en/reference/index.rst`, `docs/web/ja/user_guide/physics_models.md`, `docs/web/en/user_guide/physics_models.md` | reference 入口から理論・アルゴリズム・tutorial への導線を追加済みで、「数式と API 関数の紐付けが弱い」問題に対する公開 docs 側の橋渡しが実装されている。 |
+| `16-11` | `Implemented` | `docs/web/ja/reference/topics.rst`, `docs/web/en/reference/topics.rst`, `docs/web/ja/reference/api/index.rst`, `docs/web/en/reference/api/index.rst` | reference / topics / API category / class page 冒頭に `Stability` / `安定性` を表示し、API の安定性と変更リスクを公開 docs 側で明示している。 |
+| `17-4` | `Implemented` | `docs/web/ja/reference/index.rst`, `docs/web/en/reference/index.rst`, `docs/web/ja/reference/topics.rst`, `docs/web/en/reference/topics.rst`, `docs/web/ja/user_guide/validated_algorithms.md`, `docs/web/en/user_guide/validated_algorithms.md` | tutorial ⇄ API の双方向リンクは exact tutorial / exact API anchor ベースへ更新済みで、generic index 依存から脱却している。 |
+| `17-25` | `Implemented` | `docs/_templates/layout.html` | フッターに GitHub Issue 作成リンクを常設しており、フィードバック導線は公開 docs 上で実装済み。 |
+| `17-40` | `Implemented` | `docs/_static/custom.css` | `wy-breadcrumbs-aside` のサイズと opacity を落として `Edit on GitHub` の露出を抑制しており、監査指摘への UI 調整が実装済み。 |
 
 ## 47-49 吸収メモ
 


### PR DESCRIPTION
## Summary
- add the next A0 ledger batch for high-confidence implemented audit items already reflected in current docs
- mark 16-10, 16-11, 17-4, 17-25, and 17-40 as Implemented with concrete repo evidence
- keep this batch scoped to a single ledger file

## Why
- after rounds 1 and 2, these five items are the next low-risk ledger sync slice backed by current main
- tmux workers 46-49 converged on A0 round 3 being small and evidence-backed

## Validation
- `git diff --check -- docs_internal/analysis/webpage/A0_再基準化台帳.md`

## Notes
- local untracked `EN` remains intentionally excluded
- this PR changes only `docs_internal/analysis/webpage/A0_再基準化台帳.md`
