### PR TITLE
[codex] Reject oversized VectorField ndarray inputs

### DIFF
--- a/gwexpy/fields/vector.py
+++ b/gwexpy/fields/vector.py
@@ -60,7 +60,12 @@ class VectorField(FieldDict):
             if arr.ndim != 5:
                 raise ValueError(f"VectorField expected 5D array, got {arr.ndim}D")
             n_comp = arr.shape[-1]
-            labels = ["x", "y", "z"][:n_comp] or [str(i) for i in range(n_comp)]
+            if n_comp not in (1, 2, 3):
+                raise ValueError(
+                    "VectorField ndarray input supports 1, 2, or 3 components; "
+                    f"got {n_comp}"
+                )
+            labels = ["x", "y", "z"][:n_comp]
 
             # Use dictionary comprehension to create components
             # We need valid ScalarField objects. For simplicity, we create them

--- a/gwexpy/fields/vector.py
+++ b/gwexpy/fields/vector.py
@@ -1,4 +1,5 @@
 """Vector-valued field implementation using ScalarField components."""
+
 from __future__ import annotations
 
 from typing import Literal
@@ -62,7 +63,8 @@ class VectorField(FieldDict):
             n_comp = arr.shape[-1]
             if n_comp not in (1, 2, 3):
                 raise ValueError(
-                    "VectorField ndarray input supports 1, 2, or 3 components; "
+                    "VectorField ndarray input requires a component axis with "
+                    "1, 2, or 3 entries; "
                     f"got {n_comp}"
                 )
             labels = ["x", "y", "z"][:n_comp]

--- a/tests/fields/test_array_init.py
+++ b/tests/fields/test_array_init.py
@@ -25,6 +25,11 @@ def test_vectorfield_array_init():
     with pytest.raises(ValueError, match="expected 5D array"):
         VectorField(np.ones((2, 3, 4, 5)))
 
+
+def test_vectorfield_array_init_rejects_more_than_three_components():
+    with pytest.raises(ValueError, match="supports 1, 2, or 3 components"):
+        VectorField(np.ones((2, 3, 4, 5, 4)))
+
 def test_tensorfield_array_init():
     # 6D array initialization
     arr = np.ones((2, 3, 4, 5, 3, 3))

--- a/tests/fields/test_array_init.py
+++ b/tests/fields/test_array_init.py
@@ -11,24 +11,26 @@ def test_vectorfield_array_init():
     v = VectorField(arr)
 
     # Check components created successfully (x, y, z)
-    assert set(v.keys()) == {'x', 'y', 'z'}
-    assert v['x'].shape == (2, 3, 4, 5)
+    assert set(v.keys()) == {"x", "y", "z"}
+    assert v["x"].shape == (2, 3, 4, 5)
 
     # Value check
-    assert np.allclose(v['y'].value, 1.0)
+    assert np.allclose(v["y"].value, 1.0)
 
     # Dictionary initialization should still work (backward compatibility)
-    v2 = VectorField({'x': ScalarField(np.ones((2, 3, 4, 5)))})
-    assert set(v2.keys()) == {'x'}
+    v2 = VectorField({"x": ScalarField(np.ones((2, 3, 4, 5)))})
+    assert set(v2.keys()) == {"x"}
 
     # Invalid dimension -> ValueError
     with pytest.raises(ValueError, match="expected 5D array"):
         VectorField(np.ones((2, 3, 4, 5)))
 
 
-def test_vectorfield_array_init_rejects_more_than_three_components():
-    with pytest.raises(ValueError, match="supports 1, 2, or 3 components"):
-        VectorField(np.ones((2, 3, 4, 5, 4)))
+@pytest.mark.parametrize("n_comp", [0, 4])
+def test_vectorfield_array_init_rejects_invalid_component_count(n_comp):
+    with pytest.raises(ValueError, match=rf"1, 2, or 3 entries; got {n_comp}"):
+        VectorField(np.ones((2, 3, 4, 5, n_comp)))
+
 
 def test_tensorfield_array_init():
     # 6D array initialization


### PR DESCRIPTION
## Summary

- Reject `VectorField` ndarray construction when the component axis has more than 3 entries.
- Prevent silent truncation where 4+ component arrays were reduced to only `x`, `y`, and `z`.
- Add a regression test for oversized component arrays.

## Validation

- `pytest -q tests/fields/test_array_init.py tests/fields/test_vectorfield.py` -> `19 passed`
- `pytest -q tests/fields tests/types` -> `847 passed, 6 skipped`
- `pytest -q tests/types/test_series_matrix_structure.py tests/types/test_series_matrix_indexing.py tests/types/test_series_matrix_math.py tests/types/test_seriesmatrix_fixes.py tests/types/test_seriesmatrix_normalize_input.py tests/types/test_series_matrix_validation_mixin.py` -> `208 passed`
- `pytest -q tests/types/test_types_array2d_axes.py tests/types/test_types_array3d_plane.py tests/types/test_types_array4d.py tests/types/test_types_plane2d.py tests/types/test_gwexpy_array.py` -> `51 passed`
- `pytest -q tests/fields/test_scalarfield_slice.py tests/fields/test_scalarfield_metadata.py tests/fields/test_scalarfield_fft_time.py tests/fields/test_scalarfield_fft_space.py` -> `68 passed`
- `pytest -q tests/timeseries/test_matrix_analysis.py tests/timeseries/test_matrix_spectral.py tests/timeseries/test_timeseries_matrix_slice.py tests/timeseries/test_pipeline.py tests/timeseries/test_preprocess_standardize_whiten.py` -> `226 passed, 1 skipped`
- `ruff check gwexpy/fields/vector.py tests/fields/test_array_init.py` -> passed