### PR TITLE
[AGENT:github] Add I/O interop dependency contract matrix

### DIFF
--- a/docs/developers/contracts/public_interop_contract.json
+++ b/docs/developers/contracts/public_interop_contract.json
@@ -601,14 +601,13 @@
             "reference_page": "gwexpy.interop.finesse_.rst",
             "details_link": "../reference/api/gwexpy.interop.finesse_.rst",
             "notes": [
-                "Finesse import helpers are published through the interop reference."
+                "Finesse import helpers are published through the interop reference.",
+                "Finesse is not included in a GWexpy extra; install finesse directly when needed."
             ],
             "optional_dependencies": [
                 "finesse"
             ],
-            "extras": [
-                "gw"
-            ],
+            "extras": [],
             "unavailable_behavior": "raises_import_error"
         },
         {
@@ -1157,7 +1156,11 @@
             "reference_page": "gwexpy.interop.metpy_.rst",
             "details_link": "../reference/api/gwexpy.interop.metpy_.rst",
             "notes": [
-                "MetPy import helpers are public once the guide and reference page are published."
+                "MetPy import helpers are public once the guide and reference page are published.",
+                "The adapter consumes MetPy-enhanced xarray objects but does not import metpy at runtime."
+            ],
+            "source_dependencies": [
+                "metpy"
             ],
             "optional_dependencies": [
                 "xarray"
@@ -1180,7 +1183,11 @@
             "reference_page": "gwexpy.interop.wrf_.rst",
             "details_link": "../reference/api/gwexpy.interop.wrf_.rst",
             "notes": [
-                "WRF import helpers are public once the guide and reference page are published."
+                "WRF import helpers are public once the guide and reference page are published.",
+                "The adapter consumes wrf-python xarray output but does not import wrf-python at runtime."
+            ],
+            "source_dependencies": [
+                "wrf-python"
             ],
             "optional_dependencies": [
                 "xarray"
@@ -1203,7 +1210,11 @@
             "reference_page": "gwexpy.interop.harmonica_.rst",
             "details_link": "../reference/api/gwexpy.interop.harmonica_.rst",
             "notes": [
-                "Harmonica grid import helpers are public once the guide and reference page are published."
+                "Harmonica grid import helpers are public once the guide and reference page are published.",
+                "The adapter consumes Harmonica xarray grids but does not import harmonica at runtime."
+            ],
+            "source_dependencies": [
+                "harmonica"
             ],
             "optional_dependencies": [
                 "xarray"

--- a/docs/developers/contracts/public_interop_contract.json
+++ b/docs/developers/contracts/public_interop_contract.json
@@ -959,13 +959,14 @@
             "reference_page": "gwexpy.interop.pyoma_.rst",
             "details_link": "../reference/api/gwexpy.interop.pyoma_.rst",
             "notes": [
-                "pyOMA modal-identification import helpers are public once the guide and reference page are published."
+                "pyOMA modal-identification import helpers consume pyOMA-style result dictionaries; they do not import pyOMA at runtime."
             ],
-            "optional_dependencies": [
+            "source_dependencies": [
                 "pyOMA"
             ],
             "extras": [],
-            "unavailable_behavior": "raises_import_error"
+            "optional_dependencies": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "multitaper",
@@ -980,13 +981,14 @@
             "reference_page": "gwexpy.interop.multitaper_.rst",
             "details_link": "../reference/api/gwexpy.interop.multitaper_.rst",
             "notes": [
-                "The Prieto-style multitaper bridge is public once the guide and reference page are published."
+                "The Prieto-style multitaper bridge consumes MTSpec/MTSine-like objects; it does not import multitaper at runtime."
             ],
-            "optional_dependencies": [
+            "source_dependencies": [
                 "multitaper"
             ],
             "extras": [],
-            "unavailable_behavior": "raises_import_error"
+            "optional_dependencies": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "mtspec",
@@ -1001,13 +1003,14 @@
             "reference_page": "gwexpy.interop.multitaper_.rst",
             "details_link": "../reference/api/gwexpy.interop.multitaper_.rst",
             "notes": [
-                "The array-style mtspec bridge is public through the shared multitaper_ reference module."
+                "The array-style mtspec bridge consumes spectrum/frequency arrays; it does not import mtspec at runtime."
             ],
-            "optional_dependencies": [
+            "source_dependencies": [
                 "mtspec"
             ],
             "extras": [],
-            "unavailable_behavior": "raises_import_error"
+            "optional_dependencies": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "sdypy",
@@ -1023,13 +1026,14 @@
             "reference_page": "gwexpy.interop.sdypy_.rst",
             "details_link": "../reference/api/gwexpy.interop.sdypy_.rst",
             "notes": [
-                "pySDy / pyuff import helpers are public once the guide and reference page are published."
+                "pySDy / pyuff import helpers consume UFF dataset dictionaries; they do not import pyuff or pySDy at runtime."
             ],
-            "optional_dependencies": [
+            "source_dependencies": [
                 "pyuff"
             ],
             "extras": [],
-            "unavailable_behavior": "raises_import_error"
+            "optional_dependencies": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "sdynpy",
@@ -1046,13 +1050,14 @@
             "reference_page": "gwexpy.interop.sdynpy_.rst",
             "details_link": "../reference/api/gwexpy.interop.sdynpy_.rst",
             "notes": [
-                "SDynPy modal helpers are public once the guide and reference page are published."
+                "SDynPy modal helpers consume SDynPy-like array objects; they do not import sdynpy at runtime."
             ],
-            "optional_dependencies": [
+            "source_dependencies": [
                 "sdynpy"
             ],
             "extras": [],
-            "unavailable_behavior": "raises_import_error"
+            "optional_dependencies": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "meep",

--- a/docs/developers/contracts/public_interop_contract.json
+++ b/docs/developers/contracts/public_interop_contract.json
@@ -16,7 +16,10 @@
             "details_link": "../reference/api/gwexpy.interop.hdf5_.rst",
             "notes": [
                 "Object-level HDF5 helpers are part of the public interop surface."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "hdf5-frequencyseries",
@@ -33,7 +36,10 @@
             "details_link": "../reference/api/gwexpy.interop.frequency.rst",
             "notes": [
                 "FrequencySeries-specific HDF5 helpers."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "json",
@@ -50,7 +56,10 @@
             "details_link": "../reference/api/gwexpy.interop.json_.rst",
             "notes": [
                 "JSON string conversion is public and reference-indexed through json_."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "python-dict",
@@ -67,7 +76,10 @@
             "details_link": null,
             "notes": [
                 "Python dict conversion shares the json_ reference module."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "sqlite",
@@ -84,7 +96,10 @@
             "details_link": "../reference/api/gwexpy.interop.sqlite_.rst",
             "notes": [
                 "SQLite is public once the reference page and guide entry are wired."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "zarr",
@@ -101,7 +116,14 @@
             "details_link": "../reference/api/gwexpy.interop.zarr_.rst",
             "notes": [
                 "Zarr is a published interop bridge distinct from direct I/O."
-            ]
+            ],
+            "optional_dependencies": [
+                "zarr"
+            ],
+            "extras": [
+                "zarr"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "netcdf4",
@@ -118,7 +140,15 @@
             "details_link": "../reference/api/gwexpy.interop.netcdf4_.rst",
             "notes": [
                 "NetCDF4 interop stays separate from canonical direct-I/O token nc."
-            ]
+            ],
+            "optional_dependencies": [
+                "netCDF4",
+                "xarray"
+            ],
+            "extras": [
+                "netcdf4"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "numpy",
@@ -132,7 +162,10 @@
             "details_link": null,
             "notes": [
                 "NumPy is documented as infrastructure, not a dedicated helper surface."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "not_applicable"
         },
         {
             "name": "pandas",
@@ -151,7 +184,10 @@
             "details_link": "../reference/api/gwexpy.interop.pandas_.rst",
             "notes": [
                 "The public guide describes pandas at the helper-function level."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "pandas-frequencyseries",
@@ -168,7 +204,10 @@
             "details_link": "../reference/api/gwexpy.interop.frequency.rst",
             "notes": [
                 "FrequencySeries-to-pandas conversion helpers."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "polars",
@@ -190,7 +229,12 @@
             "details_link": "../reference/api/gwexpy.interop.polars_.rst",
             "notes": [
                 "Polars helpers are public once the reference page and guide entry are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "polars"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "xarray",
@@ -207,7 +251,14 @@
             "details_link": "../reference/api/gwexpy.interop.xarray_.rst",
             "notes": [
                 "xarray DataArray and Dataset helpers are part of the public surface."
-            ]
+            ],
+            "optional_dependencies": [
+                "xarray"
+            ],
+            "extras": [
+                "netcdf4"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "xarray-field",
@@ -224,7 +275,14 @@
             "details_link": "../reference/api/gwexpy.interop.xarray_.rst",
             "notes": [
                 "Field interop is published through the same xarray_ reference module."
-            ]
+            ],
+            "optional_dependencies": [
+                "xarray"
+            ],
+            "extras": [
+                "netcdf4"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "xarray-frequencyseries",
@@ -241,7 +299,14 @@
             "details_link": "../reference/api/gwexpy.interop.frequency.rst",
             "notes": [
                 "FrequencySeries-to-xarray DataArray helpers."
-            ]
+            ],
+            "optional_dependencies": [
+                "xarray"
+            ],
+            "extras": [
+                "netcdf4"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "astropy-timeseries",
@@ -258,7 +323,10 @@
             "details_link": "../reference/api/gwexpy.interop.astropy_.rst",
             "notes": [
                 "Astropy time-series conversion is published and reference-indexed."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "dask",
@@ -275,7 +343,12 @@
             "details_link": "../reference/api/gwexpy.interop.dask_.rst",
             "notes": [
                 "Dask helpers are part of the public analysis interop surface."
-            ]
+            ],
+            "optional_dependencies": [
+                "dask"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "torch",
@@ -292,7 +365,12 @@
             "details_link": "../reference/api/gwexpy.interop.torch_.rst",
             "notes": [
                 "PyTorch tensor conversion is public once the reference page is published."
-            ]
+            ],
+            "optional_dependencies": [
+                "torch"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "torch-dataset",
@@ -310,7 +388,12 @@
             "details_link": "../reference/api/gwexpy.interop.torch_dataset.rst",
             "notes": [
                 "Windowed dataset and DataLoader helpers for training loops."
-            ]
+            ],
+            "optional_dependencies": [
+                "torch"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "tensorflow",
@@ -327,7 +410,12 @@
             "details_link": "../reference/api/gwexpy.interop.tensorflow_.rst",
             "notes": [
                 "TensorFlow tensor conversion is public once the reference page is published."
-            ]
+            ],
+            "optional_dependencies": [
+                "tensorflow"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "jax",
@@ -344,7 +432,12 @@
             "details_link": "../reference/api/gwexpy.interop.jax_.rst",
             "notes": [
                 "JAX array conversion is public once the reference page is published."
-            ]
+            ],
+            "optional_dependencies": [
+                "jax"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "cupy",
@@ -362,7 +455,12 @@
             "details_link": "../reference/api/gwexpy.interop.cupy_.rst",
             "notes": [
                 "CuPy GPU-array conversion is public once the reference page is published."
-            ]
+            ],
+            "optional_dependencies": [
+                "cupy"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "root",
@@ -383,7 +481,12 @@
             "details_link": "../reference/api/gwexpy.interop.root_.rst",
             "notes": [
                 "ROOT stays reference-indexed, but the guide still marks it as only partially complete."
-            ]
+            ],
+            "optional_dependencies": [
+                "ROOT"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "obspy",
@@ -402,7 +505,14 @@
             "details_link": "../reference/api/gwexpy.interop.obspy_.rst",
             "notes": [
                 "ObsPy remains one of the highest-value public round-trip bridges."
-            ]
+            ],
+            "optional_dependencies": [
+                "obspy"
+            ],
+            "extras": [
+                "seismic"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "lal",
@@ -421,7 +531,14 @@
             "details_link": "../reference/api/gwexpy.interop.lal_.rst",
             "notes": [
                 "LAL time-domain and frequency-domain helpers are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "lalsuite"
+            ],
+            "extras": [
+                "gw"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "pycbc",
@@ -440,7 +557,12 @@
             "details_link": "../reference/api/gwexpy.interop.pycbc_.rst",
             "notes": [
                 "PyCBC helpers are part of the public GW-domain bridge surface."
-            ]
+            ],
+            "optional_dependencies": [
+                "pycbc"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "gwinc",
@@ -456,7 +578,14 @@
             "details_link": "../reference/api/gwexpy.interop.gwinc_.rst",
             "notes": [
                 "GWINC is import-only but still a published public bridge."
-            ]
+            ],
+            "optional_dependencies": [
+                "gwinc"
+            ],
+            "extras": [
+                "gw"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "finesse",
@@ -473,7 +602,14 @@
             "details_link": "../reference/api/gwexpy.interop.finesse_.rst",
             "notes": [
                 "Finesse import helpers are published through the interop reference."
-            ]
+            ],
+            "optional_dependencies": [
+                "finesse"
+            ],
+            "extras": [
+                "gw"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "control",
@@ -491,7 +627,14 @@
             "details_link": "../reference/api/gwexpy.interop.control_.rst",
             "notes": [
                 "Control FRD and response import are public even though class wrappers differ by object family."
-            ]
+            ],
+            "optional_dependencies": [
+                "control"
+            ],
+            "extras": [
+                "control"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "simpeg",
@@ -508,7 +651,12 @@
             "details_link": "../reference/api/gwexpy.interop.simpeg_.rst",
             "notes": [
                 "SimPEG geophysics helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "simpeg"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "mth5",
@@ -525,7 +673,14 @@
             "details_link": "../reference/api/gwexpy.interop.mt_.rst",
             "notes": [
                 "MTH5 is promoted to public once the top-level namespace and reference index are wired."
-            ]
+            ],
+            "optional_dependencies": [
+                "mth5"
+            ],
+            "extras": [
+                "seismic"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "mtpy",
@@ -539,7 +694,10 @@
             "details_link": null,
             "notes": [
                 "MTpy is documented as organizational work in progress rather than an exposed helper family."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "not_applicable"
         },
         {
             "name": "mne",
@@ -558,7 +716,12 @@
             "details_link": "../reference/api/gwexpy.interop.mne_.rst",
             "notes": [
                 "MNE biosignal helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "mne"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "neo",
@@ -575,7 +738,12 @@
             "details_link": "../reference/api/gwexpy.interop.neo_.rst",
             "notes": [
                 "Neo electrophysiology helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "neo"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "elephant",
@@ -589,7 +757,10 @@
             "details_link": null,
             "notes": [
                 "Elephant is explicitly documented as still in progress."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "not_applicable"
         },
         {
             "name": "quantities",
@@ -606,7 +777,12 @@
             "details_link": "../reference/api/gwexpy.interop.quantities_.rst",
             "notes": [
                 "quantities bridges are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "quantities"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "pyroomacoustics",
@@ -628,7 +804,12 @@
             "details_link": "../reference/api/gwexpy.interop.pyroomacoustics_.rst",
             "notes": [
                 "pyroomacoustics room-acoustics helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "pyroomacoustics"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "pydub",
@@ -645,7 +826,14 @@
             "details_link": "../reference/api/gwexpy.interop.pydub_.rst",
             "notes": [
                 "pydub audio helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "pydub"
+            ],
+            "extras": [
+                "audio"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "librosa",
@@ -661,7 +849,10 @@
             "details_link": "../reference/api/gwexpy.interop.pydub_.rst",
             "notes": [
                 "librosa export stays documented through the shared pydub_ reference module."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "specutils",
@@ -678,7 +869,12 @@
             "details_link": "../reference/api/gwexpy.interop.specutils_.rst",
             "notes": [
                 "specutils astronomy-spectrum helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "specutils"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "pyspeckit",
@@ -695,7 +891,12 @@
             "details_link": "../reference/api/gwexpy.interop.pyspeckit_.rst",
             "notes": [
                 "pyspeckit spectral-analysis helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "pyspeckit"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "pyspice",
@@ -714,7 +915,12 @@
             "details_link": "../reference/api/gwexpy.interop.pyspice_.rst",
             "notes": [
                 "PySpice circuit-simulation import helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "PySpice"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "skrf",
@@ -733,7 +939,12 @@
             "details_link": "../reference/api/gwexpy.interop.skrf_.rst",
             "notes": [
                 "scikit-rf RF-network helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "skrf"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "pyoma",
@@ -749,7 +960,12 @@
             "details_link": "../reference/api/gwexpy.interop.pyoma_.rst",
             "notes": [
                 "pyOMA modal-identification import helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "pyOMA"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "multitaper",
@@ -765,7 +981,12 @@
             "details_link": "../reference/api/gwexpy.interop.multitaper_.rst",
             "notes": [
                 "The Prieto-style multitaper bridge is public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "multitaper"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "mtspec",
@@ -781,7 +1002,12 @@
             "details_link": "../reference/api/gwexpy.interop.multitaper_.rst",
             "notes": [
                 "The array-style mtspec bridge is public through the shared multitaper_ reference module."
-            ]
+            ],
+            "optional_dependencies": [
+                "mtspec"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "sdypy",
@@ -798,7 +1024,12 @@
             "details_link": "../reference/api/gwexpy.interop.sdypy_.rst",
             "notes": [
                 "pySDy / pyuff import helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "pyuff"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "sdynpy",
@@ -816,7 +1047,12 @@
             "details_link": "../reference/api/gwexpy.interop.sdynpy_.rst",
             "notes": [
                 "SDynPy modal helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "sdynpy"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "meep",
@@ -832,7 +1068,10 @@
             "details_link": "../reference/api/gwexpy.interop.meep_.rst",
             "notes": [
                 "Meep field-import helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "openems",
@@ -849,7 +1088,10 @@
             "details_link": "../reference/api/gwexpy.interop.openems_.rst",
             "notes": [
                 "openEMS field-dump import helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "emg3d",
@@ -867,7 +1109,12 @@
             "details_link": "../reference/api/gwexpy.interop.emg3d_.rst",
             "notes": [
                 "emg3d field import/export helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "emg3d"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "meshio",
@@ -885,7 +1132,12 @@
             "details_link": "../reference/api/gwexpy.interop.meshio_.rst",
             "notes": [
                 "meshio and Fenics import helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "meshio"
+            ],
+            "extras": [],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "metpy",
@@ -901,7 +1153,14 @@
             "details_link": "../reference/api/gwexpy.interop.metpy_.rst",
             "notes": [
                 "MetPy import helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "xarray"
+            ],
+            "extras": [
+                "netcdf4"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "wrf",
@@ -917,7 +1176,14 @@
             "details_link": "../reference/api/gwexpy.interop.wrf_.rst",
             "notes": [
                 "WRF import helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "xarray"
+            ],
+            "extras": [
+                "netcdf4"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "harmonica",
@@ -933,7 +1199,14 @@
             "details_link": "../reference/api/gwexpy.interop.harmonica_.rst",
             "notes": [
                 "Harmonica grid import helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [
+                "xarray"
+            ],
+            "extras": [
+                "netcdf4"
+            ],
+            "unavailable_behavior": "raises_import_error"
         },
         {
             "name": "exudyn",
@@ -949,7 +1222,10 @@
             "details_link": "../reference/api/gwexpy.interop.exudyn_.rst",
             "notes": [
                 "Exudyn sensor import helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "available_in_base_install"
         },
         {
             "name": "opensees",
@@ -965,7 +1241,10 @@
             "details_link": "../reference/api/gwexpy.interop.opensees_.rst",
             "notes": [
                 "OpenSees recorder import helpers are public once the guide and reference page are published."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": "available_in_base_install"
         }
     ]
 }

--- a/docs/developers/contracts/public_interop_contract.md
+++ b/docs/developers/contracts/public_interop_contract.md
@@ -27,9 +27,12 @@ Each target entry contains these fields:
   intentionally has no dedicated helper module yet
 - `status`: public presentation status used by the guide
 - `guide_api`: `to_*()` / `from_*()` names published for that target
-- `optional_dependencies`: optional import/package names needed by that bridge,
-  or an empty list when the base install is sufficient or the row has no helper
-  surface
+- `source_dependencies`: optional package names that commonly produce accepted
+  source objects for import-only adapters, but are not imported by the bridge
+  itself
+- `optional_dependencies`: optional import/package names needed at bridge
+  runtime, or an empty list when the base install is sufficient or the row has
+  no helper surface
 - `extras`: declared GWexpy extras that satisfy those dependencies, or an empty
   list when users must install the backend directly
 - `unavailable_behavior`: expected behavior when the optional backend is
@@ -56,6 +59,9 @@ Each target entry contains these fields:
   `raises_import_error`, or `not_applicable`.
 - Helper-backed bridges with optional dependencies should raise `ImportError`
   with install guidance when the dependency is unavailable.
+- Import-only adapters that consume caller-supplied objects or dictionaries
+  should list producer packages in `source_dependencies`, not in
+  `optional_dependencies`, when the adapter does not import those packages.
 
 ## Boundary Decisions
 

--- a/docs/developers/contracts/public_interop_contract.md
+++ b/docs/developers/contracts/public_interop_contract.md
@@ -27,6 +27,13 @@ Each target entry contains these fields:
   intentionally has no dedicated helper module yet
 - `status`: public presentation status used by the guide
 - `guide_api`: `to_*()` / `from_*()` names published for that target
+- `optional_dependencies`: optional import/package names needed by that bridge,
+  or an empty list when the base install is sufficient or the row has no helper
+  surface
+- `extras`: declared GWexpy extras that satisfy those dependencies, or an empty
+  list when users must install the backend directly
+- `unavailable_behavior`: expected behavior when the optional backend is
+  unavailable
 - `row_match_en`: marker string used to find the English guide row
 - `row_match_ja`: marker string used to find the Japanese guide row
 - `reference_indexed`: whether the module must appear in `reference/api/interop.rst`
@@ -45,6 +52,10 @@ Each target entry contains these fields:
 - `reference_indexed = false` means the module must stay out of the interop
   reference index until an explicit publication decision is made.
 - Every guide row with an interop status label must appear in this contract.
+- `unavailable_behavior` is one of `available_in_base_install`,
+  `raises_import_error`, or `not_applicable`.
+- Helper-backed bridges with optional dependencies should raise `ImportError`
+  with install guidance when the dependency is unavailable.
 
 ## Boundary Decisions
 

--- a/docs/developers/contracts/public_io_contract.json
+++ b/docs/developers/contracts/public_io_contract.json
@@ -50,7 +50,13 @@
                 "Backend aliases resolve through gwpy GWF readers.",
                 "Public direct I/O includes TimeSeries and TimeSeriesDict reads.",
                 "TimeSeriesMatrix reader remains an implementation convenience path until it is published explicitly in the user guide."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": {
+                "read": "available_in_base_install",
+                "write": "available_in_base_install"
+            }
         },
         {
             "name": "hdf.ndscope",
@@ -97,7 +103,13 @@
             "notes": [
                 "Public direct I/O is collection-first and TimeSeriesDict-only.",
                 "Single-series and matrix registry adapters are implementation convenience paths, not public contract surface."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": {
+                "read": "available_in_base_install",
+                "write": "available_in_base_install"
+            }
         },
         {
             "name": "hdf5",
@@ -202,7 +214,13 @@
                 "GWpy segment classes remain part of the broader registry-backed implementation surface, but they are not part of the published HDF5 direct-I/O contract in this slice.",
                 "FrequencySeriesMatrix and SpectrogramMatrix remain outside the published HDF5 contract until matrix-axis serialization is hardened.",
                 "Field classes remain intentionally outside this schema slice pending a dedicated direct-I/O audit."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": {
+                "read": "available_in_base_install",
+                "write": "available_in_base_install"
+            }
         },
         {
             "name": "xml.diaggui",
@@ -241,7 +259,13 @@
             "notes": [
                 "Public direct I/O is TimeSeriesDict-first because DiagGUI XML is product-driven.",
                 "TimeSeries and TimeSeriesMatrix readers remain registry adapters, but public guidance requires explicit format=\"xml.diaggui\" and products=..."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": {
+                "read": "available_in_base_install",
+                "write": "not_public"
+            }
         },
         {
             "name": "csv",
@@ -301,7 +325,13 @@
                 "Published CSV direct I/O is limited to TimeSeries and TimeSeriesDict.",
                 "TimeSeriesDict supports both single-file CSV reads and manifest-backed collection-directory reads and writes.",
                 "Broader registry adapters such as TimeSeriesMatrix, FrequencySeries, Spectrogram, and EventTable remain implementation surface only."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": {
+                "read": "available_in_base_install",
+                "write": "available_in_base_install"
+            }
         },
         {
             "name": "txt",
@@ -355,7 +385,13 @@
                 "Published TXT direct I/O is limited to TimeSeries files and TimeSeriesDict collection directories.",
                 "Single-series TXT reads and writes require explicit format=\"txt\".",
                 "Multi-channel TXT direct I/O uses manifest-backed collection directories rather than single text files."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": {
+                "read": "available_in_base_install",
+                "write": "available_in_base_install"
+            }
         },
         {
             "name": "pickle",
@@ -384,7 +420,13 @@
             "notes": [
                 "Pickle compatibility is currently provided through pickle.dumps()/pickle.loads() and shelve, not through published direct .read()/.write() methods.",
                 "Security guidance remains important, but Pickle is intentionally outside the public direct-I/O contract."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": {
+                "read": "not_public",
+                "write": "not_public"
+            }
         },
         {
             "name": "root",
@@ -430,7 +472,13 @@
             "notes": [
                 "Published ROOT direct I/O is intentionally limited to EventTable.",
                 "Collection .write(..., format=\"root\") helpers remain PyROOT-based interop conveniences and are not part of the published direct-I/O contract."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": {
+                "read": "available_in_base_install",
+                "write": "available_in_base_install"
+            }
         },
         {
             "name": "sdb",
@@ -472,7 +520,13 @@
                 "Published SDB direct I/O is read-only for TimeSeries and TimeSeriesDict.",
                 "The sqlite/sqlite3 tokens are aliases in the same reader family as sdb.",
                 "TimeSeriesMatrix read support remains an implementation convenience path, not a published contract entry."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": {
+                "read": "available_in_base_install",
+                "write": "not_public"
+            }
         },
         {
             "name": "wav",
@@ -515,7 +569,17 @@
                 "Published WAV direct I/O covers TimeSeries read/write and TimeSeriesDict read.",
                 "TimeSeriesMatrix read support remains an implementation convenience path until it is published explicitly.",
                 "WAV write is intentionally single-series only in the current public contract."
-            ]
+            ],
+            "optional_dependencies": [
+                "tinytag"
+            ],
+            "extras": [
+                "audio"
+            ],
+            "unavailable_behavior": {
+                "read": "raises_import_error_for_optional_metadata",
+                "write": "available_in_base_install"
+            }
         },
         {
             "name": "flac",
@@ -561,7 +625,18 @@
                 "Published FLAC direct I/O covers TimeSeries and TimeSeriesDict reads and writes.",
                 "The implementation depends on pydub; some environments also need ffmpeg/libav.",
                 "TimeSeriesMatrix adapters remain implementation conveniences."
-            ]
+            ],
+            "optional_dependencies": [
+                "pydub",
+                "tinytag"
+            ],
+            "extras": [
+                "audio"
+            ],
+            "unavailable_behavior": {
+                "read": "raises_import_error",
+                "write": "raises_import_error"
+            }
         },
         {
             "name": "ogg",
@@ -607,7 +682,18 @@
                 "Published OGG direct I/O covers TimeSeries and TimeSeriesDict reads and writes.",
                 "The implementation depends on pydub; some environments also need ffmpeg/libav.",
                 "TimeSeriesMatrix adapters remain implementation conveniences."
-            ]
+            ],
+            "optional_dependencies": [
+                "pydub",
+                "tinytag"
+            ],
+            "extras": [
+                "audio"
+            ],
+            "unavailable_behavior": {
+                "read": "raises_import_error",
+                "write": "raises_import_error"
+            }
         },
         {
             "name": "mp3",
@@ -653,7 +739,18 @@
                 "Published MP3 direct I/O covers TimeSeries and TimeSeriesDict reads and writes.",
                 "The implementation depends on pydub and typically also requires ffmpeg/libav.",
                 "TimeSeriesMatrix adapters remain implementation conveniences."
-            ]
+            ],
+            "optional_dependencies": [
+                "pydub",
+                "tinytag"
+            ],
+            "extras": [
+                "audio"
+            ],
+            "unavailable_behavior": {
+                "read": "raises_import_error",
+                "write": "raises_import_error"
+            }
         },
         {
             "name": "m4a",
@@ -699,7 +796,18 @@
                 "Published M4A direct I/O covers TimeSeries and TimeSeriesDict reads and writes.",
                 "The implementation depends on pydub and typically also requires ffmpeg/libav.",
                 "TimeSeriesMatrix adapters remain implementation conveniences."
-            ]
+            ],
+            "optional_dependencies": [
+                "pydub",
+                "tinytag"
+            ],
+            "extras": [
+                "audio"
+            ],
+            "unavailable_behavior": {
+                "read": "raises_import_error",
+                "write": "raises_import_error"
+            }
         },
         {
             "name": "gbd",
@@ -741,7 +849,13 @@
                 "Published GBD direct I/O is read-only for the TimeSeries family.",
                 "Public reads require timezone=... because the source stores local wall-clock timestamps.",
                 "GUI auto-load is not part of the published GBD contract because it cannot supply timezone implicitly."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": {
+                "read": "available_in_base_install",
+                "write": "not_public"
+            }
         },
         {
             "name": "tdms",
@@ -780,7 +894,17 @@
             "notes": [
                 "Published TDMS direct I/O is read-only for the TimeSeries family.",
                 "The implementation depends on nptdms and should raise ImportError with installation guidance when that dependency is unavailable."
-            ]
+            ],
+            "optional_dependencies": [
+                "nptdms"
+            ],
+            "extras": [
+                "io"
+            ],
+            "unavailable_behavior": {
+                "read": "raises_import_error",
+                "write": "not_public"
+            }
         },
         {
             "name": "mseed",
@@ -825,7 +949,17 @@
                 "Published MiniSEED direct I/O is collection-first through TimeSeriesDict.",
                 "The legacy alias 'miniseed' must remain equivalent to canonical 'mseed'.",
                 "Single-series and matrix registry adapters remain implementation conveniences."
-            ]
+            ],
+            "optional_dependencies": [
+                "obspy"
+            ],
+            "extras": [
+                "seismic"
+            ],
+            "unavailable_behavior": {
+                "read": "raises_import_error",
+                "write": "raises_import_error"
+            }
         },
         {
             "name": "sac",
@@ -867,7 +1001,17 @@
             "notes": [
                 "Published SAC direct I/O is collection-first through TimeSeriesDict.",
                 "Single-series and matrix registry adapters remain implementation conveniences."
-            ]
+            ],
+            "optional_dependencies": [
+                "obspy"
+            ],
+            "extras": [
+                "seismic"
+            ],
+            "unavailable_behavior": {
+                "read": "raises_import_error",
+                "write": "raises_import_error"
+            }
         },
         {
             "name": "gse2",
@@ -909,7 +1053,17 @@
             "notes": [
                 "Published GSE2 direct I/O is collection-first through TimeSeriesDict.",
                 "Single-series and matrix registry adapters remain implementation conveniences."
-            ]
+            ],
+            "optional_dependencies": [
+                "obspy"
+            ],
+            "extras": [
+                "seismic"
+            ],
+            "unavailable_behavior": {
+                "read": "raises_import_error",
+                "write": "raises_import_error"
+            }
         },
         {
             "name": "knet",
@@ -946,7 +1100,17 @@
             "notes": [
                 "Published K-NET direct I/O is read-only and collection-first through TimeSeriesDict.",
                 "Single-series and matrix registry adapters remain implementation conveniences."
-            ]
+            ],
+            "optional_dependencies": [
+                "obspy"
+            ],
+            "extras": [
+                "seismic"
+            ],
+            "unavailable_behavior": {
+                "read": "raises_import_error",
+                "write": "not_public"
+            }
         },
         {
             "name": "win",
@@ -986,7 +1150,17 @@
                 "Published WIN direct I/O is read-only and collection-first through TimeSeriesDict.",
                 "The alias 'win32' must remain equivalent to canonical 'win' at the public-contract level.",
                 "Single-series and matrix registry adapters remain implementation conveniences."
-            ]
+            ],
+            "optional_dependencies": [
+                "obspy"
+            ],
+            "extras": [
+                "seismic"
+            ],
+            "unavailable_behavior": {
+                "read": "conditional_registration",
+                "write": "not_public"
+            }
         },
         {
             "name": "ats",
@@ -1024,7 +1198,13 @@
             "notes": [
                 "Published ATS direct I/O covers TimeSeries and TimeSeriesDict reads.",
                 "TimeSeriesMatrix read support remains an implementation convenience path."
-            ]
+            ],
+            "optional_dependencies": [],
+            "extras": [],
+            "unavailable_behavior": {
+                "read": "available_in_base_install",
+                "write": "not_public"
+            }
         },
         {
             "name": "ats.mth5",
@@ -1059,7 +1239,17 @@
             "notes": [
                 "Published ATS.MTH5 direct I/O is intentionally limited to TimeSeries.read(..., format='ats.mth5').",
                 "The implementation depends on mth5 and should raise ImportError with installation guidance when that dependency is unavailable."
-            ]
+            ],
+            "optional_dependencies": [
+                "mth5"
+            ],
+            "extras": [
+                "seismic"
+            ],
+            "unavailable_behavior": {
+                "read": "raises_import_error",
+                "write": "not_public"
+            }
         },
         {
             "name": "nc",
@@ -1106,7 +1296,18 @@
             "notes": [
                 "Public direct I/O covers the TimeSeries family only.",
                 "The legacy alias 'netcdf4' must remain equivalent to the canonical 'nc' token."
-            ]
+            ],
+            "optional_dependencies": [
+                "xarray",
+                "netCDF4"
+            ],
+            "extras": [
+                "netcdf4"
+            ],
+            "unavailable_behavior": {
+                "read": "raises_import_error",
+                "write": "raises_import_error"
+            }
         },
         {
             "name": "zarr",
@@ -1153,7 +1354,17 @@
             "notes": [
                 "Public direct I/O covers the TimeSeries family only.",
                 "Legacy stores without timing metadata are recoverable only through explicit sample_rate_override or dt_override."
-            ]
+            ],
+            "optional_dependencies": [
+                "zarr"
+            ],
+            "extras": [
+                "zarr"
+            ],
+            "unavailable_behavior": {
+                "read": "raises_import_error",
+                "write": "raises_import_error"
+            }
         }
     ]
 }

--- a/docs/developers/contracts/public_io_contract.md
+++ b/docs/developers/contracts/public_io_contract.md
@@ -30,6 +30,12 @@ Each format entry contains these fields:
 - `registry_auto_identify`: whether the current implementation can identify the format automatically
 - `required_args`: operation-specific required keyword arguments
 - `trusted_only`: whether the format must be restricted to trusted data
+- `optional_dependencies`: optional import/package names used by the published
+  route, or an empty list when the base install is sufficient
+- `extras`: declared GWexpy extras that install those optional dependencies, or
+  an empty list for base-install or bare-package policy
+- `unavailable_behavior`: operation-specific behavior when the optional backend
+  is unavailable
 - `metadata_requirements`: extra metadata rules that are part of the public contract
 - `notes`: short rationale and boundary notes
 
@@ -38,6 +44,12 @@ Rules:
 - `public_api` must be a subset of `registry_api ∪ direct_api`.
 - `public_auto_identify` may be stricter than `registry_auto_identify`.
 - `required_args` and `metadata_requirements` are contract items, not optional commentary.
+- `unavailable_behavior` uses a small vocabulary:
+  `available_in_base_install`, `raises_import_error`,
+  `raises_import_error_for_optional_metadata`, `conditional_registration`, or
+  `not_public`.
+- Public registry entries may be absent only when
+  `unavailable_behavior.<operation> = conditional_registration`.
 - A registry adapter alone is not enough to publish a new direct-I/O surface.
 - A class-level direct implementation alone is not enough to publish a new direct-I/O surface.
 
@@ -134,6 +146,10 @@ These decisions are fixed before expanding P1/P2/P3 coverage:
 - Public contract: `TimeSeriesDict` read only.
 - Registry surface: `TimeSeries` and `TimeSeriesMatrix` read adapters may
   exist.
+- Optional dependency: `obspy` from the `seismic` extra.
+- `win` / `win32` use conditional registration: when ObsPy is unavailable, the
+  registry entry may be absent instead of a registered reader raising
+  `ImportError`.
 - Reason: these formats are intentionally documented as collection-first and
   read-only.
 
@@ -148,8 +164,9 @@ These decisions are fixed before expanding P1/P2/P3 coverage:
 ### `ats.mth5`
 
 - Public contract: `TimeSeries` read only.
-- Optional dependency: published reads require `mth5`; missing dependency
-  should raise a format-specific `ImportError`.
+- Optional dependency: published reads require `mth5`, available through the
+  `seismic` extra; missing dependency should raise a format-specific
+  `ImportError`.
 - Reason: this is the only currently published MTH5-backed direct path and it
   remains intentionally narrow.
 

--- a/docs/web/en/user_guide/installation.md
+++ b/docs/web/en/user_guide/installation.md
@@ -116,7 +116,7 @@ pip install -e ".[dev,all]"
 | `netcdf4` | `netCDF4`, `xarray` | Reading and writing NetCDF4 time-series files via xarray. |
 | `zarr` | `zarr` | Reading and writing Zarr array stores. |
 | `plotting` | `pygmt` | High-precision geographic mapping (GeoMap). |
-| `audio` | `pydub` | Audio export and processing. |
+| `audio` | `pydub`, `tinytag` | Audio export, processing, and optional metadata extraction. |
 | `seismic` | `obspy`, `mth5`, `mtpy` | Seismic and magnetotelluric data. |
 | `control` | `control` (python-control) | Control systems and transfer functions. |
 | `gui` | `PyQt5`, `pyqtgraph` | Graphical interface (prototype stage). Not included in `all`. |

--- a/docs/web/en/user_guide/interop.md
+++ b/docs/web/en/user_guide/interop.md
@@ -88,15 +88,22 @@ importing the backend at `import gwexpy` time.
 Some import-only adapters consume objects or dictionaries that were produced by
 external packages, but do not import those producer packages themselves. For
 example, `from_pyoma_results()`, `from_mtspec()`, `from_mtspec_array()`,
-`from_uff_dataset55()`, `from_uff_dataset58()`, and the `from_sdynpy_*()`
-helpers accept caller-supplied pyOMA, multitaper, mtspec, pyuff, or SDynPy-style
-objects. Install those packages when you need to create the source objects, not
-because the adapter imports them directly.
+`from_uff_dataset55()`, `from_uff_dataset58()`, the `from_sdynpy_*()`,
+`from_metpy_dataarray()`, `from_wrf_variable()`, and `from_harmonica_grid()`
+helpers accept caller-supplied pyOMA, multitaper, mtspec, pyuff, SDynPy-style,
+MetPy-enhanced, wrf-python, or Harmonica objects. Install those packages when
+you need to create the source objects, not because the adapter imports them
+directly.
 
 | Policy | Dependencies | Install guidance |
 | --- | --- | --- |
-| Declared GWexpy extras | `zarr`, `netCDF4`, `xarray`, `obspy`, `mth5`, `lalsuite`, `gwinc`, `finesse`, `control`, `pydub` | Use `pip install 'gwexpy[zarr]'`, `pip install 'gwexpy[netcdf4]'`, `pip install 'gwexpy[seismic]'`, `pip install 'gwexpy[gw]'`, `pip install 'gwexpy[control]'`, or `pip install 'gwexpy[audio]'` as appropriate. |
-| Bare package installs | `ROOT`, `polars`, `dask`, `torch`, `tensorflow`, `jax`, `cupy`, `pycbc`, `simpeg`, `mne`, `neo`, `quantities`, `pyroomacoustics`, `specutils`, `pyspeckit`, `PySpice`, `skrf`, `pyOMA`, `multitaper`, `mtspec`, `pyuff`, `sdynpy`, `emg3d`, `meshio` | Install the named backend directly when the bridge imports it or when you need it to create accepted source objects. |
+| Declared GWexpy extras | `zarr`, `netCDF4`, `xarray`, `obspy`, `mth5`, `lalsuite`, `gwinc`, `control`, `pydub` | Use `pip install 'gwexpy[zarr]'`, `pip install 'gwexpy[netcdf4]'`, `pip install 'gwexpy[seismic]'`, `pip install 'gwexpy[gw]'`, `pip install 'gwexpy[control]'`, or `pip install 'gwexpy[audio]'` as appropriate. |
+| Bare package installs | `ROOT`, `polars`, `dask`, `torch`, `tensorflow`, `jax`, `cupy`, `pycbc`, `finesse`, `simpeg`, `mne`, `neo`, `quantities`, `pyroomacoustics`, `specutils`, `pyspeckit`, `PySpice`, `skrf`, `pyOMA`, `multitaper`, `mtspec`, `pyuff`, `sdynpy`, `metpy`, `wrf-python`, `harmonica`, `emg3d`, `meshio` | Install the named backend directly when the bridge imports it or when you need it to create accepted source objects. |
+
+The xarray-backed interop bridges list the `netcdf4` extra because GWexpy does
+not currently publish a standalone `xarray` extra. If you only need in-memory
+xarray conversion and want to avoid installing `netCDF4`, install `xarray`
+directly.
 
 (interop-en-storage-conversion)=
 ## A. Storage Formats and Container Conversion

--- a/docs/web/en/user_guide/interop.md
+++ b/docs/web/en/user_guide/interop.md
@@ -79,6 +79,17 @@ Legacy aliases remain supported during the transition, but new examples should p
 - `In progress`: the implementation or the public presentation is not finished yet
 - `Planned`: explicitly in scope, but not implemented yet
 
+## Optional Dependency Policy
+
+Interop bridges import optional backends lazily. If a backend is missing, the
+bridge raises `ImportError` with installation guidance instead of importing the
+backend at `import gwexpy` time.
+
+| Policy | Dependencies | Install guidance |
+| --- | --- | --- |
+| Declared GWexpy extras | `zarr`, `netCDF4`, `xarray`, `obspy`, `mth5`, `lalsuite`, `gwinc`, `finesse`, `control`, `pydub` | Use `pip install 'gwexpy[zarr]'`, `pip install 'gwexpy[netcdf4]'`, `pip install 'gwexpy[seismic]'`, `pip install 'gwexpy[gw]'`, `pip install 'gwexpy[control]'`, or `pip install 'gwexpy[audio]'` as appropriate. |
+| Bare package installs | `ROOT`, `polars`, `dask`, `torch`, `tensorflow`, `jax`, `cupy`, `pycbc`, `simpeg`, `mne`, `neo`, `quantities`, `pyroomacoustics`, `specutils`, `pyspeckit`, `PySpice`, `skrf`, `pyOMA`, `multitaper`, `mtspec`, `pyuff`, `sdynpy`, `emg3d`, `meshio` | Install the named backend directly when the bridge you are using requires it. |
+
 (interop-en-storage-conversion)=
 ## A. Storage Formats and Container Conversion
 

--- a/docs/web/en/user_guide/interop.md
+++ b/docs/web/en/user_guide/interop.md
@@ -81,14 +81,22 @@ Legacy aliases remain supported during the transition, but new examples should p
 
 ## Optional Dependency Policy
 
-Interop bridges import optional backends lazily. If a backend is missing, the
-bridge raises `ImportError` with installation guidance instead of importing the
-backend at `import gwexpy` time.
+Interop bridges import optional runtime backends lazily. If a runtime backend is
+missing, the bridge raises `ImportError` with installation guidance instead of
+importing the backend at `import gwexpy` time.
+
+Some import-only adapters consume objects or dictionaries that were produced by
+external packages, but do not import those producer packages themselves. For
+example, `from_pyoma_results()`, `from_mtspec()`, `from_mtspec_array()`,
+`from_uff_dataset55()`, `from_uff_dataset58()`, and the `from_sdynpy_*()`
+helpers accept caller-supplied pyOMA, multitaper, mtspec, pyuff, or SDynPy-style
+objects. Install those packages when you need to create the source objects, not
+because the adapter imports them directly.
 
 | Policy | Dependencies | Install guidance |
 | --- | --- | --- |
 | Declared GWexpy extras | `zarr`, `netCDF4`, `xarray`, `obspy`, `mth5`, `lalsuite`, `gwinc`, `finesse`, `control`, `pydub` | Use `pip install 'gwexpy[zarr]'`, `pip install 'gwexpy[netcdf4]'`, `pip install 'gwexpy[seismic]'`, `pip install 'gwexpy[gw]'`, `pip install 'gwexpy[control]'`, or `pip install 'gwexpy[audio]'` as appropriate. |
-| Bare package installs | `ROOT`, `polars`, `dask`, `torch`, `tensorflow`, `jax`, `cupy`, `pycbc`, `simpeg`, `mne`, `neo`, `quantities`, `pyroomacoustics`, `specutils`, `pyspeckit`, `PySpice`, `skrf`, `pyOMA`, `multitaper`, `mtspec`, `pyuff`, `sdynpy`, `emg3d`, `meshio` | Install the named backend directly when the bridge you are using requires it. |
+| Bare package installs | `ROOT`, `polars`, `dask`, `torch`, `tensorflow`, `jax`, `cupy`, `pycbc`, `simpeg`, `mne`, `neo`, `quantities`, `pyroomacoustics`, `specutils`, `pyspeckit`, `PySpice`, `skrf`, `pyOMA`, `multitaper`, `mtspec`, `pyuff`, `sdynpy`, `emg3d`, `meshio` | Install the named backend directly when the bridge imports it or when you need it to create accepted source objects. |
 
 (interop-en-storage-conversion)=
 ## A. Storage Formats and Container Conversion

--- a/docs/web/en/user_guide/io_formats.md
+++ b/docs/web/en/user_guide/io_formats.md
@@ -118,6 +118,22 @@ If the main question is whether a format is for a single channel or multiple cha
 - `TimeSeriesMatrix` mainly matters for `NetCDF4`, `Zarr`, `GBD`, and `TDMS`.
 - If you need to preserve richer objects beyond Series classes, start with **HDF5**.
 
+## Optional Dependency Matrix
+
+Most direct-I/O routes work in a base GWexpy install. The formats below depend
+on optional packages or optional metadata helpers.
+
+| Format / family | Optional dependency | GWexpy extra | Missing-dependency behavior |
+|---|---|---|---|
+| **WAV metadata** | `tinytag` | `audio` | `.read(..., extract_metadata=True)` raises `ImportError`; basic WAV read/write remains available. |
+| **MP3 / FLAC / OGG / M4A** | `pydub`, `tinytag` | `audio` | Audio read/write raises `ImportError`; some codecs also need an external `ffmpeg`/`libav` binary. |
+| **TDMS** | `nptdms` | `io` | Reader raises `ImportError` with `pip install 'gwexpy[io]'` guidance. |
+| **mseed / SAC / GSE2 / K-NET** | `obspy` | `seismic` | Registered reader/writer raises `ImportError` with `pip install 'gwexpy[seismic]'` guidance. |
+| **WIN / WIN32** | `obspy` | `seismic` | Uses conditional registration: when ObsPy is unavailable, the `win` / `win32` registry entries may be absent. |
+| **ATS.MTH5** | `mth5` | `seismic` | Reader raises `ImportError` with `pip install 'gwexpy[seismic]'` guidance. |
+| **nc / NetCDF4** | `xarray`, `netCDF4` | `netcdf4` | Reader/writer raises `ImportError` with `pip install 'gwexpy[netcdf4]'` guidance. |
+| **Zarr** | `zarr` | `zarr` | Reader/writer raises `ImportError` with `pip install 'gwexpy[zarr]'` guidance. |
+
 <a id="io-formats-en-a"></a>
 
 ## A. GW Standards

--- a/docs/web/ja/user_guide/installation.md
+++ b/docs/web/ja/user_guide/installation.md
@@ -113,8 +113,10 @@ pip install -e ".[dev,all]"
 | `fitting` | `iminuit`, `emcee`, `corner` | 最小二乗法、MCMC 解析。 |
 | `gw` | `lalsuite`, `gwosc`, `gwinc`, `ligo.skymap` | 重力波データ検索、感度計算、スカイマップ描画。 |
 | `io` | `nptdms` | LabVIEW TDMS 形式の読み込み。 |
+| `netcdf4` | `netCDF4`, `xarray` | xarray 経由の NetCDF4 時系列ファイルの読み書き。 |
+| `zarr` | `zarr` | Zarr array store の読み書き。 |
 | `plotting` | `pygmt` | 高精度な地図投影（GeoMap）。 |
-| `audio` | `pydub` | 音声書き出し、オーディオ解析。 |
+| `audio` | `pydub`, `tinytag` | 音声書き出し、オーディオ解析、任意のメタデータ抽出。 |
 | `seismic` | `obspy`, `mth5`, `mtpy` | 地震・地磁気データ解析。 |
 | `control` | `control` (python-control) | 制御系モデル・伝達関数解析。 |
 | `gui` | `PyQt5`, `pyqtgraph` | グラフィカルインターフェース（試作段階）。 |

--- a/docs/web/ja/user_guide/interop.md
+++ b/docs/web/ja/user_guide/interop.md
@@ -81,12 +81,14 @@ myst:
 
 ## オプション依存関係の方針
 
-Interop bridge は optional backend を遅延 import します。backend が未導入の場合、`import gwexpy` の時点ではなく、該当 bridge を呼び出した時点でインストール案内付きの `ImportError` を送出します。
+Interop bridge は runtime optional backend を遅延 import します。runtime backend が未導入の場合、`import gwexpy` の時点ではなく、該当 bridge を呼び出した時点でインストール案内付きの `ImportError` を送出します。
+
+import 中心の adapter の一部は、外部 package が生成した object や dict を受け取りますが、その producer package 自体は import しません。たとえば `from_pyoma_results()`, `from_mtspec()`, `from_mtspec_array()`, `from_uff_dataset55()`, `from_uff_dataset58()`, `from_sdynpy_*()` は、呼び出し側が渡す pyOMA, multitaper, mtspec, pyuff, SDynPy 形式の object を消費します。これらの package は source object を作る必要がある場合に導入してください。adapter が直接 import するためではありません。
 
 | 方針 | 依存関係 | インストール案内 |
 | --- | --- | --- |
 | GWexpy extras で宣言済み | `zarr`, `netCDF4`, `xarray`, `obspy`, `mth5`, `lalsuite`, `gwinc`, `finesse`, `control`, `pydub` | 必要に応じて `pip install 'gwexpy[zarr]'`, `pip install 'gwexpy[netcdf4]'`, `pip install 'gwexpy[seismic]'`, `pip install 'gwexpy[gw]'`, `pip install 'gwexpy[control]'`, `pip install 'gwexpy[audio]'` を使います。 |
-| 個別 package install | `ROOT`, `polars`, `dask`, `torch`, `tensorflow`, `jax`, `cupy`, `pycbc`, `simpeg`, `mne`, `neo`, `quantities`, `pyroomacoustics`, `specutils`, `pyspeckit`, `PySpice`, `skrf`, `pyOMA`, `multitaper`, `mtspec`, `pyuff`, `sdynpy`, `emg3d`, `meshio` | 利用する bridge が必要とする backend を個別に導入してください。 |
+| 個別 package install | `ROOT`, `polars`, `dask`, `torch`, `tensorflow`, `jax`, `cupy`, `pycbc`, `simpeg`, `mne`, `neo`, `quantities`, `pyroomacoustics`, `specutils`, `pyspeckit`, `PySpice`, `skrf`, `pyOMA`, `multitaper`, `mtspec`, `pyuff`, `sdynpy`, `emg3d`, `meshio` | bridge が直接 import する場合、または受け渡す source object を作る必要がある場合に、該当 backend を個別に導入してください。 |
 
 (interop-ja-storage-conversion)=
 ## A. 保存形式・コンテナ変換

--- a/docs/web/ja/user_guide/interop.md
+++ b/docs/web/ja/user_guide/interop.md
@@ -83,12 +83,14 @@ myst:
 
 Interop bridge は runtime optional backend を遅延 import します。runtime backend が未導入の場合、`import gwexpy` の時点ではなく、該当 bridge を呼び出した時点でインストール案内付きの `ImportError` を送出します。
 
-import 中心の adapter の一部は、外部 package が生成した object や dict を受け取りますが、その producer package 自体は import しません。たとえば `from_pyoma_results()`, `from_mtspec()`, `from_mtspec_array()`, `from_uff_dataset55()`, `from_uff_dataset58()`, `from_sdynpy_*()` は、呼び出し側が渡す pyOMA, multitaper, mtspec, pyuff, SDynPy 形式の object を消費します。これらの package は source object を作る必要がある場合に導入してください。adapter が直接 import するためではありません。
+import 中心の adapter の一部は、外部 package が生成した object や dict を受け取りますが、その producer package 自体は import しません。たとえば `from_pyoma_results()`, `from_mtspec()`, `from_mtspec_array()`, `from_uff_dataset55()`, `from_uff_dataset58()`, `from_sdynpy_*()`, `from_metpy_dataarray()`, `from_wrf_variable()`, `from_harmonica_grid()` は、呼び出し側が渡す pyOMA, multitaper, mtspec, pyuff, SDynPy, MetPy, wrf-python, Harmonica 形式の object を消費します。これらの package は source object を作る必要がある場合に導入してください。adapter が直接 import するためではありません。
 
 | 方針 | 依存関係 | インストール案内 |
 | --- | --- | --- |
-| GWexpy extras で宣言済み | `zarr`, `netCDF4`, `xarray`, `obspy`, `mth5`, `lalsuite`, `gwinc`, `finesse`, `control`, `pydub` | 必要に応じて `pip install 'gwexpy[zarr]'`, `pip install 'gwexpy[netcdf4]'`, `pip install 'gwexpy[seismic]'`, `pip install 'gwexpy[gw]'`, `pip install 'gwexpy[control]'`, `pip install 'gwexpy[audio]'` を使います。 |
-| 個別 package install | `ROOT`, `polars`, `dask`, `torch`, `tensorflow`, `jax`, `cupy`, `pycbc`, `simpeg`, `mne`, `neo`, `quantities`, `pyroomacoustics`, `specutils`, `pyspeckit`, `PySpice`, `skrf`, `pyOMA`, `multitaper`, `mtspec`, `pyuff`, `sdynpy`, `emg3d`, `meshio` | bridge が直接 import する場合、または受け渡す source object を作る必要がある場合に、該当 backend を個別に導入してください。 |
+| GWexpy extras で宣言済み | `zarr`, `netCDF4`, `xarray`, `obspy`, `mth5`, `lalsuite`, `gwinc`, `control`, `pydub` | 必要に応じて `pip install 'gwexpy[zarr]'`, `pip install 'gwexpy[netcdf4]'`, `pip install 'gwexpy[seismic]'`, `pip install 'gwexpy[gw]'`, `pip install 'gwexpy[control]'`, `pip install 'gwexpy[audio]'` を使います。 |
+| 個別 package install | `ROOT`, `polars`, `dask`, `torch`, `tensorflow`, `jax`, `cupy`, `pycbc`, `finesse`, `simpeg`, `mne`, `neo`, `quantities`, `pyroomacoustics`, `specutils`, `pyspeckit`, `PySpice`, `skrf`, `pyOMA`, `multitaper`, `mtspec`, `pyuff`, `sdynpy`, `metpy`, `wrf-python`, `harmonica`, `emg3d`, `meshio` | bridge が直接 import する場合、または受け渡す source object を作る必要がある場合に、該当 backend を個別に導入してください。 |
+
+xarray 系の interop bridge は、GWexpy が独立した `xarray` extra を公開していないため `netcdf4` extra を案内します。メモリ上の xarray 変換だけが必要で `netCDF4` を入れたくない場合は、`xarray` を個別に導入してください。
 
 (interop-ja-storage-conversion)=
 ## A. 保存形式・コンテナ変換

--- a/docs/web/ja/user_guide/interop.md
+++ b/docs/web/ja/user_guide/interop.md
@@ -79,6 +79,15 @@ myst:
 - `対応中`: 専用の実装面または公開面の整理が未完
 - `対応予定`: 設計対象として明示するが、まだ実装がない
 
+## オプション依存関係の方針
+
+Interop bridge は optional backend を遅延 import します。backend が未導入の場合、`import gwexpy` の時点ではなく、該当 bridge を呼び出した時点でインストール案内付きの `ImportError` を送出します。
+
+| 方針 | 依存関係 | インストール案内 |
+| --- | --- | --- |
+| GWexpy extras で宣言済み | `zarr`, `netCDF4`, `xarray`, `obspy`, `mth5`, `lalsuite`, `gwinc`, `finesse`, `control`, `pydub` | 必要に応じて `pip install 'gwexpy[zarr]'`, `pip install 'gwexpy[netcdf4]'`, `pip install 'gwexpy[seismic]'`, `pip install 'gwexpy[gw]'`, `pip install 'gwexpy[control]'`, `pip install 'gwexpy[audio]'` を使います。 |
+| 個別 package install | `ROOT`, `polars`, `dask`, `torch`, `tensorflow`, `jax`, `cupy`, `pycbc`, `simpeg`, `mne`, `neo`, `quantities`, `pyroomacoustics`, `specutils`, `pyspeckit`, `PySpice`, `skrf`, `pyOMA`, `multitaper`, `mtspec`, `pyuff`, `sdynpy`, `emg3d`, `meshio` | 利用する bridge が必要とする backend を個別に導入してください。 |
+
 (interop-ja-storage-conversion)=
 ## A. 保存形式・コンテナ変換
 

--- a/docs/web/ja/user_guide/io_formats.md
+++ b/docs/web/ja/user_guide/io_formats.md
@@ -118,6 +118,21 @@ ts = TimeSeries.fetch_open_data("H1", 1126259446, 1126259478)
 - **`TimeSeriesMatrix` が出てくるのは主に** `NetCDF4`, `Zarr`, `GBD`, `TDMS` です。
 - **Series 以外もまとめて保持したい** 場合は、まず **HDF5** を検討してください。
 
+## オプション依存関係の対応表
+
+多くの direct I/O 経路は GWexpy の基本インストールで利用できます。次の形式は optional package または optional metadata helper に依存します。
+
+| 形式 / 系統 | オプション依存関係 | GWexpy extra | 未導入時の挙動 |
+|---|---|---|---|
+| **WAV metadata** | `tinytag` | `audio` | `.read(..., extract_metadata=True)` は `ImportError` を送出します。通常の WAV 読み書きは利用できます。 |
+| **MP3 / FLAC / OGG / M4A** | `pydub`, `tinytag` | `audio` | 音声の読み書きは `ImportError` を送出します。一部 codec は外部の `ffmpeg` / `libav` も必要です。 |
+| **TDMS** | `nptdms` | `io` | reader は `pip install 'gwexpy[io]'` の案内付きで `ImportError` を送出します。 |
+| **mseed / SAC / GSE2 / K-NET** | `obspy` | `seismic` | 登録済みの reader / writer は `pip install 'gwexpy[seismic]'` の案内付きで `ImportError` を送出します。 |
+| **WIN / WIN32** | `obspy` | `seismic` | 条件付き登録です。ObsPy がない環境では `win` / `win32` の registry entry 自体が存在しない場合があります。 |
+| **ATS.MTH5** | `mth5` | `seismic` | reader は `pip install 'gwexpy[seismic]'` の案内付きで `ImportError` を送出します。 |
+| **nc / NetCDF4** | `xarray`, `netCDF4` | `netcdf4` | reader / writer は `pip install 'gwexpy[netcdf4]'` の案内付きで `ImportError` を送出します。 |
+| **Zarr** | `zarr` | `zarr` | reader / writer は `pip install 'gwexpy[zarr]'` の案内付きで `ImportError` を送出します。 |
+
 <a id="io-formats-ja-a"></a>
 
 ## A. GW標準

--- a/gwexpy/interop/_optional.py
+++ b/gwexpy/interop/_optional.py
@@ -85,13 +85,11 @@ _EXTRA_MAP: dict[str, str | None] = {
     # gw: Gravitational wave data access and tools
     "lalsuite": "gw",
     "lal": "gw",
-    "pycbc": "gw",
     "gwdatafind": "gw",
     "gwosc": "gw",
     "dqsegdb2": "gw",
     "dttxml": "gw",
     "gwinc": "gw",
-    "finesse": "gw",
     "ligo.skymap": "gw",
     # io: Experimental data I/O
     "nptdms": "io",
@@ -122,6 +120,8 @@ _EXTRA_MAP: dict[str, str | None] = {
     "cupy": None,
     "mne": None,
     "neo": None,
+    "pycbc": None,
+    "finesse": None,
     "polars": None,
     "joblib": None,
     "librosa": None,

--- a/tests/interop/test_errors_and_optional.py
+++ b/tests/interop/test_errors_and_optional.py
@@ -135,6 +135,18 @@ class TestRequireOptional:
         assert "gwexpy[audio]" not in msg
         assert "gwexpy[all]" not in msg
 
+    @pytest.mark.parametrize("name", ["finesse", "pycbc"])
+    def test_contract_bare_install_interop_packages_use_bare_install(self, name):
+        """Interop packages with extras: [] should not suggest a GWexpy extra."""
+        with patch.dict(sys.modules, {name: None}):
+            with pytest.raises(ImportError) as excinfo:
+                require_optional(name)
+
+        msg = str(excinfo.value)
+        assert f"pip install {name}" in msg
+        assert "gwexpy[gw]" not in msg
+        assert "gwexpy[all]" not in msg
+
     def test_dask_array_uses_distribution_name_in_install_hint(self):
         """dask.array is an import namespace; users install the dask package."""
         with patch.dict(sys.modules, {"dask": None, "dask.array": None}):

--- a/tests/interop/test_interop_contract.py
+++ b/tests/interop/test_interop_contract.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import importlib
 import json
+import tomllib
 from pathlib import Path
 
 import gwexpy.interop as interop
 
 ROOT = Path(__file__).resolve().parents[2]
 CONTRACT_PATH = ROOT / "docs/developers/contracts/public_interop_contract.json"
+PYPROJECT_PATH = ROOT / "pyproject.toml"
 EN_REF_INDEX = ROOT / "docs/web/en/reference/api/interop.rst"
 JA_REF_INDEX = ROOT / "docs/web/ja/reference/api/interop.rst"
 
@@ -40,6 +42,20 @@ VALID_UNAVAILABLE_BEHAVIORS = {
 def _load_contract() -> list[dict]:
     data = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
     return data["targets"]
+
+
+def _package_name(requirement: str) -> str:
+    return (
+        requirement.split(";", maxsplit=1)[0]
+        .split("[", maxsplit=1)[0]
+        .split(">", maxsplit=1)[0]
+        .split("<", maxsplit=1)[0]
+        .split("=", maxsplit=1)[0]
+        .split("!", maxsplit=1)[0]
+        .split("~", maxsplit=1)[0]
+        .strip()
+        .lower()
+    )
 
 
 TARGETS = _load_contract()
@@ -190,3 +206,43 @@ def test_import_only_source_packages_are_not_runtime_dependencies():
         assert entry["optional_dependencies"] == []
         assert entry["extras"] == []
         assert entry["unavailable_behavior"] == "available_in_base_install"
+
+
+def test_xarray_source_adapters_distinguish_runtime_from_producer_packages():
+    entries = {entry["name"]: entry for entry in TARGETS}
+
+    expected_source_dependencies = {
+        "metpy": ["metpy"],
+        "wrf": ["wrf-python"],
+        "harmonica": ["harmonica"],
+    }
+
+    for name, source_dependencies in expected_source_dependencies.items():
+        entry = entries[name]
+        assert entry["source_dependencies"] == source_dependencies
+        assert entry["optional_dependencies"] == ["xarray"]
+        assert entry["extras"] == ["netcdf4"]
+        assert entry["unavailable_behavior"] == "raises_import_error"
+
+
+def test_declared_extras_contain_runtime_dependencies():
+    """Contract extras must install the runtime packages they advertise."""
+    pyproject = tomllib.loads(PYPROJECT_PATH.read_text(encoding="utf-8"))
+    optional_dependency_groups = pyproject["project"]["optional-dependencies"]
+    normalized_extras = {
+        extra: {_package_name(requirement) for requirement in requirements}
+        for extra, requirements in optional_dependency_groups.items()
+    }
+
+    for entry in TARGETS:
+        for extra in entry["extras"]:
+            installed_packages = normalized_extras[extra]
+            missing_dependencies = [
+                dependency
+                for dependency in entry["optional_dependencies"]
+                if dependency.lower() not in installed_packages
+            ]
+            assert missing_dependencies == [], (
+                f"{entry['name']} declares extra {extra!r}, but that extra does not "
+                f"install runtime dependencies: {missing_dependencies}"
+            )

--- a/tests/interop/test_interop_contract.py
+++ b/tests/interop/test_interop_contract.py
@@ -67,6 +67,10 @@ def test_interop_contract_schema_is_well_formed():
         assert len(entry["optional_dependencies"]) == len(
             set(entry["optional_dependencies"])
         )
+        source_dependencies = entry.get("source_dependencies", [])
+        assert isinstance(source_dependencies, list)
+        assert all(isinstance(name, str) and name for name in source_dependencies)
+        assert len(source_dependencies) == len(set(source_dependencies))
         assert isinstance(entry["extras"], list)
         assert all(extra in VALID_EXTRAS for extra in entry["extras"])
         assert len(entry["extras"]) == len(set(entry["extras"]))
@@ -167,3 +171,22 @@ def test_non_public_module_backed_targets_are_explicit_exceptions():
         if entry["module"] is not None and entry["status"] != "public"
     ]
     assert non_public_module_backed == ["root"]
+
+
+def test_import_only_source_packages_are_not_runtime_dependencies():
+    entries = {entry["name"]: entry for entry in TARGETS}
+
+    expected_source_dependencies = {
+        "pyoma": ["pyOMA"],
+        "multitaper": ["multitaper"],
+        "mtspec": ["mtspec"],
+        "sdypy": ["pyuff"],
+        "sdynpy": ["sdynpy"],
+    }
+
+    for name, source_dependencies in expected_source_dependencies.items():
+        entry = entries[name]
+        assert entry["source_dependencies"] == source_dependencies
+        assert entry["optional_dependencies"] == []
+        assert entry["extras"] == []
+        assert entry["unavailable_behavior"] == "available_in_base_install"

--- a/tests/interop/test_interop_contract.py
+++ b/tests/interop/test_interop_contract.py
@@ -8,6 +8,7 @@ import tomllib
 from pathlib import Path
 
 import gwexpy.interop as interop
+from gwexpy.interop._optional import _EXTRA_MAP
 
 ROOT = Path(__file__).resolve().parents[2]
 CONTRACT_PATH = ROOT / "docs/developers/contracts/public_interop_contract.json"
@@ -245,4 +246,17 @@ def test_declared_extras_contain_runtime_dependencies():
             assert missing_dependencies == [], (
                 f"{entry['name']} declares extra {extra!r}, but that extra does not "
                 f"install runtime dependencies: {missing_dependencies}"
+            )
+
+
+def test_contract_entries_without_extras_do_not_map_runtime_deps_to_extra():
+    """Runtime packages for extras: [] entries must use bare install hints."""
+    for entry in TARGETS:
+        if entry["extras"]:
+            continue
+
+        for dependency in entry["optional_dependencies"]:
+            assert _EXTRA_MAP.get(dependency) is None, (
+                f"{entry['name']} has extras: [] but {dependency!r} maps to "
+                f"GWexpy extra {_EXTRA_MAP[dependency]!r}"
             )

--- a/tests/interop/test_interop_contract.py
+++ b/tests/interop/test_interop_contract.py
@@ -21,6 +21,21 @@ VALID_STATUSES = {
     "planned",
 }
 
+VALID_EXTRAS = {
+    "audio",
+    "control",
+    "gw",
+    "netcdf4",
+    "seismic",
+    "zarr",
+}
+
+VALID_UNAVAILABLE_BEHAVIORS = {
+    "available_in_base_install",
+    "not_applicable",
+    "raises_import_error",
+}
+
 
 def _load_contract() -> list[dict]:
     data = json.loads(CONTRACT_PATH.read_text(encoding="utf-8"))
@@ -45,6 +60,17 @@ def test_interop_contract_schema_is_well_formed():
         assert entry["status"] in VALID_STATUSES
         assert isinstance(entry["guide_api"], list)
         assert all(isinstance(name, str) and name for name in entry["guide_api"])
+        assert isinstance(entry["optional_dependencies"], list)
+        assert all(
+            isinstance(name, str) and name for name in entry["optional_dependencies"]
+        )
+        assert len(entry["optional_dependencies"]) == len(
+            set(entry["optional_dependencies"])
+        )
+        assert isinstance(entry["extras"], list)
+        assert all(extra in VALID_EXTRAS for extra in entry["extras"])
+        assert len(entry["extras"]) == len(set(entry["extras"]))
+        assert entry["unavailable_behavior"] in VALID_UNAVAILABLE_BEHAVIORS
         assert isinstance(entry["row_match_en"], str) and entry["row_match_en"]
         assert isinstance(entry["row_match_ja"], str) and entry["row_match_ja"]
         assert isinstance(entry["reference_indexed"], bool)
@@ -63,6 +89,7 @@ def test_interop_contract_schema_is_well_formed():
             assert isinstance(module, str) and module
         else:
             assert module is None
+            assert entry["unavailable_behavior"] == "not_applicable"
 
 
 def test_public_namespace_is_fully_covered_by_contract():

--- a/tests/interop/test_interop_docs_contract_sync.py
+++ b/tests/interop/test_interop_docs_contract_sync.py
@@ -9,6 +9,8 @@ ROOT = Path(__file__).resolve().parents[2]
 CONTRACT_PATH = ROOT / "docs/developers/contracts/public_interop_contract.json"
 EN_GUIDE = ROOT / "docs/web/en/user_guide/interop.md"
 JA_GUIDE = ROOT / "docs/web/ja/user_guide/interop.md"
+EN_INSTALL = ROOT / "docs/web/en/user_guide/installation.md"
+JA_INSTALL = ROOT / "docs/web/ja/user_guide/installation.md"
 
 STATUS_LABELS_EN = {
     "public": "Public",
@@ -115,3 +117,25 @@ def test_contract_covers_all_documented_interop_rows():
 
     assert contract_en_rows == expected_en_rows
     assert contract_ja_rows == expected_ja_rows
+
+
+def test_optional_dependency_policy_matches_contract():
+    contract = _load_contract()
+    en_docs = _read(EN_GUIDE)
+    ja_docs = _read(JA_GUIDE)
+    en_install = _read(EN_INSTALL)
+    ja_install = _read(JA_INSTALL)
+
+    for entry in contract:
+        for dependency in entry["optional_dependencies"]:
+            assert f"`{dependency}`" in en_docs
+            assert f"`{dependency}`" in ja_docs
+        for extra in entry["extras"]:
+            assert f"`{extra}`" in en_install
+            assert f"`{extra}`" in ja_install
+
+    mth5 = {entry["name"]: entry for entry in contract}["mth5"]
+    assert mth5["optional_dependencies"] == ["mth5"]
+    assert mth5["extras"] == ["seismic"]
+    assert "pip install 'gwexpy[seismic]'" in en_docs
+    assert "pip install 'gwexpy[seismic]'" in ja_docs

--- a/tests/interop/test_interop_docs_contract_sync.py
+++ b/tests/interop/test_interop_docs_contract_sync.py
@@ -127,6 +127,9 @@ def test_optional_dependency_policy_matches_contract():
     ja_install = _read(JA_INSTALL)
 
     for entry in contract:
+        for dependency in entry.get("source_dependencies", []):
+            assert f"`{dependency}`" in en_docs
+            assert f"`{dependency}`" in ja_docs
         for dependency in entry["optional_dependencies"]:
             assert f"`{dependency}`" in en_docs
             assert f"`{dependency}`" in ja_docs

--- a/tests/io/test_io_contract.py
+++ b/tests/io/test_io_contract.py
@@ -90,6 +90,12 @@ def _writer_callable(fmt: str, cls):
         return None
 
 
+def _resolved_alias_for_contract(canonical: str, alias: str) -> str:
+    if canonical == "gwf":
+        return _normalize_gwf_format(alias) or alias
+    return alias
+
+
 def _has_gwf_backend() -> bool:
     try:
         from gwpy.io.gwf.core import get_channel_names
@@ -184,8 +190,7 @@ def test_registry_contract_is_registered_in_registry():
                 continue
             for alias in aliases:
                 alias_reader = _reader_callable(alias, cls)
-                normalized = _normalize_gwf_format(alias)
-                resolved = normalized if normalized is not None else canonical
+                resolved = _resolved_alias_for_contract(canonical, alias)
                 if alias_reader is None:
                     if resolved == canonical:
                         continue
@@ -209,8 +214,7 @@ def test_registry_contract_is_registered_in_registry():
                 continue
             for alias in aliases:
                 alias_writer = _writer_callable(alias, cls)
-                normalized = _normalize_gwf_format(alias)
-                resolved = normalized if normalized is not None else canonical
+                resolved = _resolved_alias_for_contract(canonical, alias)
                 if alias_writer is None:
                     if resolved == canonical:
                         continue

--- a/tests/io/test_io_contract.py
+++ b/tests/io/test_io_contract.py
@@ -53,6 +53,22 @@ CLASS_MAP = {
     "EventTable": EventTable,
 }
 
+VALID_EXTRAS = {
+    "audio",
+    "io",
+    "netcdf4",
+    "seismic",
+    "zarr",
+}
+
+VALID_UNAVAILABLE_BEHAVIORS = {
+    "available_in_base_install",
+    "conditional_registration",
+    "not_public",
+    "raises_import_error",
+    "raises_import_error_for_optional_metadata",
+}
+
 
 def _load_contracts():
     import json
@@ -100,8 +116,21 @@ def test_public_contract_schema_is_well_formed():
         assert isinstance(entry["trusted_only"], bool)
         assert isinstance(entry.get("metadata_requirements", []), list)
         assert isinstance(entry.get("notes", []), list)
+        assert isinstance(entry["optional_dependencies"], list)
+        assert isinstance(entry["extras"], list)
+        assert set(entry["unavailable_behavior"]) == {"read", "write"}
         assert set(entry["required_args"]) == {"read", "write"}
         assert set(entry["direct_api"]) == {"read", "write"}
+
+        optional_dependencies = entry["optional_dependencies"]
+        extras = entry["extras"]
+        assert all(
+            isinstance(dependency, str) and dependency
+            for dependency in optional_dependencies
+        )
+        assert all(extra in VALID_EXTRAS for extra in extras)
+        assert len(optional_dependencies) == len(set(optional_dependencies))
+        assert len(extras) == len(set(extras))
 
         public_read = set(_api_classes(entry, "public_api", "read"))
         public_write = set(_api_classes(entry, "public_api", "write"))
@@ -127,8 +156,12 @@ def test_public_contract_schema_is_well_formed():
 
         for operation in ("read", "write"):
             required_args = entry["required_args"][operation]
+            unavailable_behavior = entry["unavailable_behavior"][operation]
             assert isinstance(required_args, list)
             assert all(isinstance(arg, str) and arg for arg in required_args)
+            assert unavailable_behavior in VALID_UNAVAILABLE_BEHAVIORS
+            if not entry["public_api"][operation]:
+                assert unavailable_behavior == "not_public"
 
 
 def test_registry_contract_is_registered_in_registry():
@@ -146,6 +179,8 @@ def test_registry_contract_is_registered_in_registry():
             cls = CLASS_MAP[class_name]
             canonical_reader = _reader_callable(canonical, cls)
             if canonical_reader is None:
+                assert entry["unavailable_behavior"]["read"] == "conditional_registration"
+                assert entry["optional_dependencies"]
                 continue
             for alias in aliases:
                 alias_reader = _reader_callable(alias, cls)
@@ -169,6 +204,8 @@ def test_registry_contract_is_registered_in_registry():
             cls = CLASS_MAP[class_name]
             canonical_writer = _writer_callable(canonical, cls)
             if canonical_writer is None:
+                assert entry["unavailable_behavior"]["write"] == "conditional_registration"
+                assert entry["optional_dependencies"]
                 continue
             for alias in aliases:
                 alias_writer = _writer_callable(alias, cls)
@@ -420,6 +457,9 @@ def test_current_public_boundary_decisions_are_recorded():
     ]
     assert _api_classes(entries["win"], "registry_api", "write") == []
     assert entries["win"]["aliases"] == ["win32"]
+    assert entries["win"]["optional_dependencies"] == ["obspy"]
+    assert entries["win"]["extras"] == ["seismic"]
+    assert entries["win"]["unavailable_behavior"]["read"] == "conditional_registration"
     assert entries["win"]["metadata_requirements"]
     assert _api_classes(entries["ats"], "public_api", "read") == [
         "TimeSeries",
@@ -439,6 +479,11 @@ def test_current_public_boundary_decisions_are_recorded():
     assert _api_classes(entries["ats.mth5"], "registry_api", "write") == []
     assert entries["ats.mth5"]["public_auto_identify"] is False
     assert entries["ats.mth5"]["registry_auto_identify"] is False
+    assert entries["ats.mth5"]["optional_dependencies"] == ["mth5"]
+    assert entries["ats.mth5"]["extras"] == ["seismic"]
+    assert (
+        entries["ats.mth5"]["unavailable_behavior"]["read"] == "raises_import_error"
+    )
     assert entries["ats.mth5"]["metadata_requirements"]
     assert _api_classes(entries["root"], "public_api", "read") == ["EventTable"]
     assert _api_classes(entries["root"], "public_api", "write") == ["EventTable"]

--- a/tests/io/test_io_contract.py
+++ b/tests/io/test_io_contract.py
@@ -91,6 +91,8 @@ def _writer_callable(fmt: str, cls):
 
 
 def _resolved_alias_for_contract(canonical: str, alias: str) -> str:
+    # Only GWF aliases use format-token normalization. Other declared aliases
+    # must remain registered as their own public tokens when canonical exists.
     if canonical == "gwf":
         return _normalize_gwf_format(alias) or alias
     return alias

--- a/tests/io/test_io_docs_contract_sync.py
+++ b/tests/io/test_io_docs_contract_sync.py
@@ -9,6 +9,8 @@ ROOT = Path(__file__).resolve().parents[2]
 CONTRACT_PATH = ROOT / "docs/developers/contracts/public_io_contract.json"
 EN_GUIDE = ROOT / "docs/web/en/user_guide/io_formats.md"
 JA_GUIDE = ROOT / "docs/web/ja/user_guide/io_formats.md"
+EN_INSTALL = ROOT / "docs/web/en/user_guide/installation.md"
+JA_INSTALL = ROOT / "docs/web/ja/user_guide/installation.md"
 
 
 def _load_contract() -> dict[str, dict]:
@@ -75,3 +77,29 @@ def test_docs_seismic_table_matches_current_public_boundary():
     assert contract["ats.mth5"]["public_api"]["read"] == ["TimeSeries"]
     assert "The only direct path today is `ats.mth5`" in en
     assert "使える direct path は `ats.mth5` のみ" in ja
+
+
+def test_optional_dependency_matrix_matches_contract():
+    contract = _load_contract()
+    en = _read(EN_GUIDE)
+    ja = _read(JA_GUIDE)
+    en_install = _read(EN_INSTALL)
+    ja_install = _read(JA_INSTALL)
+
+    for entry in contract.values():
+        for dependency in entry["optional_dependencies"]:
+            assert f"`{dependency}`" in en
+            assert f"`{dependency}`" in ja
+        for extra in entry["extras"]:
+            assert f"`{extra}`" in en_install
+            assert f"`{extra}`" in ja_install
+
+    win = contract["win"]
+    assert win["unavailable_behavior"]["read"] == "conditional_registration"
+    assert "conditional registration" in en
+    assert "条件付き登録" in ja
+
+    ats_mth5 = contract["ats.mth5"]
+    assert ats_mth5["extras"] == ["seismic"]
+    assert "pip install 'gwexpy[seismic]'" in en
+    assert "pip install 'gwexpy[seismic]'" in ja

--- a/tests/timeseries/test_timeseries.py
+++ b/tests/timeseries/test_timeseries.py
@@ -31,6 +31,10 @@ class TestTimeSeries(gwpy_test_module.TestTimeSeries):  # noqa: F405
         return super().test_fetch_open_data_error(*args, **kwargs)
 
     @pytest.mark.network
+    def test_get_gwosc_kwargs(self, gw150914):
+        return super().test_get_gwosc_kwargs(gw150914)
+
+    @pytest.mark.network
     def test_find_datafind_httperror(self, *args, **kwargs):
         self._require_host(
             "datafind.gwosc.org", "network unavailable for datafind tests"


### PR DESCRIPTION
## Summary
- Add `optional_dependencies`, `extras`, and `unavailable_behavior` fields to the public I/O and interop contract JSON, including explicit WIN conditional registration and `ats.mth5` seismic-extra ownership.
- Extend I/O and interop contract/docs-sync tests so the new matrix fields stay represented in public docs and installation extras.
- Add compact EN/JA optional-dependency policy sections for direct I/O and interop, plus installation table updates for `tinytag`, `netcdf4`, and `zarr` coverage.

## Validation
- `git diff --check`
- `ruff check tests/io/test_io_contract.py tests/io/test_io_docs_contract_sync.py tests/interop/test_interop_contract.py tests/interop/test_interop_docs_contract_sync.py`
- `pytest tests/io/test_io_contract.py tests/io/test_io_docs_contract_sync.py tests/interop/test_interop_contract.py tests/interop/test_interop_docs_contract_sync.py` (20 passed)

## Audit Log
- Worktree: `/tmp/gwexpy-issue248-impl`
- Base: `origin/main` at `c3901ccb0e6f15ca16fc53771939e59335b3e5c8`
- Commit: `73136dc99f926f89d000c195a0f2f47f7e7ef0f6`
- Skills/instructions used: `.agent/AGENTS.md`, GitHub workflow, isolated git worktree, test-first contract checks, verification-before-completion.
- Physics/data-model review: no physics algorithms, SeriesMatrix code, or runtime data model behavior changed.

Refs #248
