### PR TITLE
fix: reject mismatched axis lengths in ScalarField/TensorField constructors (issue #242)

### DIFF
--- a/gwexpy/fields/tensor.py
+++ b/gwexpy/fields/tensor.py
@@ -23,14 +23,19 @@ class TensorField(FieldDict):
 
     Parameters
     ----------
-    components : dict[tuple, ScalarField], optional
-        Mapping of index tuples to field objects.
+    components : dict[tuple, ScalarField] or numpy.ndarray, optional
+        Mapping of index tuples to ScalarField objects, or a 6-D numpy array
+        of shape ``(n0, n1, n2, n3, i, j)`` representing a rank-2 tensor field.
+        When a numpy array is supplied the last two dimensions are the tensor
+        indices and each ``(n0, n1, n2, n3)`` slice becomes a ScalarField with
+        default ``arange`` coordinate axes.  Axis metadata (units, custom
+        coordinates) must be assigned after construction when using this path.
 
     rank : int, optional
         The tensor rank. If None, it is inferred from keys.
 
     validate : bool, optional
-        If True (default), validates component consistency.
+        If True (default), validates component consistency (shape, units, axes).
 
     Notes
     -----
@@ -58,7 +63,9 @@ class TensorField(FieldDict):
         if isinstance(components, np.ndarray):
             arr = components
             if arr.ndim != 6:
-                raise ValueError(f"TensorField rank-2 expects 6D array, got {arr.ndim}D")
+                raise ValueError(
+                    f"TensorField rank-2 expects 6D array, got {arr.ndim}D"
+                )
 
             dim_i, dim_j = arr.shape[-2:]
             new_components: dict[tuple[int, ...], ScalarField] = {}

--- a/gwexpy/interop/emg3d_.py
+++ b/gwexpy/interop/emg3d_.py
@@ -127,6 +127,26 @@ def _build_node_coords(
     )
 
 
+def _coords_for_component_shape(
+    mesh: Any,
+    shape: tuple[int, ...],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return mesh coordinates whose lengths match a raw component shape."""
+    cell_coords = _build_cell_center_coords(mesh)
+    if shape == tuple(len(axis) for axis in cell_coords):
+        return cell_coords
+
+    node_coords = _build_node_coords(mesh)
+    if shape == tuple(len(axis) for axis in node_coords):
+        return node_coords
+
+    raise ValueError(
+        f"Component shape {shape} does not match cell-center coordinate lengths "
+        f"{tuple(len(axis) for axis in cell_coords)} or node coordinate lengths "
+        f"{tuple(len(axis) for axis in node_coords)}."
+    )
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
@@ -243,7 +263,7 @@ def from_emg3d_field(
                 "Set interpolate_to_cell_center=True to align them."
             )
         fx_c, fy_c, fz_c = fx, fy, fz
-        cx, cy, cz = _build_cell_center_coords(mesh)
+        cx, cy, cz = _coords_for_component_shape(mesh, fx_c.shape)
         metadata = {}
 
     # Add singleton axis0 dimension

--- a/gwexpy/interop/emg3d_.py
+++ b/gwexpy/interop/emg3d_.py
@@ -21,6 +21,7 @@ References
 https://emg3d.emsig.xyz/
 
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -242,7 +243,7 @@ def from_emg3d_field(
                 "Set interpolate_to_cell_center=True to align them."
             )
         fx_c, fy_c, fz_c = fx, fy, fz
-        cx, cy, cz = _build_node_coords(mesh)
+        cx, cy, cz = _build_cell_center_coords(mesh)
         metadata = {}
 
     # Add singleton axis0 dimension

--- a/gwexpy/types/array4d.py
+++ b/gwexpy/types/array4d.py
@@ -1,4 +1,5 @@
 """4D Array with explicit axis management."""
+
 from __future__ import annotations
 
 import numpy as np
@@ -89,21 +90,41 @@ class Array4D(Array):
             obj._axis0_index = np.arange(obj.shape[0]) * dimensionless_unscaled
         else:
             obj._axis0_index = coerce_1d_quantity(axis0)
+            if len(obj._axis0_index) != obj.shape[0]:
+                raise ValueError(
+                    f"axis0 length {len(obj._axis0_index)} does not match "
+                    f"data shape[0]={obj.shape[0]}"
+                )
 
         if axis1 is None:
             obj._axis1_index = np.arange(obj.shape[1]) * dimensionless_unscaled
         else:
             obj._axis1_index = coerce_1d_quantity(axis1)
+            if len(obj._axis1_index) != obj.shape[1]:
+                raise ValueError(
+                    f"axis1 length {len(obj._axis1_index)} does not match "
+                    f"data shape[1]={obj.shape[1]}"
+                )
 
         if axis2 is None:
             obj._axis2_index = np.arange(obj.shape[2]) * dimensionless_unscaled
         else:
             obj._axis2_index = coerce_1d_quantity(axis2)
+            if len(obj._axis2_index) != obj.shape[2]:
+                raise ValueError(
+                    f"axis2 length {len(obj._axis2_index)} does not match "
+                    f"data shape[2]={obj.shape[2]}"
+                )
 
         if axis3 is None:
             obj._axis3_index = np.arange(obj.shape[3]) * dimensionless_unscaled
         else:
             obj._axis3_index = coerce_1d_quantity(axis3)
+            if len(obj._axis3_index) != obj.shape[3]:
+                raise ValueError(
+                    f"axis3 length {len(obj._axis3_index)} does not match "
+                    f"data shape[3]={obj.shape[3]}"
+                )
 
         # Update generic axis_names if present
         if getattr(obj, "_axis_names", None) is not None:

--- a/tests/fields/test_constructor_validation.py
+++ b/tests/fields/test_constructor_validation.py
@@ -1,0 +1,141 @@
+"""Regression tests for ScalarField and TensorField constructor shape/axis validation.
+
+Covers Issue #242: silent acceptance of mismatched axis lengths must be rejected
+with a clear ValueError, matching the fix applied to VectorField in PR #240.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from astropy import units as u
+
+from gwexpy.fields import ScalarField, TensorField
+
+DATA_4D = np.ones((4, 3, 5, 6))
+
+
+# ---------------------------------------------------------------------------
+# ScalarField — axis length mismatch
+# ---------------------------------------------------------------------------
+
+
+class TestScalarFieldAxisLengthValidation:
+    def test_axis0_wrong_length_raises(self):
+        axis0 = np.arange(7) * u.s  # 7 != 4
+        with pytest.raises(
+            ValueError, match="axis0 length 7 does not match data shape\\[0\\]=4"
+        ):
+            ScalarField(DATA_4D, axis0=axis0)
+
+    def test_axis1_wrong_length_raises(self):
+        axis1 = np.arange(10) * u.m  # 10 != 3
+        with pytest.raises(
+            ValueError, match="axis1 length 10 does not match data shape\\[1\\]=3"
+        ):
+            ScalarField(DATA_4D, axis1=axis1)
+
+    def test_axis2_wrong_length_raises(self):
+        axis2 = np.arange(2) * u.m  # 2 != 5
+        with pytest.raises(
+            ValueError, match="axis2 length 2 does not match data shape\\[2\\]=5"
+        ):
+            ScalarField(DATA_4D, axis2=axis2)
+
+    def test_axis3_wrong_length_raises(self):
+        axis3 = np.arange(99) * u.m  # 99 != 6
+        with pytest.raises(
+            ValueError, match="axis3 length 99 does not match data shape\\[3\\]=6"
+        ):
+            ScalarField(DATA_4D, axis3=axis3)
+
+    def test_all_axes_correct_length_succeeds(self):
+        axis0 = np.linspace(0, 1, 4) * u.s
+        axis1 = np.linspace(0, 1, 3) * u.m
+        axis2 = np.linspace(0, 1, 5) * u.m
+        axis3 = np.linspace(0, 1, 6) * u.m
+        sf = ScalarField(DATA_4D, axis0=axis0, axis1=axis1, axis2=axis2, axis3=axis3)
+        assert sf.shape == (4, 3, 5, 6)
+        assert len(sf._axis0_index) == 4
+        assert len(sf._axis1_index) == 3
+        assert len(sf._axis2_index) == 5
+        assert len(sf._axis3_index) == 6
+
+    def test_default_axes_match_shape(self):
+        """When no axis is passed the defaults must match the data dimensions."""
+        sf = ScalarField(DATA_4D)
+        assert len(sf._axis0_index) == DATA_4D.shape[0]
+        assert len(sf._axis1_index) == DATA_4D.shape[1]
+        assert len(sf._axis2_index) == DATA_4D.shape[2]
+        assert len(sf._axis3_index) == DATA_4D.shape[3]
+
+    def test_axis_length_one_mismatch_raises(self):
+        """A single-element axis for a dimension > 1 must be rejected."""
+        axis0 = np.array([0.0]) * u.s  # length 1 != 4
+        with pytest.raises(ValueError, match="axis0 length"):
+            ScalarField(DATA_4D, axis0=axis0)
+
+
+# ---------------------------------------------------------------------------
+# TensorField — ndarray construction path
+# ---------------------------------------------------------------------------
+
+
+class TestTensorFieldNdarrayConstruction:
+    def test_non_6d_array_raises(self):
+        with pytest.raises(ValueError, match="TensorField rank-2 expects 6D array"):
+            TensorField(np.ones((4, 3, 5, 6, 3)))  # 5D — must fail
+
+    def test_non_6d_4d_raises(self):
+        with pytest.raises(ValueError, match="TensorField rank-2 expects 6D array"):
+            TensorField(np.ones((4, 3, 5, 6)))  # 4D — must fail
+
+    def test_6d_array_creates_components(self):
+        arr = np.ones((4, 3, 5, 6, 2, 2))
+        tf = TensorField(arr)
+        assert tf.rank == 2
+        assert set(tf.keys()) == {(0, 0), (0, 1), (1, 0), (1, 1)}
+
+    def test_component_axes_are_default_arange(self):
+        """Components created from ndarray get default arange() axes (documented behaviour)."""
+        arr = np.ones((4, 3, 5, 6, 2, 2))
+        tf = TensorField(arr)
+        comp = tf[(0, 0)]
+        expected_axis0 = np.arange(4)
+        np.testing.assert_array_equal(comp._axis0_index.value, expected_axis0)
+
+    def test_component_shapes_match_field_dimensions(self):
+        arr = np.ones((4, 3, 5, 6, 3, 3))
+        tf = TensorField(arr)
+        for key, comp in tf.items():
+            assert comp.shape == (4, 3, 5, 6), (
+                f"Component {key} has shape {comp.shape}, expected (4, 3, 5, 6)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# TensorField — dict construction path
+# ---------------------------------------------------------------------------
+
+
+class TestTensorFieldDictConstruction:
+    def _make_sf(self, shape=(4, 3, 5, 6)):
+        return ScalarField(np.ones(shape))
+
+    def test_consistent_components_validate_true(self):
+        comps = {
+            (0, 0): self._make_sf(),
+            (0, 1): self._make_sf(),
+            (1, 0): self._make_sf(),
+            (1, 1): self._make_sf(),
+        }
+        tf = TensorField(comps, validate=True)
+        assert tf.rank == 2
+
+    def test_inconsistent_shapes_validate_true_raises(self):
+        comps = {
+            (0, 0): self._make_sf(shape=(4, 3, 5, 6)),
+            (0, 1): self._make_sf(shape=(4, 3, 5, 7)),  # shape mismatch on axis3
+        }
+        with pytest.raises((ValueError, Exception)):
+            TensorField(comps, validate=True)

--- a/tests/interop/test_interop_emg3d.py
+++ b/tests/interop/test_interop_emg3d.py
@@ -4,6 +4,7 @@ These tests use mock emg3d objects to avoid requiring the emg3d package in the
 test environment.  The staggered-grid interpolation helpers are tested with
 plain NumPy arrays.
 """
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
@@ -94,8 +95,10 @@ def _make_complex_efield() -> MagicMock:
     field.frequency = 1e6
 
     rng = np.random.default_rng(13)
+
     def _cpx(shape):
         return rng.random(shape) + 1j * rng.random(shape)
+
     field.fx = _cpx((NCX, NNY, NNZ))
     field.fy = _cpx((NNX, NCY, NNZ))
     field.fz = _cpx((NNX, NNY, NCZ))
@@ -277,6 +280,31 @@ class TestFromEmg3dNoInterp:
         assert isinstance(vf, VectorField)
         for sf in vf.values():
             assert sf.shape == (1, NCX, NCY, NCZ)
+            assert len(sf._axis1_index) == NCX
+            assert len(sf._axis2_index) == NCY
+            assert len(sf._axis3_index) == NCZ
+
+    def test_ok_when_node_shapes_equal(self):
+        """No-interpolation node-grid inputs must keep node coordinates."""
+        mesh = _make_mesh()
+        field = MagicMock()
+        field.grid = mesh
+        field.electric = True
+        field.frequency = 1.0
+        rng = np.random.default_rng(1)
+        shape = (NNX, NNY, NNZ)
+        field.fx = rng.random(shape)
+        field.fy = rng.random(shape)
+        field.fz = rng.random(shape)
+
+        vf = from_emg3d_field(VectorField, field, interpolate_to_cell_center=False)
+
+        assert isinstance(vf, VectorField)
+        for sf in vf.values():
+            assert sf.shape == (1, NNX, NNY, NNZ)
+            np.testing.assert_array_equal(sf._axis1_index.value, mesh.nodes_x)
+            np.testing.assert_array_equal(sf._axis2_index.value, mesh.nodes_y)
+            np.testing.assert_array_equal(sf._axis3_index.value, mesh.nodes_z)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/interop/test_interop_meshio.py
+++ b/tests/interop/test_interop_meshio.py
@@ -2,6 +2,7 @@
 
 Uses synthetic meshio.Mesh objects (no dolfinx or real mesh files needed).
 """
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock
@@ -166,7 +167,8 @@ class TestFromMeshio2DScalar:
     def test_interpolation_accuracy_linear(self):
         """Known parabolic function: f(x,y) = x^2 + y^2."""
         mesh = _make_2d_tri_mesh(
-            nx=20, ny=20,
+            nx=20,
+            ny=20,
             field_fn=lambda p: p[:, 0] ** 2 + p[:, 1] ** 2,
         )
         sf = from_meshio(ScalarField, mesh, grid_resolution=0.05)
@@ -223,12 +225,16 @@ class TestFromMeshioOptions:
 
     def test_custom_axis0(self):
         mesh = _make_2d_tri_mesh()
-        axis0 = np.array([0.0, 0.5, 1.0])
+        axis0 = np.array([0.5])  # single timestamp matching the single snapshot
         sf = from_meshio(
-            ScalarField, mesh, grid_resolution=0.1, axis0=axis0,
+            ScalarField,
+            mesh,
+            grid_resolution=0.1,
+            axis0=axis0,
         )
         assert isinstance(sf, ScalarField)
-        assert sf.shape[0] == 1  # single snapshot, axis0 stored
+        assert sf.shape[0] == 1  # single snapshot
+        assert sf._axis0_index.value[0] == pytest.approx(0.5)
 
     def test_grid_resolution_required(self):
         """grid_resolution is mandatory — missing it should raise TypeError."""
@@ -246,11 +252,13 @@ class TestFromMeshioCellData:
     def test_cell_data_only_raises(self):
         """cell_data without point_data must raise ValueError (unsupported interpolation)."""
         mesh = MagicMock()
-        mesh.points = np.column_stack([
-            np.linspace(0, 1, 100),
-            np.linspace(0, 1, 100),
-            np.zeros(100),
-        ])
+        mesh.points = np.column_stack(
+            [
+                np.linspace(0, 1, 100),
+                np.linspace(0, 1, 100),
+                np.zeros(100),
+            ]
+        )
         mesh.point_data = {}
         # Realistic mesh: 50 cells != 100 points
         mesh.cell_data = {"sigma": [np.ones(30), np.ones(20)]}


### PR DESCRIPTION
Array4D.__new__ now raises ValueError when a provided axis length does not
match the corresponding data dimension, preventing silent metadata drift.
Also documents TensorField ndarray-path default-axis behaviour and adds
regression tests for all mismatch cases.

https://claude.ai/code/session_01Sde8ehS2MWRzL3MPmAAyVZ