### PR TITLE
[codex] Isolate io-contract wheel build from local artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,6 +188,13 @@ gwexpy = [
   "py.typed",
 ]
 
+[tool.setuptools.exclude-package-data]
+"*" = [
+  "__pycache__/*",
+  "*.pyc",
+  "*.pyo",
+]
+
 [tool.setuptools.packages.find]
 include = ["gwexpy*"]
 exclude = ["typings*", "tests*", "docs*", "examples*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ gui = [
 
 # Development tools
 dev = [
+  "build",
   "ruff",
   "mypy",
   "pytest",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -18,6 +18,8 @@ attrs==26.1.0
     #   referencing
 bottleneck==1.6.0
     # via gwexpy (pyproject.toml)
+build==1.3.0
+    # via gwexpy (pyproject.toml)
 certifi==2026.2.25
     # via requests
 cffi==2.0.0

--- a/scripts/ci/run_gate.py
+++ b/scripts/ci/run_gate.py
@@ -15,11 +15,11 @@ import sys
 from pathlib import Path
 
 
-def run_cmd(cmd: list[str]) -> None:
+def run_cmd(cmd: list[str], *, cwd: Path | None = None) -> None:
     """Run one command and fail fast."""
     quoted = " ".join(cmd)
     print(f"\n$ {quoted}")
-    completed = subprocess.run(cmd, check=False)
+    completed = subprocess.run(cmd, check=False, cwd=cwd)
     if completed.returncode:
         raise SystemExit(completed.returncode)
 
@@ -33,6 +33,7 @@ def run_gate(gate: str, with_fixtures: bool) -> None:
     print(f"Platform: {platform.platform()}")
     print(f"Git root: {Path.cwd()}")
     print(f"with_fixtures: {with_fixtures}")
+    repo_root = Path.cwd().resolve()
 
     if gate == "pr-fast":
         run_cmd(["ruff", "check", "gwexpy", "tests"])
@@ -85,7 +86,17 @@ def run_gate(gate: str, with_fixtures: bool) -> None:
                 "tests/table/",
             ]
         )
-        run_cmd(["python", "-m", "build", "--wheel", "--no-isolation"])
+        run_cmd(
+            [
+                "python",
+                "-m",
+                "build",
+                str(repo_root),
+                "--wheel",
+                "--no-isolation",
+            ],
+            cwd=repo_root.parent,
+        )
         run_cmd(
             [
                 "python",

--- a/scripts/ci/run_gate.py
+++ b/scripts/ci/run_gate.py
@@ -29,6 +29,7 @@ def run_cmd(cmd: list[str], *, cwd: Path | None = None) -> None:
 def remove_generated_build_artifacts(repo_root: Path) -> None:
     """Remove generated artifacts that must not leak into wheel builds."""
     shutil.rmtree(repo_root / "build", ignore_errors=True)
+    shutil.rmtree(repo_root / "dist", ignore_errors=True)
     for pycache_dir in (repo_root / "gwexpy").rglob("__pycache__"):
         shutil.rmtree(pycache_dir, ignore_errors=True)
     for bytecode in (repo_root / "gwexpy").rglob("*.py[co]"):
@@ -36,14 +37,15 @@ def remove_generated_build_artifacts(repo_root: Path) -> None:
 
 
 def assert_wheel_has_no_bytecode(repo_root: Path) -> None:
-    """Fail if the latest wheel contains interpreter cache artifacts."""
-    wheels = sorted(
-        (repo_root / "dist").glob("*.whl"), key=lambda path: path.stat().st_mtime
-    )
+    """Fail if the built wheel contains interpreter cache artifacts."""
+    wheels = sorted((repo_root / "dist").glob("*.whl"))
     if not wheels:
         raise SystemExit("No wheel artifact found in dist/.")
+    if len(wheels) != 1:
+        wheel_list = "\n".join(f"  - {wheel.name}" for wheel in wheels)
+        raise SystemExit(f"Expected exactly one wheel artifact in dist/:\n{wheel_list}")
 
-    wheel = wheels[-1]
+    wheel = wheels[0]
     with zipfile.ZipFile(wheel) as archive:
         forbidden = [
             name
@@ -68,7 +70,6 @@ def run_gate(gate: str, with_fixtures: bool) -> None:
     print(f"Platform: {platform.platform()}")
     print(f"Git root: {Path.cwd()}")
     print(f"with_fixtures: {with_fixtures}")
-    repo_root = Path.cwd().resolve()
 
     if gate == "pr-fast":
         run_cmd(["ruff", "check", "gwexpy", "tests"])
@@ -106,6 +107,7 @@ def run_gate(gate: str, with_fixtures: bool) -> None:
         return
 
     if gate == "io-contract":
+        repo_root = Path.cwd().resolve()
         if with_fixtures:
             run_cmd(["python", "tests/fixtures/generate_fixtures.py"])
         run_cmd(

--- a/scripts/ci/run_gate.py
+++ b/scripts/ci/run_gate.py
@@ -10,8 +10,10 @@ from __future__ import annotations
 import argparse
 import os
 import platform
+import shutil
 import subprocess
 import sys
+import zipfile
 from pathlib import Path
 
 
@@ -22,6 +24,39 @@ def run_cmd(cmd: list[str], *, cwd: Path | None = None) -> None:
     completed = subprocess.run(cmd, check=False, cwd=cwd)
     if completed.returncode:
         raise SystemExit(completed.returncode)
+
+
+def remove_generated_build_artifacts(repo_root: Path) -> None:
+    """Remove generated artifacts that must not leak into wheel builds."""
+    shutil.rmtree(repo_root / "build", ignore_errors=True)
+    for pycache_dir in (repo_root / "gwexpy").rglob("__pycache__"):
+        shutil.rmtree(pycache_dir, ignore_errors=True)
+    for bytecode in (repo_root / "gwexpy").rglob("*.py[co]"):
+        bytecode.unlink(missing_ok=True)
+
+
+def assert_wheel_has_no_bytecode(repo_root: Path) -> None:
+    """Fail if the latest wheel contains interpreter cache artifacts."""
+    wheels = sorted(
+        (repo_root / "dist").glob("*.whl"), key=lambda path: path.stat().st_mtime
+    )
+    if not wheels:
+        raise SystemExit("No wheel artifact found in dist/.")
+
+    wheel = wheels[-1]
+    with zipfile.ZipFile(wheel) as archive:
+        forbidden = [
+            name
+            for name in archive.namelist()
+            if "__pycache__/" in name or name.endswith((".pyc", ".pyo"))
+        ]
+
+    if forbidden:
+        preview = "\n".join(f"  - {name}" for name in forbidden[:20])
+        extra = (
+            "" if len(forbidden) <= 20 else f"\n  ... and {len(forbidden) - 20} more"
+        )
+        raise SystemExit(f"Wheel contains bytecode/cache artifacts:\n{preview}{extra}")
 
 
 def run_gate(gate: str, with_fixtures: bool) -> None:
@@ -86,6 +121,7 @@ def run_gate(gate: str, with_fixtures: bool) -> None:
                 "tests/table/",
             ]
         )
+        remove_generated_build_artifacts(repo_root)
         run_cmd(
             [
                 "python",
@@ -97,11 +133,12 @@ def run_gate(gate: str, with_fixtures: bool) -> None:
             ],
             cwd=repo_root.parent,
         )
+        assert_wheel_has_no_bytecode(repo_root)
         run_cmd(
             [
                 "python",
                 "-c",
-                "import gwexpy\nprint(f\"gwexpy version: {gwexpy.__version__}\")",
+                'import gwexpy\nprint(f"gwexpy version: {gwexpy.__version__}")',
             ],
         )
         return
@@ -174,15 +211,18 @@ def run_gate(gate: str, with_fixtures: bool) -> None:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("gate", choices=[
-        "pr-fast",
-        "io-contract",
-        "io-optional",
-        "io-network-backend",
-        "docs-notebook",
-        "io-zarr",
-        "interop-contract",
-    ])
+    parser.add_argument(
+        "gate",
+        choices=[
+            "pr-fast",
+            "io-contract",
+            "io-optional",
+            "io-network-backend",
+            "docs-notebook",
+            "io-zarr",
+            "interop-contract",
+        ],
+    )
     parser.add_argument(
         "--fixtures",
         default=True,


### PR DESCRIPTION
## Summary

- Run the `io-contract` wheel build from the repository parent while passing the source tree explicitly, so an ignored repository-local `build/` directory cannot shadow PyPA `build`.
- Add `build` to the development extra and dev requirements because the local gate invokes `python -m build`.

## Validation

- `pytest tests/io/test_io_docs_contract_sync.py tests/interop/test_interop_docs_contract_sync.py -q`
- `python -m py_compile scripts/ci/run_gate.py`
- `python scripts/ci/run_gate.py io-contract --no-fixtures`