### PR TITLE
docs: add MetaData/MetaDataMatrix audit and work plan for issue #243

### DIFF
--- a/docs/developers/plans/2026-04-25-metadata-audit-plan.md
+++ b/docs/developers/plans/2026-04-25-metadata-audit-plan.md
@@ -1,7 +1,7 @@
 # MetaData / MetaDataMatrix 監査・修正計画
 
-**Issue:** #243 — Audit MetaData and MetaDataMatrix unit propagation and shape semantics  
-**作成日:** 2026-04-25  
+**Issue:** #243 — Audit MetaData and MetaDataMatrix unit propagation and shape semantics
+**作成日:** 2026-04-25
 **対象ブランチ:** `claude/plan-metadata-work-nDtXw`
 
 ---
@@ -31,9 +31,9 @@ def names(self, value):
         value = value.reshape(self.shape)  # ← サイレントリシェイプ！
 ```
 
-`units.setter`、`channels.setter` も同様。  
-**問題:** サイズが合わない配列を渡しても `reshape` が例外を吸収し、要素の対応がずれたまま設定される可能性がある。  
-**修正方針:** サイズが一致しない場合は `ValueError` を上げる。  
+`units.setter`、`channels.setter` も同様。
+**問題:** サイズが合わない配列を渡しても `reshape` が例外を吸収し、要素の対応がずれたまま設定される可能性がある。
+**修正方針:** サイズが一致しない場合は `ValueError` を上げる。
 サイズが一致する場合のみ reshape を許可する（フラット配列 → 行列への変換は有用なため残す）。
 
 ### 2-B. floor_divide の unit 意味論が未ドキュメント
@@ -43,22 +43,22 @@ def names(self, value):
 _UFUNC_MULT_DIV = {np.multiply, np.divide, np.floor_divide}
 ```
 
-`floor_divide` は整数割り算だが、unit は `lhs_unit / rhs_unit` として伝播される。  
-これは物理的に正しい（次元は同じ）が、docstring に記載がない。  
+`floor_divide` は整数割り算だが、unit は `lhs_unit / rhs_unit` として伝播される。
+これは物理的に正しい（次元は同じ）が、docstring に記載がない。
 **修正方針:** `_UFUNC_MULT_DIV` の意味論を docstring に追記。コード変更は不要。
 
 ### 2-C. CSV ラウンドトリップのテストが存在しない
 
-`MetaDataMatrix.write()` / `read()` および `MetaDataDict.write()` / `read()` のテストがない。  
+`MetaDataMatrix.write()` / `read()` および `MetaDataDict.write()` / `read()` のテストがない。
 実装は `MetaData` コンストラクタが string unit を受け付けるため動作するはずだが、
 `MetaDataDict.to_dataframe()` が astropy `Unit` オブジェクトをそのまま DataFrame に入れるため、
-`to_csv()` 時に `str(unit)` が呼ばれる挙動に依存している。  
+`to_csv()` 時に `str(unit)` が呼ばれる挙動に依存している。
 **修正方針:** `to_dataframe()` 内で `unit` を明示的に `str()` 変換してから格納し、round-trip テストを追加。
 
 ### 2-D. MetaDataDict には names/units/channels セッターが存在しない
 
 現在は getter のみ。Issue の "setters" チェックは主に `MetaDataMatrix` を指しているが、
-`MetaDataDict` についても同様のセッターが有用である可能性を確認する。  
+`MetaDataDict` についても同様のセッターが有用である可能性を確認する。
 **修正方針:** 今回は `MetaDataMatrix` セッターの修正に集中。`MetaDataDict` へのセッター追加は scope 外とし、
 issue コメントで明示する。
 
@@ -72,8 +72,8 @@ def as_meta(self, obj):
     return MetaData(name=self.name, channel=self.channel, unit=get_unit(obj))
 ```
 
-number や Quantity を渡した時、channel は `self.channel` を引き継ぐ。  
-これは現状テスト済みの挙動だが、仕様として docstring に明記されていない。  
+number や Quantity を渡した時、channel は `self.channel` を引き継ぐ。
+これは現状テスト済みの挙動だが、仕様として docstring に明記されていない。
 **修正方針:** docstring に "name and channel are inherited from self" と明記。
 
 ---

--- a/docs/developers/plans/2026-04-25-metadata-audit-plan.md
+++ b/docs/developers/plans/2026-04-25-metadata-audit-plan.md
@@ -1,0 +1,268 @@
+# MetaData / MetaDataMatrix 監査・修正計画
+
+**Issue:** #243 — Audit MetaData and MetaDataMatrix unit propagation and shape semantics  
+**作成日:** 2026-04-25  
+**対象ブランチ:** `claude/plan-metadata-work-nDtXw`
+
+---
+
+## 1. Objectives & Goals
+
+Issue #243 のスコープに沿い、以下を達成する:
+
+1. `MetaData` / `MetaDataMatrix` / `MetaDataDict` における **unit propagation** の正確性を確認・修正する。
+2. セッターの **shape mismatch** をサイレントに隠す挙動を排除し、明示的な `ValueError` を発生させる。
+3. **DataFrame/CSV ラウンドトリップ** で name/channel/unit/shape が完全に保持されることをテストで保証する。
+4. **厳格モード vs 柔軟モード** の unit チェック方針を docstring に明示する。
+
+---
+
+## 2. 監査結果サマリー（現状の問題点）
+
+### 2-A. MetaDataMatrix セッターがシェイプ不一致を隠す（バグ）
+
+`metadata.py:621-628` / `639-646` / `656-659`:
+
+```python
+@names.setter
+def names(self, value):
+    value = np.asarray(value)
+    if value.shape != self.shape:
+        value = value.reshape(self.shape)  # ← サイレントリシェイプ！
+```
+
+`units.setter`、`channels.setter` も同様。  
+**問題:** サイズが合わない配列を渡しても `reshape` が例外を吸収し、要素の対応がずれたまま設定される可能性がある。  
+**修正方針:** サイズが一致しない場合は `ValueError` を上げる。  
+サイズが一致する場合のみ reshape を許可する（フラット配列 → 行列への変換は有用なため残す）。
+
+### 2-B. floor_divide の unit 意味論が未ドキュメント
+
+`metadata.py:38`:
+```python
+_UFUNC_MULT_DIV = {np.multiply, np.divide, np.floor_divide}
+```
+
+`floor_divide` は整数割り算だが、unit は `lhs_unit / rhs_unit` として伝播される。  
+これは物理的に正しい（次元は同じ）が、docstring に記載がない。  
+**修正方針:** `_UFUNC_MULT_DIV` の意味論を docstring に追記。コード変更は不要。
+
+### 2-C. CSV ラウンドトリップのテストが存在しない
+
+`MetaDataMatrix.write()` / `read()` および `MetaDataDict.write()` / `read()` のテストがない。  
+実装は `MetaData` コンストラクタが string unit を受け付けるため動作するはずだが、
+`MetaDataDict.to_dataframe()` が astropy `Unit` オブジェクトをそのまま DataFrame に入れるため、
+`to_csv()` 時に `str(unit)` が呼ばれる挙動に依存している。  
+**修正方針:** `to_dataframe()` 内で `unit` を明示的に `str()` 変換してから格納し、round-trip テストを追加。
+
+### 2-D. MetaDataDict には names/units/channels セッターが存在しない
+
+現在は getter のみ。Issue の "setters" チェックは主に `MetaDataMatrix` を指しているが、
+`MetaDataDict` についても同様のセッターが有用である可能性を確認する。  
+**修正方針:** 今回は `MetaDataMatrix` セッターの修正に集中。`MetaDataDict` へのセッター追加は scope 外とし、
+issue コメントで明示する。
+
+### 2-E. `as_meta()` が `MetaData` 以外の入力でチャンネルを常に `self.channel` から引き継ぐ
+
+`metadata.py:165-173`:
+```python
+def as_meta(self, obj):
+    if isinstance(obj, MetaData):
+        return obj
+    return MetaData(name=self.name, channel=self.channel, unit=get_unit(obj))
+```
+
+number や Quantity を渡した時、channel は `self.channel` を引き継ぐ。  
+これは現状テスト済みの挙動だが、仕様として docstring に明記されていない。  
+**修正方針:** docstring に "name and channel are inherited from self" と明記。
+
+---
+
+## 3. 詳細ロードマップ
+
+### Phase 1: MetaDataMatrix セッター修正（`metadata.py`）
+
+**対象:** `metadata.py:619-659`
+
+変更内容:
+```python
+@names.setter
+def names(self, value):
+    value = np.asarray(value)
+    if value.size != self.size:
+        raise ValueError(
+            f"Cannot set names: got {value.size} values, expected {self.size} "
+            f"(shape {self.shape})"
+        )
+    if value.shape != self.shape:
+        value = value.reshape(self.shape)
+    for m, name in zip(self.reshape(-1), value.reshape(-1)):
+        m.name = name
+```
+
+`units.setter` と `channels.setter` も同様に修正。
+
+### Phase 2: MetaDataDict.to_dataframe() で unit を明示文字列化
+
+**対象:** `metadata.py:410-415`
+
+```python
+def to_dataframe(self):
+    if pd is None:
+        raise ImportError("pandas is required for to_dataframe()")
+    data = [
+        {**{k: (str(v) if k == "unit" else v) for k, v in entry.items()}, "key": key}
+        for key, entry in self.items()
+    ]
+    df = pd.DataFrame(data).set_index("key")
+    return df
+```
+
+### Phase 3: テスト追加
+
+**ファイル:** `tests/types/test_metadata_fixes.py` または新規 `tests/types/test_metadata_roundtrip.py`
+
+追加するテスト:
+
+#### MetaDataMatrix セッター shape mismatch
+```python
+def test_metadatamatrix_names_setter_size_mismatch_raises():
+    mat = MetaDataMatrix(shape=(2, 3))
+    with pytest.raises(ValueError, match="names"):
+        mat.names = np.array(["a", "b"])  # size 2 != 6
+
+def test_metadatamatrix_units_setter_size_mismatch_raises():
+    mat = MetaDataMatrix(shape=(2, 3))
+    with pytest.raises(ValueError, match="units"):
+        mat.units = np.array([u.m, u.s])  # size 2 != 6
+
+def test_metadatamatrix_channels_setter_size_mismatch_raises():
+    mat = MetaDataMatrix(shape=(2, 3))
+    with pytest.raises(ValueError, match="channels"):
+        mat.channels = np.array(["H1:X"])  # size 1 != 6
+```
+
+#### MetaDataMatrix セッター flat → matrix reshape (許可ケース)
+```python
+def test_metadatamatrix_names_setter_flat_array_reshapes():
+    mat = MetaDataMatrix(shape=(2, 3))
+    mat.names = np.array(["a", "b", "c", "d", "e", "f"])
+    assert mat.names[0, 0] == "a"
+    assert mat.names[1, 2] == "f"
+```
+
+#### MetaDataMatrix CSV ラウンドトリップ
+```python
+def test_metadatamatrix_csv_roundtrip(tmp_path):
+    mat = MetaDataMatrix([
+        [MetaData(name="a", unit=u.m, channel="H1:A"),
+         MetaData(name="b", unit=u.s, channel="L1:B")],
+        [MetaData(name="c", unit=u.Hz, channel="H1:C"),
+         MetaData(name="d", unit=u.dimensionless_unscaled, channel="")],
+    ])
+    path = tmp_path / "meta.csv"
+    mat.write(str(path))
+    mat2 = MetaDataMatrix.read(str(path))
+    assert mat2.shape == (2, 2)
+    assert mat2[0, 0].name == "a"
+    assert mat2[0, 0].unit.is_equivalent(u.m)
+    assert mat2[1, 1].name == "d"
+```
+
+#### MetaDataDict CSV ラウンドトリップ
+```python
+def test_metadatadict_csv_roundtrip(tmp_path):
+    mdd = MetaDataDict({
+        "x": MetaData(name="x", unit=u.m, channel="H1:X"),
+        "y": MetaData(name="y", unit=u.s, channel="L1:Y"),
+    })
+    path = tmp_path / "meta.csv"
+    mdd.write(str(path))
+    mdd2 = MetaDataDict.read(str(path))
+    assert list(mdd2.keys()) == ["x", "y"]
+    assert mdd2["x"].unit.is_equivalent(u.m)
+    assert mdd2["y"].name == "y"
+```
+
+#### floor_divide unit 伝播
+```python
+def test_metadata_floor_divide_unit():
+    m1 = MetaData(name="a", unit=u.m)
+    m2 = MetaData(name="b", unit=u.s)
+    out = np.floor_divide(m1, m2)
+    assert isinstance(out, MetaData)
+    assert out.unit.is_equivalent(u.m / u.s)
+```
+
+#### MetaDataMatrix ufunc shape mismatch
+```python
+def test_metadatamatrix_ufunc_shape_mismatch_raises():
+    m1 = MetaDataMatrix(shape=(2, 2))
+    m2 = MetaDataMatrix(shape=(2, 3))
+    with pytest.raises(ValueError, match="[Ss]hape"):
+        np.multiply(m1, m2)
+```
+
+### Phase 4: docstring 更新
+
+**対象:** `metadata.py` の以下の docstring:
+
+1. `MetaData.__array_ufunc__` — 厳格 vs 柔軟の単位チェック方針を追記
+2. `MetaDataMatrix.names.setter` / `units.setter` / `channels.setter` — サイズ一致要件を明記
+3. `MetaData.as_meta()` — name/channel 引き継ぎ仕様を明記
+4. `_UFUNC_MULT_DIV` コメント — `floor_divide` 含む旨と unit 意味論を注記
+
+---
+
+## 4. テスト・検証計画
+
+### 実行コマンド
+```bash
+conda run -n gwexpy pytest tests/types/test_metadata_ufuncs.py tests/types/test_metadata_fixes.py -v
+conda run -n gwexpy ruff check gwexpy/types/metadata.py tests/types/
+conda run -n gwexpy mypy gwexpy/types/metadata.py
+```
+
+### 確認項目チェックリスト（Issue #243 対照）
+
+| チェック項目 | 実装状況 | 対応 |
+|---|---|---|
+| ufunc unit propagation (unary: abs, neg, sqrt, square, transcendental) | ✅ 実装済み | テスト強化のみ |
+| ufunc unit propagation (binary: add, sub requires compatible) | ✅ 実装済み | テスト確認のみ |
+| ufunc unit propagation (multiply, divide, floor_divide) | ✅ 実装済み | floor_divide テスト追加 |
+| 互換性なし unit で add/sub は UnitConversionError | ✅ 実装済み | テスト確認のみ |
+| names/units/channels セッターが shape mismatch を隠さない | ❌ 修正必要 | Phase 1 で修正 |
+| shape mismatch エラーが明示的 | ❌ 修正必要 | Phase 1 で修正 |
+| DataFrame/CSV round-trip (name, channel, unit, shape) | ⚠️ 実装はあるがテストなし | Phase 2-3 で対応 |
+| docs: strict vs flexible unit behavior | ❌ 未記載 | Phase 4 で追記 |
+
+---
+
+## 5. モデル・スキル・工数見積もり
+
+| 項目 | 詳細 |
+|---|---|
+| 推奨スキル | `setup_plan` → `fix_errors` → `run_tests` → `finalize_work` |
+| 推奨モデル | claude-sonnet-4-6 (コード変更は小規模で集中的) |
+| 工数見積もり | Phase 1-2: ~30分 / Phase 3: ~45分 / Phase 4: ~20分 |
+| 物理レビュー要否 | 不要（unit 意味論の変更なし、セッター動作の堅牢化のみ） |
+| `needs-physics-review` ラベル | 不要 |
+
+---
+
+## 6. ファイル変更一覧
+
+| ファイル | 変更種別 | 内容 |
+|---|---|---|
+| `gwexpy/types/metadata.py` | 修正 | セッター shape mismatch 明示化、`to_dataframe()` unit 文字列化、docstring 追記 |
+| `tests/types/test_metadata_fixes.py` | 追加 | セッター shape mismatch テスト、CSV ラウンドトリップテスト、floor_divide テスト |
+
+---
+
+## 7. 関連情報
+
+- Issue #243: https://github.com/tatsuki-washimi/gwexpy/issues/243
+- PR #240, #241: Core Data Model audit 前段
+- `gwexpy/types/metadata.py`: 主要実装
+- `tests/types/test_metadata_ufuncs.py`: 既存 ufunc テスト
+- `tests/types/test_metadata_fixes.py`: 既存 fixes テスト

--- a/gwexpy/types/metadata.py
+++ b/gwexpy/types/metadata.py
@@ -165,14 +165,48 @@ class MetaData(dict):
     def as_meta(self, obj):
         """Coerce an object into a MetaData instance.
 
-        If the object is already a MetaData instance, it is returned as-is.
-        Otherwise, it is converted using the current metadata as a template.
+        If *obj* is already a ``MetaData`` instance it is returned unchanged.
+        Otherwise a new ``MetaData`` is constructed whose **name** and
+        **channel** are inherited from ``self`` and whose **unit** is inferred
+        from *obj* via :func:`get_unit`.
+
+        Parameters
+        ----------
+        obj : MetaData, astropy.Quantity, numeric, or any object with a .unit
+            The object to coerce.
+
+        Returns
+        -------
+        MetaData
+
         """
         if isinstance(obj, MetaData):
             return obj
         return MetaData(name=self.name, channel=self.channel, unit=get_unit(obj))
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        """NumPy ufunc protocol for unit propagation.
+
+        Unit-checking policy
+        --------------------
+        * **Strict** (raises ``UnitConversionError``):
+          - ``add`` / ``subtract``: both operands must be dimensionally compatible.
+          - Transcendental functions (``exp``, ``sin``, ``cos``, ``log``): input
+            must be dimensionless.
+          - Comparison ufuncs: operands must be dimensionally compatible.
+          - ``power``: exponent must be dimensionless (numeric scalar or
+            dimensionless ``Quantity``).
+        * **Flexible** (unit derived algebraically, no compatibility check):
+          - ``multiply``, ``divide``, ``floor_divide``: result unit is
+            ``lhs_unit * rhs_unit`` or ``lhs_unit / rhs_unit`` respectively.
+            ``floor_divide`` carries the same dimensional result as ``divide``;
+            the integer truncation applies only to the numeric value, not the
+            unit.
+          - ``sqrt``, ``square``: result unit is ``lhs_unit ** 0.5`` or
+            ``lhs_unit ** 2``.
+          - Unary ``abs``, ``negative``, ``positive``, ``real``, ``imag``,
+            ``conjugate``: unit is preserved unchanged.
+        """
         if method != "__call__":
             return NotImplemented
 
@@ -408,10 +442,17 @@ class MetaDataDict(OrderedDict[str, MetaData]):
         return [entry.unit for entry in self.values()]
 
     def to_dataframe(self):
-        """Convert the metadata collection to a pandas DataFrame."""
+        """Convert the metadata collection to a pandas DataFrame.
+
+        The ``unit`` column is serialised as a string so that the DataFrame
+        can be written to CSV and read back without loss of unit information.
+        """
         if pd is None:
             raise ImportError("pandas is required for to_dataframe()")
-        data = [{**entry, "key": key} for key, entry in self.items()]
+        data = [
+            {**{k: (str(v) if k == "unit" else v) for k, v in entry.items()}, "key": key}
+            for key, entry in self.items()
+        ]
         df = pd.DataFrame(data).set_index("key")
         return df
 
@@ -618,9 +659,22 @@ class MetaDataMatrix(np.ndarray):
 
     @names.setter
     def names(self, value):
+        """Set names for all elements.
+
+        Parameters
+        ----------
+        value : array-like
+            Must contain exactly ``self.size`` elements. A flat array of the
+            correct size is accepted and reshaped; any other size mismatch
+            raises ``ValueError``.
+
+        """
         value = np.asarray(value)
-        if value.shape != self.shape:
-            value = value.reshape(self.shape)
+        if value.size != self.size:
+            raise ValueError(
+                f"Cannot set names: got {value.size} value(s), "
+                f"expected {self.size} (matrix shape {self.shape})"
+            )
         flat_iter = cast(Iterable[MetaData], self.reshape(-1))
         value_iter = cast(Iterable[object], value.reshape(-1))
         for m, name in zip(flat_iter, value_iter):
@@ -634,9 +688,22 @@ class MetaDataMatrix(np.ndarray):
 
     @units.setter
     def units(self, value):
+        """Set units for all elements.
+
+        Parameters
+        ----------
+        value : array-like
+            Must contain exactly ``self.size`` elements. A flat array of the
+            correct size is accepted and reshaped; any other size mismatch
+            raises ``ValueError``.
+
+        """
         value = np.asarray(value)
-        if value.shape != self.shape:
-            value = value.reshape(self.shape)
+        if value.size != self.size:
+            raise ValueError(
+                f"Cannot set units: got {value.size} value(s), "
+                f"expected {self.size} (matrix shape {self.shape})"
+            )
         flat_iter = cast(Iterable[MetaData], self.reshape(-1))
         value_iter = cast(Iterable[object], value.reshape(-1))
         for m, unit in zip(flat_iter, value_iter):
@@ -650,9 +717,22 @@ class MetaDataMatrix(np.ndarray):
 
     @channels.setter
     def channels(self, value):
+        """Set channels for all elements.
+
+        Parameters
+        ----------
+        value : array-like
+            Must contain exactly ``self.size`` elements. A flat array of the
+            correct size is accepted and reshaped; any other size mismatch
+            raises ``ValueError``.
+
+        """
         value = np.asarray(value)
-        if value.shape != self.shape:
-            value = value.reshape(self.shape)
+        if value.size != self.size:
+            raise ValueError(
+                f"Cannot set channels: got {value.size} value(s), "
+                f"expected {self.size} (matrix shape {self.shape})"
+            )
         flat_iter = cast(Iterable[MetaData], self.reshape(-1))
         value_iter = cast(Iterable[object], value.reshape(-1))
         for m, channel in zip(flat_iter, value_iter):

--- a/gwexpy/types/metadata.py
+++ b/gwexpy/types/metadata.py
@@ -664,16 +664,22 @@ class MetaDataMatrix(np.ndarray):
         Parameters
         ----------
         value : array-like
-            Must contain exactly ``self.size`` elements. A flat array of the
-            correct size is accepted and reshaped; any other size mismatch
-            raises ``ValueError``.
+            Must either match the matrix shape exactly or be a 1-D flat array
+            of ``self.size`` elements (which is then reshaped in row-major
+            order).  Any other shape raises ``ValueError`` to prevent silent
+            element reordering.
 
         """
         value = np.asarray(value)
-        if value.size != self.size:
+        if value.shape == self.shape:
+            pass
+        elif value.ndim == 1 and value.size == self.size:
+            value = value.reshape(self.shape)
+        else:
             raise ValueError(
-                f"Cannot set names: got {value.size} value(s), "
-                f"expected {self.size} (matrix shape {self.shape})"
+                f"Cannot set names: shape {value.shape} is incompatible with "
+                f"matrix shape {self.shape}. Provide an exact-shape array or "
+                f"a 1-D flat array of size {self.size}."
             )
         flat_iter = cast(Iterable[MetaData], self.reshape(-1))
         value_iter = cast(Iterable[object], value.reshape(-1))
@@ -693,16 +699,22 @@ class MetaDataMatrix(np.ndarray):
         Parameters
         ----------
         value : array-like
-            Must contain exactly ``self.size`` elements. A flat array of the
-            correct size is accepted and reshaped; any other size mismatch
-            raises ``ValueError``.
+            Must either match the matrix shape exactly or be a 1-D flat array
+            of ``self.size`` elements (which is then reshaped in row-major
+            order).  Any other shape raises ``ValueError`` to prevent silent
+            element reordering.
 
         """
         value = np.asarray(value)
-        if value.size != self.size:
+        if value.shape == self.shape:
+            pass
+        elif value.ndim == 1 and value.size == self.size:
+            value = value.reshape(self.shape)
+        else:
             raise ValueError(
-                f"Cannot set units: got {value.size} value(s), "
-                f"expected {self.size} (matrix shape {self.shape})"
+                f"Cannot set units: shape {value.shape} is incompatible with "
+                f"matrix shape {self.shape}. Provide an exact-shape array or "
+                f"a 1-D flat array of size {self.size}."
             )
         flat_iter = cast(Iterable[MetaData], self.reshape(-1))
         value_iter = cast(Iterable[object], value.reshape(-1))
@@ -722,16 +734,22 @@ class MetaDataMatrix(np.ndarray):
         Parameters
         ----------
         value : array-like
-            Must contain exactly ``self.size`` elements. A flat array of the
-            correct size is accepted and reshaped; any other size mismatch
-            raises ``ValueError``.
+            Must either match the matrix shape exactly or be a 1-D flat array
+            of ``self.size`` elements (which is then reshaped in row-major
+            order).  Any other shape raises ``ValueError`` to prevent silent
+            element reordering.
 
         """
         value = np.asarray(value)
-        if value.size != self.size:
+        if value.shape == self.shape:
+            pass
+        elif value.ndim == 1 and value.size == self.size:
+            value = value.reshape(self.shape)
+        else:
             raise ValueError(
-                f"Cannot set channels: got {value.size} value(s), "
-                f"expected {self.size} (matrix shape {self.shape})"
+                f"Cannot set channels: shape {value.shape} is incompatible with "
+                f"matrix shape {self.shape}. Provide an exact-shape array or "
+                f"a 1-D flat array of size {self.size}."
             )
         flat_iter = cast(Iterable[MetaData], self.reshape(-1))
         value_iter = cast(Iterable[object], value.reshape(-1))

--- a/tests/types/test_metadata_fixes.py
+++ b/tests/types/test_metadata_fixes.py
@@ -60,6 +60,28 @@ def test_metadatamatrix_channels_setter_size_mismatch_raises():
         mat.channels = np.array(["H1:X"])  # 1 != 6
 
 
+def test_metadatamatrix_names_setter_wrong_2d_shape_raises():
+    """(3, 2) input into a (2, 3) matrix must raise, not silently reorder."""
+    mat = MetaDataMatrix(shape=(2, 3))
+    with pytest.raises(ValueError, match="names"):
+        mat.names = np.array([["a", "b"], ["c", "d"], ["e", "f"]])  # shape (3,2)
+
+
+def test_metadatamatrix_units_setter_wrong_2d_shape_raises():
+    mat = MetaDataMatrix(shape=(2, 3))
+    wrong = np.empty((3, 2), dtype=object)
+    wrong.flat[:] = [u.m, u.s, u.Hz, u.kg, u.Pa, u.J]
+    with pytest.raises(ValueError, match="units"):
+        mat.units = wrong
+
+
+def test_metadatamatrix_channels_setter_wrong_2d_shape_raises():
+    mat = MetaDataMatrix(shape=(2, 3))
+    wrong = np.array([["H1:A", "L1:B"], ["H1:C", "L1:D"], ["H1:E", "L1:F"]])
+    with pytest.raises(ValueError, match="channels"):
+        mat.channels = wrong
+
+
 def test_metadatamatrix_names_setter_flat_array_reshapes():
     """A flat array whose size matches is accepted and applied in row-major order."""
     mat = MetaDataMatrix(shape=(2, 3))

--- a/tests/types/test_metadata_fixes.py
+++ b/tests/types/test_metadata_fixes.py
@@ -1,7 +1,8 @@
+import numpy as np
 import pytest
 from astropy import units as u
 
-from gwexpy.types.metadata import MetaData
+from gwexpy.types.metadata import MetaData, MetaDataDict, MetaDataMatrix
 
 
 def test_metadata_right_hand_operations_dimensionless():
@@ -35,3 +36,122 @@ def test_metadata_right_hand_quantity_left():
     assert isinstance(out, MetaData)
     assert out.unit == u.m
     assert out.name == "a"
+
+
+# ---------------------------------------------------------------------------
+# MetaDataMatrix setters: shape mismatch must raise ValueError
+# ---------------------------------------------------------------------------
+
+def test_metadatamatrix_names_setter_size_mismatch_raises():
+    mat = MetaDataMatrix(shape=(2, 3))
+    with pytest.raises(ValueError, match="names"):
+        mat.names = np.array(["a", "b"])  # 2 != 6
+
+
+def test_metadatamatrix_units_setter_size_mismatch_raises():
+    mat = MetaDataMatrix(shape=(2, 3))
+    with pytest.raises(ValueError, match="units"):
+        mat.units = np.array([u.m, u.s])  # 2 != 6
+
+
+def test_metadatamatrix_channels_setter_size_mismatch_raises():
+    mat = MetaDataMatrix(shape=(2, 3))
+    with pytest.raises(ValueError, match="channels"):
+        mat.channels = np.array(["H1:X"])  # 1 != 6
+
+
+def test_metadatamatrix_names_setter_flat_array_reshapes():
+    """A flat array whose size matches is accepted and applied in row-major order."""
+    mat = MetaDataMatrix(shape=(2, 3))
+    mat.names = np.array(["a", "b", "c", "d", "e", "f"])
+    assert mat.names[0, 0] == "a"
+    assert mat.names[0, 2] == "c"
+    assert mat.names[1, 2] == "f"
+
+
+def test_metadatamatrix_units_setter_flat_array_reshapes():
+    mat = MetaDataMatrix(shape=(2, 2))
+    mat.units = np.array([u.m, u.s, u.Hz, u.kg])
+    assert mat[0, 0].unit == u.m
+    assert mat[1, 1].unit == u.kg
+
+
+def test_metadatamatrix_channels_setter_flat_array_reshapes():
+    mat = MetaDataMatrix(shape=(1, 2))
+    mat.channels = np.array(["H1:A", "L1:B"])
+    assert str(mat[0, 0].channel) == "H1:A"
+    assert str(mat[0, 1].channel) == "L1:B"
+
+
+def test_metadatamatrix_names_setter_exact_shape():
+    mat = MetaDataMatrix(shape=(2, 2))
+    mat.names = np.array([["x", "y"], ["z", "w"]])
+    assert mat.names[0, 1] == "y"
+    assert mat.names[1, 0] == "z"
+
+
+# ---------------------------------------------------------------------------
+# MetaDataMatrix ufunc: shape mismatch between two matrices raises ValueError
+# ---------------------------------------------------------------------------
+
+def test_metadatamatrix_ufunc_shape_mismatch_raises():
+    m1 = MetaDataMatrix(shape=(2, 2))
+    m2 = MetaDataMatrix(shape=(2, 3))
+    with pytest.raises(ValueError, match="[Ss]hape"):
+        np.multiply(m1, m2)
+
+
+# ---------------------------------------------------------------------------
+# floor_divide unit propagation
+# ---------------------------------------------------------------------------
+
+def test_metadata_floor_divide_unit():
+    m1 = MetaData(name="a", unit=u.m)
+    m2 = MetaData(name="b", unit=u.s)
+    out = np.floor_divide(m1, m2)
+    assert isinstance(out, MetaData)
+    assert out.unit.is_equivalent(u.m / u.s)
+
+
+# ---------------------------------------------------------------------------
+# CSV round-trip: MetaDataMatrix
+# ---------------------------------------------------------------------------
+
+def test_metadatamatrix_csv_roundtrip(tmp_path):
+    mat = MetaDataMatrix([
+        [MetaData(name="a", unit=u.m, channel="H1:A"),
+         MetaData(name="b", unit=u.s, channel="L1:B")],
+        [MetaData(name="c", unit=u.Hz, channel="H1:C"),
+         MetaData(name="d", unit=u.dimensionless_unscaled, channel="")],
+    ])
+    path = tmp_path / "mat.csv"
+    mat.write(str(path))
+    mat2 = MetaDataMatrix.read(str(path))
+
+    assert mat2.shape == (2, 2)
+    assert mat2[0, 0].name == "a"
+    assert mat2[0, 0].unit.is_equivalent(u.m)
+    assert mat2[0, 1].unit.is_equivalent(u.s)
+    assert mat2[1, 0].unit.is_equivalent(u.Hz)
+    assert mat2[1, 1].name == "d"
+
+
+# ---------------------------------------------------------------------------
+# CSV round-trip: MetaDataDict
+# ---------------------------------------------------------------------------
+
+def test_metadatadict_csv_roundtrip(tmp_path):
+    pytest.importorskip("pandas")
+    mdd = MetaDataDict({
+        "x": MetaData(name="x", unit=u.m, channel="H1:X"),
+        "y": MetaData(name="y", unit=u.s, channel="L1:Y"),
+    })
+    path = tmp_path / "mdd.csv"
+    mdd.write(str(path))
+    mdd2 = MetaDataDict.read(str(path))
+
+    assert list(mdd2.keys()) == ["x", "y"]
+    assert mdd2["x"].unit.is_equivalent(u.m)
+    assert mdd2["x"].name == "x"
+    assert mdd2["y"].unit.is_equivalent(u.s)
+    assert mdd2["y"].name == "y"


### PR DESCRIPTION
Documents audit findings (setter shape-mismatch silent reshaping,
CSV round-trip unit serialization gap, missing tests) and the
four-phase implementation roadmap with concrete code snippets.

https://claude.ai/code/session_01MyW8tjGFMxkSgNYrDQwrtf