### PR TITLE
[codex] Replace internal API mapping tutorial links

### DIFF
--- a/docs/web/en/user_guide/tutorials/advanced_coupling.ipynb
+++ b/docs/web/en/user_guide/tutorials/advanced_coupling.ipynb
@@ -80,7 +80,7 @@
     "\n",
     "**レガシーコード移行メモ:**  \n",
     "scipy で PSD を手動計算してカスタム閾値処理していた既存コードは、このワークフローに置き換えられます。  \n",
-    "[GWpy ユーザー向け移行ガイド](../gwexpy_for_gwpy_users_ja.md) と [GWpy 差分 API 一覧](../gwpy_added_api_index_ja.md) も参照してください。"
+    "[GWpy ユーザー向け移行ガイド](../gwexpy_for_gwpy_users_en.md) と [GWpy 差分 API 一覧](../gwpy_added_api_index_en.md) も参照してください。"
    ]
   },
   {

--- a/docs/web/en/user_guide/tutorials/advanced_coupling.ipynb
+++ b/docs/web/en/user_guide/tutorials/advanced_coupling.ipynb
@@ -48,7 +48,7 @@
     "\n",
     "**Legacy migration note:**  \n",
     "If your legacy code manually computed PSDs, divided them, and applied custom thresholds via scipy, this workflow replaces all of that.  \n",
-    "See API_MAPPING.md for the before/after migration guide."
+    "See the [Migration Guide for GWpy Users](../gwexpy_for_gwpy_users_en.md) and [GWpy Difference API Index](../gwpy_added_api_index_en.md) for migration guidance."
    ]
   },
   {
@@ -80,7 +80,7 @@
     "\n",
     "**レガシーコード移行メモ:**  \n",
     "scipy で PSD を手動計算してカスタム閾値処理していた既存コードは、このワークフローに置き換えられます。  \n",
-    "API_MAPPING.md の移行ガイドも参照してください。"
+    "[GWpy ユーザー向け移行ガイド](../gwexpy_for_gwpy_users_ja.md) と [GWpy 差分 API 一覧](../gwpy_added_api_index_ja.md) も参照してください。"
    ]
   },
   {

--- a/docs/web/en/user_guide/tutorials/advanced_decomposition.ipynb
+++ b/docs/web/en/user_guide/tutorials/advanced_decomposition.ipynb
@@ -65,7 +65,7 @@
     "\n",
     "**レガシーコード移行メモ:**  \n",
     "`sklearn.decomposition.PCA` / `FastICA` を直接使っていたコードは `matrix.pca()` / `matrix.ica()` に置き換えられます。  \n",
-    "[GWpy ユーザー向け移行ガイド](../gwexpy_for_gwpy_users_ja.md) と [GWpy 差分 API 一覧](../gwpy_added_api_index_ja.md) の Before/After 例も参照してください。"
+    "[GWpy ユーザー向け移行ガイド](../gwexpy_for_gwpy_users_en.md) と [GWpy 差分 API 一覧](../gwpy_added_api_index_en.md) の Before/After 例も参照してください。"
    ]
   },
   {

--- a/docs/web/en/user_guide/tutorials/advanced_decomposition.ipynb
+++ b/docs/web/en/user_guide/tutorials/advanced_decomposition.ipynb
@@ -39,7 +39,7 @@
     "\n",
     "**Legacy migration note:**  \n",
     "If your code used `sklearn.decomposition.PCA` or `sklearn.decomposition.FastICA` directly, you can replace them with `matrix.pca()` and `matrix.ica()`.  \n",
-    "See API_MAPPING.md Category 3 for before/after examples."
+    "See the [Migration Guide for GWpy Users](../gwexpy_for_gwpy_users_en.md) and [GWpy Difference API Index](../gwpy_added_api_index_en.md) for before/after migration examples."
    ]
   },
   {
@@ -65,7 +65,7 @@
     "\n",
     "**レガシーコード移行メモ:**  \n",
     "`sklearn.decomposition.PCA` / `FastICA` を直接使っていたコードは `matrix.pca()` / `matrix.ica()` に置き換えられます。  \n",
-    "API_MAPPING.md Category 3 の Before/After コード例も参照してください。"
+    "[GWpy ユーザー向け移行ガイド](../gwexpy_for_gwpy_users_ja.md) と [GWpy 差分 API 一覧](../gwpy_added_api_index_ja.md) の Before/After 例も参照してください。"
    ]
   },
   {

--- a/docs/web/en/user_guide/tutorials/case_gbd_format.ipynb
+++ b/docs/web/en/user_guide/tutorials/case_gbd_format.ipynb
@@ -41,7 +41,7 @@
     "\n",
     "**Legacy migration note:**  \n",
     "The `gbd2gwf.py` and `read_gbd.py` scripts in legacy KAGRA repositories have been consolidated into `gwexpy.timeseries.io.gbd`.  \n",
-    "See API_MAPPING.md Category 1 for details."
+    "See the [File I/O Supported Formats Guide](../io_formats.md) for the current public direct-I/O contract."
    ]
   },
   {
@@ -69,7 +69,7 @@
     "\n",
     "**レガシー移行ノート:**  \n",
     "これまでの KAGRA リポジトリで使われていた `gbd2gwf.py` や `read_gbd.py` などのスクリプトは、`gwexpy.timeseries.io.gbd` に統合されました。  \n",
-    "詳細は API_MAPPING.md カテゴリ 1 を参照してください。"
+    "現在の public direct-I/O 契約は [ファイル I/O 対応フォーマットガイド](../io_formats.md) を参照してください。"
    ]
   },
   {

--- a/docs/web/en/user_guide/tutorials/case_seismic_obspy.ipynb
+++ b/docs/web/en/user_guide/tutorials/case_seismic_obspy.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "**Legacy migration note:**  \n",
     "If your code used `obspy.read()` directly followed by manual numpy processing, replace it with `TimeSeries.read(format='miniseed')` and gwexpy's high-level signal processing methods.  \n",
-    "See API_MAPPING.md Category 4 for the full interop reference."
+    "See the [Interop / Conversion Guide](../interop.md) and [Interop API reference](../../reference/api/interop.rst) for the current public interop surface."
    ]
   },
   {
@@ -60,7 +60,7 @@
     "**レガシーコード移行メモ:**  \n",
     "`obspy.read()` で読み込んで手動で numpy 処理していたコードは、  \n",
     "`TimeSeries.read(format='miniseed')` + gwexpy の高レベル API に置き換えられます。  \n",
-    "API_MAPPING.md Category 4 の interop リファレンスも参照してください。"
+    "現在の public interop surface は [Interop / 変換ガイド](../interop.md) と [Interop API リファレンス](../../reference/api/interop.rst) を参照してください。"
    ]
   },
   {

--- a/scripts/notebook_gen/check_changed_notebooks.py
+++ b/scripts/notebook_gen/check_changed_notebooks.py
@@ -167,6 +167,7 @@ def run_heavy_notebooks(paths: list[Path]) -> None:
     """Check heavy notebooks with nbval-lax."""
     rel_paths = [str(path.relative_to(REPO_ROOT)) for path in paths]
     env = os.environ.copy()
+    # Keep unrelated pytest plugins, such as pytest-qt, out of nbval-only checks.
     env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
     cmd = [
         sys.executable,

--- a/scripts/notebook_gen/check_changed_notebooks.py
+++ b/scripts/notebook_gen/check_changed_notebooks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -22,7 +23,12 @@ BOOTSTRAP_PATTERNS = (
 BOOTSTRAP_HINTS = ("gwexpy[all]", "colab", "scipy<", "numpy<", "astropy<", "gwpy<")
 
 
-def run_command(cmd: list[str], *, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
+def run_command(
+    cmd: list[str],
+    *,
+    capture_output: bool = False,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
     """Run a subprocess from the repository root."""
     return subprocess.run(
         cmd,
@@ -30,6 +36,7 @@ def run_command(cmd: list[str], *, capture_output: bool = False) -> subprocess.C
         check=False,
         text=True,
         capture_output=capture_output,
+        env=env,
     )
 
 
@@ -159,9 +166,21 @@ def run_light_notebooks(paths: list[Path], output_dir: Path, kernel: str) -> Non
 def run_heavy_notebooks(paths: list[Path]) -> None:
     """Check heavy notebooks with nbval-lax."""
     rel_paths = [str(path.relative_to(REPO_ROOT)) for path in paths]
-    cmd = [sys.executable, "-m", "pytest", "--nbval-lax", "-v", "-q", *rel_paths]
+    env = os.environ.copy()
+    env["PYTEST_DISABLE_PLUGIN_AUTOLOAD"] = "1"
+    cmd = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "-p",
+        "nbval.plugin",
+        "--nbval-lax",
+        "-v",
+        "-q",
+        *rel_paths,
+    ]
     print("\n[heavy] Running nbval syntax checks")
-    result = run_command(cmd)
+    result = run_command(cmd, env=env)
     if result.returncode != 0:
         raise SystemExit(result.returncode)
 

--- a/scripts/notebook_gen/check_changed_notebooks.py
+++ b/scripts/notebook_gen/check_changed_notebooks.py
@@ -174,6 +174,8 @@ def run_heavy_notebooks(paths: list[Path]) -> None:
         "-m",
         "pytest",
         "-p",
+        "no:qt",
+        "-p",
         "nbval.plugin",
         "--nbval-lax",
         "-v",

--- a/tests/docs/test_docs_warning_regressions.py
+++ b/tests/docs/test_docs_warning_regressions.py
@@ -1,8 +1,12 @@
 import json
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 PUBLIC_DOC_SUFFIXES = {".ipynb", ".md", ".rst"}
+MIGRATION_GUIDE_LINK_RE = re.compile(
+    r"\]\(([^)]*(?:gwexpy_for_gwpy_users|gwpy_added_api_index)_[a-z]{2}\.md)\)"
+)
 
 
 def _read_notebook(relative_path: str) -> dict:
@@ -42,6 +46,21 @@ def test_public_docs_do_not_reference_internal_api_mapping():
     ]
 
     assert not offenders, "Internal API_MAPPING.md references found:\n" + "\n".join(offenders)
+
+
+def test_public_docs_migration_guide_links_exist():
+    offenders: list[str] = []
+
+    for path, text in _iter_public_doc_texts():
+        for match in MIGRATION_GUIDE_LINK_RE.finditer(text):
+            target = match.group(1)
+            if "://" in target or target.startswith("#"):
+                continue
+            resolved = (path.parent / target).resolve()
+            if not resolved.is_file():
+                offenders.append(f"{path.relative_to(ROOT)} -> {target}")
+
+    assert not offenders, "Broken migration guide links found:\n" + "\n".join(offenders)
 
 
 def test_io_format_guides_do_not_start_sections_with_transition():

--- a/tests/docs/test_docs_warning_regressions.py
+++ b/tests/docs/test_docs_warning_regressions.py
@@ -4,9 +4,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 PUBLIC_DOC_SUFFIXES = {".ipynb", ".md", ".rst"}
-MIGRATION_GUIDE_LINK_RE = re.compile(
-    r"\]\(([^)]*(?:gwexpy_for_gwpy_users|gwpy_added_api_index)_[a-z]{2}\.md)\)"
-)
+PUBLIC_DOC_LINK_RE = re.compile(r"\]\(([^)]+\.(?:md|rst)(?:#[^)]*)?)\)")
 
 
 def _read_notebook(relative_path: str) -> dict:
@@ -48,19 +46,24 @@ def test_public_docs_do_not_reference_internal_api_mapping():
     assert not offenders, "Internal API_MAPPING.md references found:\n" + "\n".join(offenders)
 
 
-def test_public_docs_migration_guide_links_exist():
+def test_public_docs_relative_markdown_links_exist():
     offenders: list[str] = []
 
     for path, text in _iter_public_doc_texts():
-        for match in MIGRATION_GUIDE_LINK_RE.finditer(text):
-            target = match.group(1)
-            if "://" in target or target.startswith("#"):
+        for match in PUBLIC_DOC_LINK_RE.finditer(text):
+            raw_target = match.group(1)
+            target = raw_target.split("#", 1)[0]
+            if "://" in target or target.startswith(("#", "mailto:")):
                 continue
             resolved = (path.parent / target).resolve()
+            try:
+                resolved.relative_to((ROOT / "docs" / "web").resolve())
+            except ValueError:
+                continue
             if not resolved.is_file():
-                offenders.append(f"{path.relative_to(ROOT)} -> {target}")
+                offenders.append(f"{path.relative_to(ROOT)} -> {raw_target}")
 
-    assert not offenders, "Broken migration guide links found:\n" + "\n".join(offenders)
+    assert not offenders, "Broken public docs links found:\n" + "\n".join(offenders)
 
 
 def test_io_format_guides_do_not_start_sections_with_transition():

--- a/tests/docs/test_docs_warning_regressions.py
+++ b/tests/docs/test_docs_warning_regressions.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
+PUBLIC_DOC_SUFFIXES = {".ipynb", ".md", ".rst"}
 
 
 def _read_notebook(relative_path: str) -> dict:
@@ -18,6 +19,12 @@ def _cell_source(cell: dict) -> str:
     return str(source)
 
 
+def _iter_public_doc_texts():
+    for path in sorted((ROOT / "docs" / "web").rglob("*")):
+        if path.is_file() and path.suffix in PUBLIC_DOC_SUFFIXES:
+            yield path, path.read_text(encoding="utf-8")
+
+
 def test_interop_autosummary_uses_currentmodule_short_names():
     for rel in (
         "docs/web/en/reference/api/interop.rst",
@@ -25,6 +32,16 @@ def test_interop_autosummary_uses_currentmodule_short_names():
     ):
         text = (ROOT / rel).read_text()
         assert "gwexpy.interop." not in text
+
+
+def test_public_docs_do_not_reference_internal_api_mapping():
+    offenders = [
+        str(path.relative_to(ROOT))
+        for path, text in _iter_public_doc_texts()
+        if "API_MAPPING.md" in text
+    ]
+
+    assert not offenders, "Internal API_MAPPING.md references found:\n" + "\n".join(offenders)
 
 
 def test_io_format_guides_do_not_start_sections_with_transition():

--- a/tests/docs/test_tutorial_notebook_quality.py
+++ b/tests/docs/test_tutorial_notebook_quality.py
@@ -130,19 +130,6 @@ def test_tutorial_outputs_do_not_expose_local_paths_or_raw_warnings():
     assert not offenders, "Forbidden notebook output found:\n" + "\n".join(offenders)
 
 
-def test_public_tutorials_do_not_reference_internal_api_mapping():
-    notebooks = sorted(TUTORIAL_ROOT.glob("*/user_guide/tutorials/*.ipynb"))
-    offenders: list[str] = []
-
-    for path in notebooks:
-        nb = _read_notebook(path)
-        joined = "\n".join(_markdown_texts(nb))
-        if "API_MAPPING.md" in joined:
-            offenders.append(str(path.relative_to(ROOT)))
-
-    assert not offenders, "Internal API_MAPPING.md references found:\n" + "\n".join(offenders)
-
-
 @pytest.mark.parametrize(
     "relative_path",
     [

--- a/tests/docs/test_tutorial_notebook_quality.py
+++ b/tests/docs/test_tutorial_notebook_quality.py
@@ -130,6 +130,19 @@ def test_tutorial_outputs_do_not_expose_local_paths_or_raw_warnings():
     assert not offenders, "Forbidden notebook output found:\n" + "\n".join(offenders)
 
 
+def test_public_tutorials_do_not_reference_internal_api_mapping():
+    notebooks = sorted(TUTORIAL_ROOT.glob("*/user_guide/tutorials/*.ipynb"))
+    offenders: list[str] = []
+
+    for path in notebooks:
+        nb = _read_notebook(path)
+        joined = "\n".join(_markdown_texts(nb))
+        if "API_MAPPING.md" in joined:
+            offenders.append(str(path.relative_to(ROOT)))
+
+    assert not offenders, "Internal API_MAPPING.md references found:\n" + "\n".join(offenders)
+
+
 @pytest.mark.parametrize(
     "relative_path",
     [


### PR DESCRIPTION
## Summary

- Replace public tutorial references to the internal `API_MAPPING.md` with published migration, I/O, and interop guides.
- Update both English and Japanese markdown cells in the affected notebooks.
- Add a regression test that blocks future public tutorial references to `API_MAPPING.md`.

## Validation

- `pytest tests/docs/test_tutorial_notebook_quality.py -q`
- `rg -n "API_MAPPING\.md" docs/web gwexpy tests -g '!docs/_build/**'` now only finds the regression test text.