### PR TITLE
Add FrequencySeries, torch_dataset interop contracts and update exports

### DIFF
--- a/docs/developers/contracts/public_interop_contract.json
+++ b/docs/developers/contracts/public_interop_contract.json
@@ -19,6 +19,23 @@
             ]
         },
         {
+            "name": "hdf5-frequencyseries",
+            "module": "frequency",
+            "status": "public",
+            "guide_api": [
+                "to_hdf5_frequencyseries",
+                "from_hdf5_frequencyseries"
+            ],
+            "row_match_en": "| HDF5 FrequencySeries |",
+            "row_match_ja": "| HDF5 FrequencySeries |",
+            "reference_indexed": true,
+            "reference_page": "gwexpy.interop.frequency.rst",
+            "details_link": "../reference/api/gwexpy.interop.frequency.rst",
+            "notes": [
+                "FrequencySeries-specific HDF5 helpers."
+            ]
+        },
+        {
             "name": "json",
             "module": "json_",
             "status": "public",
@@ -137,6 +154,23 @@
             ]
         },
         {
+            "name": "pandas-frequencyseries",
+            "module": "frequency",
+            "status": "public",
+            "guide_api": [
+                "to_pandas_frequencyseries",
+                "from_pandas_frequencyseries"
+            ],
+            "row_match_en": "| pandas FrequencySeries |",
+            "row_match_ja": "| pandas FrequencySeries |",
+            "reference_indexed": true,
+            "reference_page": "gwexpy.interop.frequency.rst",
+            "details_link": "../reference/api/gwexpy.interop.frequency.rst",
+            "notes": [
+                "FrequencySeries-to-pandas conversion helpers."
+            ]
+        },
+        {
             "name": "polars",
             "module": "polars_",
             "status": "public",
@@ -145,6 +179,7 @@
                 "from_polars_series",
                 "to_polars_dataframe",
                 "from_polars_dataframe",
+                "to_polars_frequencyseries",
                 "to_polars_dict",
                 "from_polars_dict"
             ],
@@ -189,6 +224,23 @@
             "details_link": "../reference/api/gwexpy.interop.xarray_.rst",
             "notes": [
                 "Field interop is published through the same xarray_ reference module."
+            ]
+        },
+        {
+            "name": "xarray-frequencyseries",
+            "module": "frequency",
+            "status": "public",
+            "guide_api": [
+                "to_xarray_frequencyseries",
+                "from_xarray_frequencyseries"
+            ],
+            "row_match_en": "| xarray FrequencySeries |",
+            "row_match_ja": "| xarray FrequencySeries |",
+            "reference_indexed": true,
+            "reference_page": "gwexpy.interop.frequency.rst",
+            "details_link": "../reference/api/gwexpy.interop.frequency.rst",
+            "notes": [
+                "FrequencySeries-to-xarray DataArray helpers."
             ]
         },
         {
@@ -243,6 +295,24 @@
             ]
         },
         {
+            "name": "torch-dataset",
+            "module": "torch_dataset",
+            "status": "public",
+            "guide_api": [
+                "TimeSeriesWindowDataset",
+                "to_torch_dataset",
+                "to_torch_dataloader"
+            ],
+            "row_match_en": "| [PyTorch](https://pytorch.org/) Dataset |",
+            "row_match_ja": "| [PyTorch](https://pytorch.org/) Dataset |",
+            "reference_indexed": true,
+            "reference_page": "gwexpy.interop.torch_dataset.rst",
+            "details_link": "../reference/api/gwexpy.interop.torch_dataset.rst",
+            "notes": [
+                "Windowed dataset and DataLoader helpers for training loops."
+            ]
+        },
+        {
             "name": "tensorflow",
             "module": "tensorflow_",
             "status": "public",
@@ -282,7 +352,8 @@
             "status": "public",
             "guide_api": [
                 "to_cupy",
-                "from_cupy"
+                "from_cupy",
+                "is_cupy_available"
             ],
             "row_match_en": "| [CuPy](https://cupy.dev/) |",
             "row_match_ja": "| [CuPy](https://cupy.dev/) |",
@@ -768,7 +839,8 @@
             "module": "openems_",
             "status": "public",
             "guide_api": [
-                "from_openems_hdf5"
+                "from_openems_hdf5",
+                "DUMP_TYPE_MAP"
             ],
             "row_match_en": "| openEMS |",
             "row_match_ja": "| openEMS |",

--- a/docs/web/en/reference/api/gwexpy.interop.frequency.rst
+++ b/docs/web/en/reference/api/gwexpy.interop.frequency.rst
@@ -1,0 +1,4 @@
+gwexpy.interop.frequency
+========================
+
+.. automodule:: gwexpy.interop.frequency

--- a/docs/web/en/reference/api/gwexpy.interop.torch_dataset.rst
+++ b/docs/web/en/reference/api/gwexpy.interop.torch_dataset.rst
@@ -1,0 +1,4 @@
+gwexpy.interop.torch_dataset
+============================
+
+.. automodule:: gwexpy.interop.torch_dataset

--- a/docs/web/en/reference/api/interop.rst
+++ b/docs/web/en/reference/api/interop.rst
@@ -13,6 +13,7 @@ Standard Formats
    :nosignatures:
 
    hdf5_
+   frequency
    json_
    sqlite_
    zarr_
@@ -39,6 +40,7 @@ Array and Tensor Libraries
    :nosignatures:
 
    torch_
+   torch_dataset
    tensorflow_
    jax_
    cupy_

--- a/docs/web/en/user_guide/interop.md
+++ b/docs/web/en/user_guide/interop.md
@@ -92,6 +92,7 @@ Use it when the question is “what storage representation do I bridge to?”
 | Target | API / Entry | Status | Notes | Details |
 | --- | --- | --- | --- | --- |
 | [HDF5](https://www.hdfgroup.org/solutions/hdf5/) | `to_hdf5()`, `from_hdf5()` | Public | object-level conversion | [API](../reference/api/gwexpy.interop.hdf5_.rst) |
+| HDF5 FrequencySeries | `to_hdf5_frequencyseries()`, `from_hdf5_frequencyseries()` | Public | FrequencySeries HDF5 helpers | [API](../reference/api/gwexpy.interop.frequency.rst) |
 | JSON | `to_json()`, `from_json()` | Public | JSON string conversion | [API](../reference/api/gwexpy.interop.json_.rst) |
 | Python dict | `to_dict()`, `from_dict()` | Public | dict conversion | — |
 | [SQLite](https://www.sqlite.org/index.html) | `to_sqlite()`, `from_sqlite()` | Public | object-level bridge | [API](../reference/api/gwexpy.interop.sqlite_.rst) |
@@ -112,9 +113,11 @@ Use it when the question is “which analysis-library object do I bridge to?”
 | --- | --- | --- | --- | --- |
 | NumPy | no dedicated `to_*()` / `from_*()` API | Implemented as infrastructure | widely used as the internal array basis | — |
 | [pandas](https://pandas.pydata.org/) | `to_pandas_series()`, `from_pandas_series()`, `to_pandas_dataframe()`, `from_pandas_dataframe()` | Public | Series / DataFrame | [API](../reference/api/gwexpy.interop.pandas_.rst) |
-| [polars](https://pola.rs/) | `to_polars_series()`, `from_polars_series()`, `to_polars_dataframe()`, `from_polars_dataframe()`, `to_polars_dict()`, `from_polars_dict()` | Public | Series / DataFrame / dict | [API](../reference/api/gwexpy.interop.polars_.rst) |
+| pandas FrequencySeries | `to_pandas_frequencyseries()`, `from_pandas_frequencyseries()` | Public | FrequencySeries ⇔ pandas.Series | [API](../reference/api/gwexpy.interop.frequency.rst) |
+| [polars](https://pola.rs/) | `to_polars_series()`, `from_polars_series()`, `to_polars_dataframe()`, `from_polars_dataframe()`, `to_polars_frequencyseries()`, `to_polars_dict()`, `from_polars_dict()` | Public | Series / DataFrame / dict / FrequencySeries | [API](../reference/api/gwexpy.interop.polars_.rst) |
 | [xarray](https://docs.xarray.dev/) | `to_xarray()`, `from_xarray()` | Public | DataArray / Dataset | [API](../reference/api/gwexpy.interop.xarray_.rst) |
 | [xarray](https://docs.xarray.dev/) Field | `to_xarray_field()`, `from_xarray_field()` | Public | ScalarField / VectorField | [API](../reference/api/gwexpy.interop.xarray_.rst) |
+| xarray FrequencySeries | `to_xarray_frequencyseries()`, `from_xarray_frequencyseries()` | Public | FrequencySeries ⇔ xarray.DataArray | [API](../reference/api/gwexpy.interop.frequency.rst) |
 | [astropy](https://www.astropy.org/) | `to_astropy_timeseries()`, `from_astropy_timeseries()` | Public | `astropy.timeseries.TimeSeries` | [API](../reference/api/gwexpy.interop.astropy_.rst) |
 | [dask](https://www.dask.org/) | `to_dask()`, `from_dask()` | Public | dask array bridge | [API](../reference/api/gwexpy.interop.dask_.rst) |
 
@@ -131,9 +134,10 @@ Check whether only the array payload moves, or whether metadata can also be reco
 | Target | API / Entry | Status | Notes | Details |
 | --- | --- | --- | --- | --- |
 | [PyTorch](https://pytorch.org/) | `to_torch()`, `from_torch()` | Public | tensor conversion | [API](../reference/api/gwexpy.interop.torch_.rst) |
+| [PyTorch](https://pytorch.org/) Dataset | `TimeSeriesWindowDataset`, `to_torch_dataset()`, `to_torch_dataloader()` | Public | windowed dataset for training | [API](../reference/api/gwexpy.interop.torch_dataset.rst) |
 | [TensorFlow](https://www.tensorflow.org/) | `to_tf()`, `from_tf()` | Public | tensor conversion | [API](../reference/api/gwexpy.interop.tensorflow_.rst) |
 | [JAX](https://jax.readthedocs.io/en/latest/) | `to_jax()`, `from_jax()` | Public | JAX array conversion | [API](../reference/api/gwexpy.interop.jax_.rst) |
-| [CuPy](https://cupy.dev/) | `to_cupy()`, `from_cupy()` | Public | GPU array conversion | [API](../reference/api/gwexpy.interop.cupy_.rst) |
+| [CuPy](https://cupy.dev/) | `to_cupy()`, `from_cupy()`, `is_cupy_available()` | Public | GPU array conversion | [API](../reference/api/gwexpy.interop.cupy_.rst) |
 
 (interop-en-domain-conversion)=
 ## D. Physics and Domain-Specific Libraries
@@ -174,7 +178,7 @@ Read the status carefully: some targets are full round-trips, some are mainly im
 | pySDy | `from_uff_dataset55()`, `from_uff_dataset58()` | Public | mainly import | [API](../reference/api/gwexpy.interop.sdypy_.rst) |
 | SDynPy | `from_sdynpy_frf()`, `from_sdynpy_shape()`, `from_sdynpy_timehistory()` | Public | mainly import | [API](../reference/api/gwexpy.interop.sdynpy_.rst) |
 | Meep | `from_meep_hdf5()` | Public | mainly import | [API](../reference/api/gwexpy.interop.meep_.rst) |
-| openEMS | `from_openems_hdf5()` | Public | mainly import | [API](../reference/api/gwexpy.interop.openems_.rst) |
+| openEMS | `from_openems_hdf5()`, `DUMP_TYPE_MAP` | Public | mainly import | [API](../reference/api/gwexpy.interop.openems_.rst) |
 | emg3d | `to_emg3d_field()`, `from_emg3d_field()`, `from_emg3d_h5()` | Public | EM field import/export | [API](../reference/api/gwexpy.interop.emg3d_.rst) |
 | meshio | `from_meshio()`, `from_fenics_xdmf()`, `from_fenics_vtk()` | Public | mainly import | [API](../reference/api/gwexpy.interop.meshio_.rst) |
 | MetPy | `from_metpy_dataarray()` | Public | mainly import | [API](../reference/api/gwexpy.interop.metpy_.rst) |

--- a/docs/web/ja/reference/api/gwexpy.interop.frequency.rst
+++ b/docs/web/ja/reference/api/gwexpy.interop.frequency.rst
@@ -1,0 +1,4 @@
+gwexpy.interop.frequency
+========================
+
+.. automodule:: gwexpy.interop.frequency

--- a/docs/web/ja/reference/api/gwexpy.interop.torch_dataset.rst
+++ b/docs/web/ja/reference/api/gwexpy.interop.torch_dataset.rst
@@ -1,0 +1,4 @@
+gwexpy.interop.torch_dataset
+============================
+
+.. automodule:: gwexpy.interop.torch_dataset

--- a/docs/web/ja/reference/api/interop.rst
+++ b/docs/web/ja/reference/api/interop.rst
@@ -13,6 +13,7 @@
    :nosignatures:
 
    hdf5_
+   frequency
    json_
    sqlite_
    zarr_
@@ -39,6 +40,7 @@
    :nosignatures:
 
    torch_
+   torch_dataset
    tensorflow_
    jax_
    cupy_

--- a/docs/web/ja/user_guide/interop.md
+++ b/docs/web/ja/user_guide/interop.md
@@ -92,6 +92,7 @@ myst:
 | 連携先 | API / 入口 | 状態 | 補足 | 詳細 |
 | --- | --- | --- | --- | --- |
 | [HDF5](https://www.hdfgroup.org/solutions/hdf5/) | `to_hdf5()`, `from_hdf5()` | 公開済み | object-level 変換 | [API](../reference/api/gwexpy.interop.hdf5_.rst) |
+| HDF5 FrequencySeries | `to_hdf5_frequencyseries()`, `from_hdf5_frequencyseries()` | 公開済み | FrequencySeries HDF5 ヘルパー | [API](../reference/api/gwexpy.interop.frequency.rst) |
 | JSON | `to_json()`, `from_json()` | 公開済み | JSON 文字列との相互変換 | [API](../reference/api/gwexpy.interop.json_.rst) |
 | Python dict | `to_dict()`, `from_dict()` | 公開済み | dict との相互変換 | — |
 | [SQLite](https://www.sqlite.org/index.html) | `to_sqlite()`, `from_sqlite()` | 公開済み | object-level bridge | [API](../reference/api/gwexpy.interop.sqlite_.rst) |
@@ -112,9 +113,11 @@ myst:
 | --- | --- | --- | --- | --- |
 | NumPy | 専用 `to_*()` / `from_*()` API なし | 実装済み（基盤対応） | 内部配列表現として広く利用 | — |
 | [pandas](https://pandas.pydata.org/) | `to_pandas_series()`, `from_pandas_series()`, `to_pandas_dataframe()`, `from_pandas_dataframe()` | 公開済み | Series / DataFrame | [API](../reference/api/gwexpy.interop.pandas_.rst) |
-| [polars](https://pola.rs/) | `to_polars_series()`, `from_polars_series()`, `to_polars_dataframe()`, `from_polars_dataframe()`, `to_polars_dict()`, `from_polars_dict()` | 公開済み | Series / DataFrame / dict | [API](../reference/api/gwexpy.interop.polars_.rst) |
+| pandas FrequencySeries | `to_pandas_frequencyseries()`, `from_pandas_frequencyseries()` | 公開済み | FrequencySeries ⇔ pandas.Series | [API](../reference/api/gwexpy.interop.frequency.rst) |
+| [polars](https://pola.rs/) | `to_polars_series()`, `from_polars_series()`, `to_polars_dataframe()`, `from_polars_dataframe()`, `to_polars_frequencyseries()`, `to_polars_dict()`, `from_polars_dict()` | 公開済み | Series / DataFrame / dict / FrequencySeries | [API](../reference/api/gwexpy.interop.polars_.rst) |
 | [xarray](https://docs.xarray.dev/) | `to_xarray()`, `from_xarray()` | 公開済み | DataArray / Dataset | [API](../reference/api/gwexpy.interop.xarray_.rst) |
 | [xarray](https://docs.xarray.dev/) Field | `to_xarray_field()`, `from_xarray_field()` | 公開済み | ScalarField / VectorField | [API](../reference/api/gwexpy.interop.xarray_.rst) |
+| xarray FrequencySeries | `to_xarray_frequencyseries()`, `from_xarray_frequencyseries()` | 公開済み | FrequencySeries ⇔ xarray.DataArray | [API](../reference/api/gwexpy.interop.frequency.rst) |
 | [astropy](https://www.astropy.org/) | `to_astropy_timeseries()`, `from_astropy_timeseries()` | 公開済み | `astropy.timeseries.TimeSeries` | [API](../reference/api/gwexpy.interop.astropy_.rst) |
 | [dask](https://www.dask.org/) | `to_dask()`, `from_dask()` | 公開済み | dask array bridge | [API](../reference/api/gwexpy.interop.dask_.rst) |
 
@@ -131,9 +134,10 @@ myst:
 | 連携先 | API / 入口 | 状態 | 補足 | 詳細 |
 | --- | --- | --- | --- | --- |
 | [PyTorch](https://pytorch.org/) | `to_torch()`, `from_torch()` | 公開済み | Tensor 変換 | [API](../reference/api/gwexpy.interop.torch_.rst) |
+| [PyTorch](https://pytorch.org/) Dataset | `TimeSeriesWindowDataset`, `to_torch_dataset()`, `to_torch_dataloader()` | 公開済み | トレーニングループ用ウィンドウデータセット | [API](../reference/api/gwexpy.interop.torch_dataset.rst) |
 | [TensorFlow](https://www.tensorflow.org/) | `to_tf()`, `from_tf()` | 公開済み | Tensor 変換 | [API](../reference/api/gwexpy.interop.tensorflow_.rst) |
 | [JAX](https://jax.readthedocs.io/en/latest/) | `to_jax()`, `from_jax()` | 公開済み | JAX array 変換 | [API](../reference/api/gwexpy.interop.jax_.rst) |
-| [CuPy](https://cupy.dev/) | `to_cupy()`, `from_cupy()` | 公開済み | GPU array 変換 | [API](../reference/api/gwexpy.interop.cupy_.rst) |
+| [CuPy](https://cupy.dev/) | `to_cupy()`, `from_cupy()`, `is_cupy_available()` | 公開済み | GPU array 変換 | [API](../reference/api/gwexpy.interop.cupy_.rst) |
 
 (interop-ja-domain-conversion)=
 ## D. 物理・ドメイン特化ライブラリ
@@ -174,7 +178,7 @@ myst:
 | pySDy | `from_uff_dataset55()`, `from_uff_dataset58()` | 公開済み | import 中心 | [API](../reference/api/gwexpy.interop.sdypy_.rst) |
 | SDynPy | `from_sdynpy_frf()`, `from_sdynpy_shape()`, `from_sdynpy_timehistory()` | 公開済み | import 中心 | [API](../reference/api/gwexpy.interop.sdynpy_.rst) |
 | Meep | `from_meep_hdf5()` | 公開済み | import 中心 | [API](../reference/api/gwexpy.interop.meep_.rst) |
-| openEMS | `from_openems_hdf5()` | 公開済み | import 中心 | [API](../reference/api/gwexpy.interop.openems_.rst) |
+| openEMS | `from_openems_hdf5()`, `DUMP_TYPE_MAP` | 公開済み | import 中心 | [API](../reference/api/gwexpy.interop.openems_.rst) |
 | emg3d | `to_emg3d_field()`, `from_emg3d_field()`, `from_emg3d_h5()` | 公開済み | EM field import/export | [API](../reference/api/gwexpy.interop.emg3d_.rst) |
 | meshio | `from_meshio()`, `from_fenics_xdmf()`, `from_fenics_vtk()` | 公開済み | import 中心 | [API](../reference/api/gwexpy.interop.meshio_.rst) |
 | MetPy | `from_metpy_dataarray()` | 公開済み | import 中心 | [API](../reference/api/gwexpy.interop.metpy_.rst) |

--- a/gwexpy/interop/__init__.py
+++ b/gwexpy/interop/__init__.py
@@ -49,7 +49,7 @@ from .multitaper_ import from_mtspec, from_mtspec_array
 from .neo_ import from_neo, to_neo
 from .netcdf4_ import from_netcdf4, to_netcdf4
 from .obspy_ import from_obspy, from_obspy_trace, to_obspy, to_obspy_trace
-from .openems_ import from_openems_hdf5
+from .openems_ import DUMP_TYPE_MAP, from_openems_hdf5
 from .opensees_ import from_opensees_recorder
 from .pandas_ import (
     from_pandas_dataframe,
@@ -168,8 +168,6 @@ __all__ = [
     # sqlite
     "to_sqlite",
     "from_sqlite",
-    # optional
-    "require_optional",
     # frequency series
     "to_pandas_frequencyseries",
     "from_pandas_frequencyseries",
@@ -259,6 +257,7 @@ __all__ = [
     "from_meep_hdf5",
     # openems
     "from_openems_hdf5",
+    "DUMP_TYPE_MAP",
     # emg3d
     "from_emg3d_field",
     "from_emg3d_h5",

--- a/gwexpy/interop/__init__.py
+++ b/gwexpy/interop/__init__.py
@@ -13,6 +13,9 @@ os.environ.setdefault("LAL_DEBUG_LEVEL", "0")
 # Force JAX to CPU if GPU is not fully setup to avoid warnings
 if "JAX_PLATFORMS" not in os.environ:
     os.environ["JAX_PLATFORMS"] = "cpu"
+# Deprecated compat re-export: not in __all__, but kept importable to avoid ImportError
+# for code that relied on the previously exported symbol.
+from ._optional import require_optional as require_optional
 from .astropy_ import from_astropy_timeseries, to_astropy_timeseries
 from .control_ import from_control_frd, from_control_response, to_control_frd
 from .cupy_ import from_cupy, is_cupy_available, to_cupy

--- a/gwexpy/interop/__init__.py
+++ b/gwexpy/interop/__init__.py
@@ -13,7 +13,6 @@ os.environ.setdefault("LAL_DEBUG_LEVEL", "0")
 # Force JAX to CPU if GPU is not fully setup to avoid warnings
 if "JAX_PLATFORMS" not in os.environ:
     os.environ["JAX_PLATFORMS"] = "cpu"
-from ._optional import require_optional
 from .astropy_ import from_astropy_timeseries, to_astropy_timeseries
 from .control_ import from_control_frd, from_control_response, to_control_frd
 from .cupy_ import from_cupy, is_cupy_available, to_cupy

--- a/tests/interop/test_interop_contract.py
+++ b/tests/interop/test_interop_contract.py
@@ -65,6 +65,25 @@ def test_interop_contract_schema_is_well_formed():
             assert module is None
 
 
+def test_public_namespace_is_fully_covered_by_contract():
+    """Reverse-direction check: every symbol in interop.__all__ must appear in the contract.
+
+    Prevents __all__ from growing beyond what the contract explicitly tracks.
+    """
+    contract_symbols: set[str] = set()
+    for entry in TARGETS:
+        contract_symbols.update(entry.get("guide_api", []))
+
+    exported = set(interop.__all__)
+    unregistered = sorted(exported - contract_symbols)
+
+    assert unregistered == [], (
+        f"Symbols in interop.__all__ not registered in any contract entry's guide_api: "
+        f"{unregistered}\n"
+        f"Either add them to the contract or remove from __all__."
+    )
+
+
 def test_documented_interop_api_is_available_from_public_namespace():
     exported = set(interop.__all__)
 

--- a/tests/interop/test_interop_docs_contract_sync.py
+++ b/tests/interop/test_interop_docs_contract_sync.py
@@ -65,7 +65,9 @@ def test_english_guide_rows_match_contract():
         line = _find_row(guide, entry["row_match_en"])
         assert STATUS_LABELS_EN[entry["status"]] in line
         for func_name in entry["guide_api"]:
-            assert f"`{func_name}()`" in line
+            assert (
+                f"`{func_name}()`" in line or f"`{func_name}`" in line
+            ), f"Expected `{func_name}` (with or without ()) in guide row: {line!r}"
         details_link = entry.get("details_link")
         if details_link:
             assert f"[API]({details_link})" in line
@@ -78,7 +80,9 @@ def test_japanese_guide_rows_match_contract():
         line = _find_row(guide, entry["row_match_ja"])
         assert STATUS_LABELS_JA[entry["status"]] in line
         for func_name in entry["guide_api"]:
-            assert f"`{func_name}()`" in line
+            assert (
+                f"`{func_name}()`" in line or f"`{func_name}`" in line
+            ), f"Expected `{func_name}` (with or without ()) in guide row: {line!r}"
         details_link = entry.get("details_link")
         if details_link:
             assert f"[API]({details_link})" in line


### PR DESCRIPTION
## Summary

This PR expands the interoperability contract documentation to cover new FrequencySeries conversion helpers and PyTorch Dataset utilities, while also updating the public API exports and adding validation tests.

### Key Changes

1. **Contract Updates** (`public_interop_contract.json`):
   - Added 4 new contract entries for FrequencySeries interop:
     - `hdf5-frequencyseries`: HDF5 serialization helpers
     - `pandas-frequencyseries`: pandas Series conversion
     - `xarray-frequencyseries`: xarray DataArray conversion
   - Added `torch-dataset` contract entry for windowed dataset/dataloader utilities
   - Extended `polars` contract to include `to_polars_frequencyseries()`
   - Extended `cupy` contract to include `is_cupy_available()`
   - Extended `openems_` contract to include `DUMP_TYPE_MAP`

2. **Public API Exports** (`gwexpy/interop/__init__.py`):
   - Added `DUMP_TYPE_MAP` to imports and `__all__` from `openems_`
   - Removed `require_optional` from `__all__` (no longer exported)
   - Reordered `__all__` to group frequency series helpers together

3. **Documentation**:
   - Updated English and Japanese user guides to reflect new interop targets
   - Added new reference pages for `gwexpy.interop.frequency` and `gwexpy.interop.torch_dataset`
   - Updated API reference index to include new modules

4. **Testing**:
   - Added `test_public_namespace_is_fully_covered_by_contract()` to ensure all symbols in `interop.__all__` are registered in the contract
   - Updated guide row matching tests to accept both `func_name()` and `func_name` formats (for class names like `TimeSeriesWindowDataset`)

## Acceptance Criteria

- [x] Code follows the project's style guidelines
- [x] Tests have been added to validate contract coverage
- [x] Documentation updated in both English and Japanese with paired changes

## Documentation Checklist

- [x] **JA/EN Sync**: Changes verified for consistency between Japanese and English pages
- [x] **Contract Validation**: New test ensures `__all__` exports match contract entries

## Impact

No breaking changes. This PR formalizes existing or new interop functionality through contract documentation and ensures consistency between public exports and documented APIs.

https://claude.ai/code/session_015tE4xD2AcFDWBUEntJ7C1N