### PR TITLE
[AGENT:docs] docs: restore branding logo on root docs page

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -13,6 +13,31 @@ body {
     font-family: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
 
+/* Root docs page logo, used because the index page hides the RTD sidebar. */
+.gw-home-brand {
+    padding: 1.5rem 1rem 0.5rem;
+    text-align: center;
+}
+
+.gw-home-brand img {
+    display: block;
+    width: min(72vw, 280px);
+    max-width: 280px;
+    height: auto;
+    margin: 0 auto;
+}
+
+@media (max-width: 768px) {
+    .gw-home-brand {
+        padding-top: 1.1rem;
+    }
+
+    .gw-home-brand img {
+        width: min(78vw, 220px);
+        max-width: 220px;
+    }
+}
+
 /* Brand logo sizing for the RTD sidebar/header */
 .wy-side-nav-search > a,
 .wy-side-nav-search > a:hover,

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -87,6 +87,11 @@
 
 {% block extrabody %}
   {{ super() }}
+  {% if pagename == 'index' %}
+    <div class="gw-home-brand">
+      <img src="_static/branding/logo.svg" alt="GWexpy" />
+    </div>
+  {% endif %}
   {% if pagename.startswith('web/ja/') %}
     {% set peer_doc = 'web/en/' + pagename.split('web/ja/', 1)[1] %}
     {% set peer_href = pathto(peer_doc if hasdoc(peer_doc) else 'web/en/index') %}

--- a/tests/docs/test_root_index_branding.py
+++ b/tests/docs/test_root_index_branding.py
@@ -1,0 +1,16 @@
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+ROOT_INDEX_HTML = ROOT / "docs" / "_build" / "html" / "index.html"
+
+
+def test_root_docs_index_renders_home_brand_anchor():
+    html = ROOT_INDEX_HTML.read_text(encoding="utf-8")
+
+    match = re.search(
+        r'<div class="gw-home-brand">\s*<img src="_static/branding/logo.svg" alt="GWexpy" />\s*</div>',
+        html,
+    )
+    assert match is not None
+    assert 'href="web/en/index.html"' in html

--- a/tests/docs/test_root_index_branding.py
+++ b/tests/docs/test_root_index_branding.py
@@ -2,15 +2,19 @@ import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
-ROOT_INDEX_HTML = ROOT / "docs" / "_build" / "html" / "index.html"
+ROOT_LAYOUT = ROOT / "docs" / "_templates" / "layout.html"
+ROOT_INDEX_RST = ROOT / "docs" / "index.rst"
 
 
-def test_root_docs_index_renders_home_brand_anchor():
-    html = ROOT_INDEX_HTML.read_text(encoding="utf-8")
+def test_root_docs_index_keeps_branding_source_contract():
+    layout = ROOT_LAYOUT.read_text(encoding="utf-8")
+    index_rst = ROOT_INDEX_RST.read_text(encoding="utf-8")
 
     match = re.search(
-        r'<div class="gw-home-brand">\s*<img src="_static/branding/logo.svg" alt="GWexpy" />\s*</div>',
-        html,
+        r"\{% if pagename == 'index' %\}.*?<div class=\"gw-home-brand\">.*?<img src=\"_static/branding/logo\.svg\" alt=\"GWexpy\" />.*?</div>",
+        layout,
+        flags=re.DOTALL,
     )
     assert match is not None
-    assert 'href="web/en/index.html"' in html
+    assert ".wy-nav-side          { display: none !important; }" in index_rst
+    assert ".wy-nav-content-wrap  { margin-left: 0 !important; }" in index_rst


### PR DESCRIPTION
## Summary
- restore the explicit root-page branding hook for docs/index.html
- keep the root landing page logo visible even though the RTD sidebar is hidden
- add a focused regression test for root index branding

## Validation
- conda run -n gwexpy python -m sphinx -q -b html -D nbsphinx_execute=never -D exclude_patterns='web/**,developers/**,repro/**,superpowers/plans/**' docs docs/_build/html
- rg -n -C 2 "gw-home-brand|_static/branding/logo.svg|href=\"web/en/index.html\"" docs/_build/html/index.html
- timeout 60s conda run -n gwexpy python -m pytest -q tests/docs/test_root_index_branding.py tests/docs/test_og_metadata.py --noconftest -vv