### PR TITLE
[codex] Clean up Spectrogram metadata propagation

### DIFF
--- a/gwexpy/spectrogram/spectrogram.py
+++ b/gwexpy/spectrogram/spectrogram.py
@@ -138,7 +138,11 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
 
     @staticmethod
     def _axis_step_value(value: Any, unit: str) -> float:
-        """Return an axis spacing as a float, preserving unitless GWpy fallback."""
+        """Return an axis spacing as a float.
+
+        GWpy normally exposes Spectrogram ``dt``/``df`` as Quantities, but the
+        scalar fallback keeps older objects and subclasses compatible.
+        """
         if hasattr(value, "to"):
             return float(value.to(unit).value)
         return float(value)

--- a/gwexpy/spectrogram/spectrogram.py
+++ b/gwexpy/spectrogram/spectrogram.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, SupportsIndex
+from typing import TYPE_CHECKING, Any, Self, SupportsIndex
 
 import numpy as np
 from astropy import units as u
@@ -118,8 +118,15 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
         times: Any,
         frequencies: Any,
         unit: Any,
-    ) -> Spectrogram:
-        """Build a Spectrogram from explicit axes without redundant x0 metadata."""
+    ) -> Self:
+        """Build a Spectrogram from explicit axes without redundant x0 metadata.
+
+        GWpy derives Spectrogram epoch/x0 from explicit ``times``. Passing
+        ``epoch`` at the same time is redundant and can trigger ignored-x0
+        warnings. The series-list conversion methods keep passing epoch because
+        their one-dimensional TimeSeries/FrequencySeries constructors use it as
+        part of the output series metadata.
+        """
         return self.__class__(
             data,
             times=times,
@@ -128,6 +135,13 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
             name=self.name,
             channel=self.channel,
         )
+
+    @staticmethod
+    def _axis_step_value(value: Any, unit: str) -> float:
+        """Return an axis spacing as a float, preserving unitless GWpy fallback."""
+        if hasattr(value, "to"):
+            return float(value.to(unit).value)
+        return float(value)
 
     def bootstrap(
         self,
@@ -530,9 +544,8 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
 
         # Frequency rebinning
         if df is not None:
-            if hasattr(df, "to"):
-                df = df.to("Hz").value
-            orig_df = self.df.to("Hz").value
+            df = self._axis_step_value(df, "Hz")
+            orig_df = self._axis_step_value(self.df, "Hz")
             bin_size = int(round(df / orig_df))
             if bin_size > 1:
                 nt, nf = data.shape
@@ -548,9 +561,8 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
 
         # Time rebinning
         if dt is not None:
-            if hasattr(dt, "to"):
-                dt = dt.to("s").value
-            orig_dt = self.dt.to("s").value
+            dt = self._axis_step_value(dt, "s")
+            orig_dt = self._axis_step_value(self.dt, "s")
             bin_size = int(round(dt / orig_dt))
             if bin_size > 1:
                 nt, nf = data.shape

--- a/gwexpy/spectrogram/spectrogram.py
+++ b/gwexpy/spectrogram/spectrogram.py
@@ -111,6 +111,24 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
 
         return spectrogram_reduce_args(self)
 
+    def _new_with_explicit_axes(
+        self,
+        data: Any,
+        *,
+        times: Any,
+        frequencies: Any,
+        unit: Any,
+    ) -> Spectrogram:
+        """Build a Spectrogram from explicit axes without redundant x0 metadata."""
+        return self.__class__(
+            data,
+            times=times,
+            frequencies=frequencies,
+            unit=unit,
+            name=self.name,
+            channel=self.channel,
+        )
+
     def bootstrap(
         self,
         n_boot=1000,
@@ -514,7 +532,7 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
         if df is not None:
             if hasattr(df, "to"):
                 df = df.to("Hz").value
-            orig_df = self.df.to("Hz").value if hasattr(self.df, "to") else self.df
+            orig_df = self.df.to("Hz").value
             bin_size = int(round(df / orig_df))
             if bin_size > 1:
                 nt, nf = data.shape
@@ -532,7 +550,7 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
         if dt is not None:
             if hasattr(dt, "to"):
                 dt = dt.to("s").value
-            orig_dt = self.dt.to("s").value if hasattr(self.dt, "to") else self.dt
+            orig_dt = self.dt.to("s").value
             bin_size = int(round(dt / orig_dt))
             if bin_size > 1:
                 nt, nf = data.shape
@@ -546,14 +564,11 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
                     times[: nt_new * bin_size].reshape(nt_new, bin_size).mean(axis=1)
                 )
 
-        return self.__class__(
+        return self._new_with_explicit_axes(
             data,
             times=times,
             frequencies=freqs,
             unit=self.unit,
-            name=self.name,
-            channel=self.channel,
-            epoch=self.epoch,
         )
 
     def imshow(self, **kwargs):
@@ -732,14 +747,11 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
             result = data / ref[np.newaxis, :]
             result[~np.isfinite(result)] = np.nan
 
-        return self.__class__(
+        return self._new_with_explicit_axes(
             result,
             times=self.times,
             frequencies=self.frequencies,
             unit=u.dimensionless_unscaled,
-            name=self.name,
-            channel=self.channel,
-            epoch=self.epoch,
         )
 
     def clean(
@@ -834,14 +846,11 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
                 "Choose from 'threshold', 'rolling_median', 'line_removal', 'combined'."
             )
 
-        result = self.__class__(
+        result = self._new_with_explicit_axes(
             cleaned,
             times=self.times,
             frequencies=self.frequencies,
             unit=self.unit,
-            name=self.name,
-            channel=self.channel,
-            epoch=self.epoch,
         )
 
         if return_mask:

--- a/gwexpy/spectrogram/spectrogram.py
+++ b/gwexpy/spectrogram/spectrogram.py
@@ -522,7 +522,7 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
 
     def rebin(
         self, dt: float | u.Quantity | None = None, df: float | u.Quantity | None = None
-    ) -> Spectrogram:
+    ) -> Self:
         """Rebin the spectrogram in time and/or frequency.
 
         Rebinning averages only complete bins. If the time or frequency axis
@@ -538,7 +538,7 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
 
         Returns
         -------
-        Spectrogram
+        Self
             The rebinned spectrogram.
 
         """
@@ -691,7 +691,7 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
         reference: Any | None = None,
         *,
         percentile: float = 50.0,
-    ) -> Spectrogram:
+    ) -> Self:
         """Normalize the spectrogram along the time axis.
 
         Parameters
@@ -720,7 +720,7 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
 
         Returns
         -------
-        Spectrogram
+        Self
             Normalized spectrogram. Unit is set to dimensionless for ratio
             methods.
 
@@ -780,7 +780,7 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
         persistence_threshold: float = 0.8,
         amplitude_threshold: float = 3.0,
         return_mask: bool = False,
-    ) -> Spectrogram | tuple[Spectrogram, np.ndarray]:
+    ) -> Self | tuple[Self, np.ndarray]:
         """Clean the spectrogram by removing artifacts.
 
         Parameters
@@ -813,7 +813,7 @@ class Spectrogram(PlotMixin, PhaseMethodsMixin, InteropMixin, BaseSpectrogram):
 
         Returns
         -------
-        Spectrogram
+        Self
             Cleaned spectrogram.
         mask : ndarray, optional
             Boolean mask where True = pixel was cleaned. Only returned when

--- a/tests/spectrogram/test_spectrogram_metadata_propagation.py
+++ b/tests/spectrogram/test_spectrogram_metadata_propagation.py
@@ -53,6 +53,32 @@ def test_rebin_same_grid_preserves_metadata_without_ignored_x0_warning(
     assert result.unit == explicit_axis_spectrogram.unit
 
 
+def test_rebin_actual_bins_updates_axes_without_ignored_x0_warning(
+    explicit_axis_spectrogram: Spectrogram,
+) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = explicit_axis_spectrogram.rebin(dt=2 * u.s, df=2 * u.Hz)
+
+    _assert_no_ignored_x0_warning(caught)
+    assert result.shape == (2, 2)
+    np.testing.assert_allclose(result.value, [[3.5, 5.5], [11.5, 13.5]])
+    np.testing.assert_allclose(result.times.to_value(u.s), [0.5, 2.5])
+    np.testing.assert_allclose(result.frequencies.to_value(u.Hz), [10.5, 12.5])
+    assert result.dt == 2 * u.s
+    assert result.df == 2 * u.Hz
+    assert result.name == explicit_axis_spectrogram.name
+    assert result.channel == explicit_axis_spectrogram.channel
+    assert result.epoch.gps == pytest.approx(0.5)
+    assert result.unit == explicit_axis_spectrogram.unit
+
+
+def test_rebin_axis_step_value_accepts_unitless_and_quantity_spacing() -> None:
+    assert Spectrogram._axis_step_value(2.0, "Hz") == 2.0
+    assert Spectrogram._axis_step_value(2 * u.Hz, "Hz") == 2.0
+    assert Spectrogram._axis_step_value(2000 * u.ms, "s") == 2.0
+
+
 def test_normalize_preserves_metadata_without_ignored_x0_warning(
     explicit_axis_spectrogram: Spectrogram,
 ) -> None:

--- a/tests/spectrogram/test_spectrogram_metadata_propagation.py
+++ b/tests/spectrogram/test_spectrogram_metadata_propagation.py
@@ -1,0 +1,80 @@
+"""Regression tests for Spectrogram metadata propagation."""
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+from astropy import units as u
+
+from gwexpy.spectrogram import Spectrogram
+
+
+def _assert_no_ignored_x0_warning(caught: list[warnings.WarningMessage]) -> None:
+    messages = [str(warning.message) for warning in caught]
+    assert not any("xindex was given" in message for message in messages), messages
+
+
+def _assert_common_metadata(result: Spectrogram, source: Spectrogram) -> None:
+    np.testing.assert_allclose(result.times.to_value(u.s), source.times.to_value(u.s))
+    np.testing.assert_allclose(
+        result.frequencies.to_value(u.Hz),
+        source.frequencies.to_value(u.Hz),
+    )
+    assert result.dt == source.dt
+    assert result.df == source.df
+    assert result.name == source.name
+    assert result.channel == source.channel
+    assert result.epoch == source.epoch
+
+
+@pytest.fixture
+def explicit_axis_spectrogram() -> Spectrogram:
+    data = np.arange(20.0).reshape(5, 4) + 1.0
+    return Spectrogram(
+        data,
+        times=np.arange(5) * u.s,
+        frequencies=(10 + np.arange(4)) * u.Hz,
+        unit=u.V,
+        name="metadata_source",
+        channel="H1:TEST",
+    )
+
+
+def test_rebin_same_grid_preserves_metadata_without_ignored_x0_warning(
+    explicit_axis_spectrogram: Spectrogram,
+) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = explicit_axis_spectrogram.rebin(dt=1 * u.s, df=1 * u.Hz)
+
+    _assert_no_ignored_x0_warning(caught)
+    _assert_common_metadata(result, explicit_axis_spectrogram)
+    assert result.unit == explicit_axis_spectrogram.unit
+
+
+def test_normalize_preserves_metadata_without_ignored_x0_warning(
+    explicit_axis_spectrogram: Spectrogram,
+) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = explicit_axis_spectrogram.normalize(method="median")
+
+    _assert_no_ignored_x0_warning(caught)
+    _assert_common_metadata(result, explicit_axis_spectrogram)
+    assert result.unit == u.dimensionless_unscaled
+
+
+def test_clean_preserves_metadata_without_ignored_x0_warning(
+    explicit_axis_spectrogram: Spectrogram,
+) -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = explicit_axis_spectrogram.clean(
+            method="rolling_median",
+            window_size=3,
+        )
+
+    _assert_no_ignored_x0_warning(caught)
+    _assert_common_metadata(result, explicit_axis_spectrogram)
+    assert result.unit == explicit_axis_spectrogram.unit


### PR DESCRIPTION
## Summary

- Add regression coverage for `Spectrogram.rebin()`, `normalize()`, and `clean()` metadata propagation with explicit time/frequency axes.
- Stop passing redundant `epoch=` when reconstructing Spectrograms from explicit `times=`/`frequencies=`, removing the GWpy `xindex was given ..., x0 will be ignored` warning for these methods.
- Remove dead non-Quantity fallback branches for `self.dt` and `self.df` in `rebin()`; tests now pin Quantity-backed `dt`/`df` behavior.

## Why

Follow-up for #253. These methods were reconstructing a Spectrogram with explicit axes and `epoch=self.epoch`. GWpy ignores `epoch`/`x0` when explicit `times`/`xindex` is provided, so the extra argument produced avoidable warnings without preserving additional metadata.

## Validation

- `pytest -q tests/spectrogram/test_spectrogram_metadata_propagation.py tests/spectrogram/test_spectrogram_core.py tests/spectrogram/test_normalize.py tests/spectrogram/test_cleaning.py` -> 83 passed
- `pytest -q tests/spectrogram` -> 370 passed, 7 skipped, 1 xfailed
- `ruff check gwexpy/spectrogram/spectrogram.py tests/spectrogram/test_spectrogram_metadata_propagation.py` -> passed
- `mypy gwexpy/spectrogram/spectrogram.py --ignore-missing-imports` -> passed

Closes #253