### PR TITLE
fix(types): preserve SeriesMatrix construction invariants

### DIFF
--- a/gwexpy/types/series_matrix_indexing.py
+++ b/gwexpy/types/series_matrix_indexing.py
@@ -31,12 +31,28 @@ def _is_advanced_axis_selector(key: Any) -> bool:
     return isinstance(key, (list, tuple))
 
 
-def _as_position_list(key: Any) -> list[int]:
+def _as_position_list(key: Any, axis_len: int) -> list[int]:
     """Normalize a list-like row/column selector into integer positions."""
     arr = np.asarray(key)
+    if arr.ndim != 1:
+        raise IndexError("SeriesMatrix row/column selectors must be 1-dimensional")
     if arr.dtype == np.bool_:
+        if arr.size != axis_len:
+            raise IndexError(
+                "boolean row/column selector length mismatch: "
+                f"expected {axis_len}, got {arr.size}"
+            )
         return np.nonzero(arr)[0].tolist()
-    return [int(item) for item in arr.tolist()]
+    if arr.dtype.kind not in "iu":
+        raise TypeError("SeriesMatrix row/column selectors must be integer positions")
+    positions = [int(item) for item in arr.tolist()]
+    for pos in positions:
+        if pos < -axis_len or pos >= axis_len:
+            raise IndexError(
+                f"SeriesMatrix row/column selector index {pos} is out of bounds "
+                f"for axis with size {axis_len}"
+            )
+    return positions
 
 
 class SeriesMatrixIndexingMixin:
@@ -124,8 +140,8 @@ class SeriesMatrixIndexingMixin:
 
         # 4. Perform actual ndarray slicing
         if _is_advanced_axis_selector(ri) and _is_advanced_axis_selector(ci):
-            ri_pos = _as_position_list(ri)
-            ci_pos = _as_position_list(ci)
+            ri_pos = _as_position_list(ri, self.shape[0])
+            ci_pos = _as_position_list(ci, self.shape[1])
             result = self.view(np.ndarray)[np.ix_(ri_pos, ci_pos)][:, :, s]
             meta_ri: Any = ri_pos
             meta_ci: Any = ci_pos
@@ -160,7 +176,10 @@ class SeriesMatrixIndexingMixin:
         # 5. Slice internal metadata
         if _is_advanced_axis_selector(meta_ri) and _is_advanced_axis_selector(meta_ci):
             new_meta = self.meta[
-                np.ix_(_as_position_list(meta_ri), _as_position_list(meta_ci))
+                np.ix_(
+                    _as_position_list(meta_ri, self.shape[0]),
+                    _as_position_list(meta_ci, self.shape[1]),
+                )
             ]
         else:
             new_meta = self.meta[meta_ri, meta_ci]
@@ -212,12 +231,16 @@ class SeriesMatrixIndexingMixin:
 
         ri = _resolve_label_key(r, self.row_index)
         ci = _resolve_label_key(c, self.col_index)
+        base_value = _to_base(value) if hasattr(value, "shape") else value
 
-        if hasattr(value, "shape"):
-            # If value is a Series or Matrix, ensure compatibility
-            self.view(np.ndarray)[ri, ci, s] = _to_base(value)
+        if _is_advanced_axis_selector(ri) and _is_advanced_axis_selector(ci):
+            ri_pos = np.asarray(_as_position_list(ri, self.shape[0]))
+            ci_pos = np.asarray(_as_position_list(ci, self.shape[1]))
+            self.view(np.ndarray)[ri_pos[:, np.newaxis], ci_pos[np.newaxis, :], s] = (
+                base_value
+            )
         else:
-            self.view(np.ndarray)[ri, ci, s] = value
+            self.view(np.ndarray)[ri, ci, s] = base_value
 
     @property
     def loc(self):

--- a/gwexpy/types/series_matrix_indexing.py
+++ b/gwexpy/types/series_matrix_indexing.py
@@ -13,6 +13,17 @@ if TYPE_CHECKING:
     from gwexpy.types.metadata import MetaDataDict, MetaDataMatrix
 
 
+def _resolve_label_key(key: Any, resolver: Any) -> Any:
+    """Resolve string labels while leaving integer positions unchanged."""
+    if isinstance(key, str):
+        return resolver(key)
+    if isinstance(key, (list, tuple)):
+        return [resolver(item) if isinstance(item, str) else item for item in key]
+    if isinstance(key, np.ndarray) and key.dtype.kind in "US":
+        return [resolver(item) for item in key.tolist()]
+    return key
+
+
 class SeriesMatrixIndexingMixin:
     """Mixin for SeriesMatrix indexing and slicing operations."""
 
@@ -93,23 +104,8 @@ class SeriesMatrixIndexingMixin:
             return series_cls(result, **kwargs)
 
         # 3. Handle label-based slicing for rows/cols
-        ri = r
-        if isinstance(r, (str, list)) or (
-            isinstance(r, np.ndarray) and r.dtype.kind in "US"
-        ):
-            if isinstance(r, str):
-                ri = self.row_index(r)
-            else:
-                ri = [self.row_index(k) for k in r]
-
-        ci = c
-        if isinstance(c, (str, list)) or (
-            isinstance(c, np.ndarray) and c.dtype.kind in "US"
-        ):
-            if isinstance(c, str):
-                ci = self.col_index(c)
-            else:
-                ci = [self.col_index(k) for k in c]
+        ri = _resolve_label_key(r, self.row_index)
+        ci = _resolve_label_key(c, self.col_index)
 
         # 4. Perform actual ndarray slicing
         new_key = (ri, ci, s)
@@ -185,23 +181,8 @@ class SeriesMatrixIndexingMixin:
         expanded_key = _expand_key(key, 3)
         r, c, s = expanded_key
 
-        ri = r
-        if isinstance(r, (str, list)) or (
-            isinstance(r, np.ndarray) and r.dtype.kind in "US"
-        ):
-            if isinstance(r, str):
-                ri = self.row_index(r)
-            else:
-                ri = [self.row_index(k) for k in r]
-
-        ci = c
-        if isinstance(c, (str, list)) or (
-            isinstance(c, np.ndarray) and c.dtype.kind in "US"
-        ):
-            if isinstance(c, str):
-                ci = self.col_index(c)
-            else:
-                ci = [self.col_index(k) for k in c]
+        ri = _resolve_label_key(r, self.row_index)
+        ci = _resolve_label_key(c, self.col_index)
 
         if hasattr(value, "shape"):
             # If value is a Series or Matrix, ensure compatibility
@@ -236,5 +217,6 @@ class SeriesMatrixIndexingMixin:
         ri = [self.row_index(k) for k in row_keys]
         ci = [self.col_index(k) for k in col_keys]
 
-        # Use __getitem__ logic
-        return self[ri, ci, :]
+        # Apply row and column lists separately to get the Cartesian submatrix,
+        # not NumPy's pairwise advanced-indexing result.
+        return self[ri, :, :][:, ci, :]

--- a/gwexpy/types/series_matrix_indexing.py
+++ b/gwexpy/types/series_matrix_indexing.py
@@ -36,6 +36,8 @@ def _as_position_list(key: Any, axis_len: int) -> list[int]:
     arr = np.asarray(key)
     if arr.ndim != 1:
         raise IndexError("SeriesMatrix row/column selectors must be 1-dimensional")
+    if arr.size == 0:
+        return []
     if arr.dtype == np.bool_:
         if arr.size != axis_len:
             raise IndexError(
@@ -234,8 +236,8 @@ class SeriesMatrixIndexingMixin:
         base_value = _to_base(value) if hasattr(value, "shape") else value
 
         if _is_advanced_axis_selector(ri) and _is_advanced_axis_selector(ci):
-            ri_pos = np.asarray(_as_position_list(ri, self.shape[0]))
-            ci_pos = np.asarray(_as_position_list(ci, self.shape[1]))
+            ri_pos = np.asarray(_as_position_list(ri, self.shape[0]), dtype=int)
+            ci_pos = np.asarray(_as_position_list(ci, self.shape[1]), dtype=int)
             self.view(np.ndarray)[ri_pos[:, np.newaxis], ci_pos[np.newaxis, :], s] = (
                 base_value
             )

--- a/gwexpy/types/series_matrix_indexing.py
+++ b/gwexpy/types/series_matrix_indexing.py
@@ -24,6 +24,21 @@ def _resolve_label_key(key: Any, resolver: Any) -> Any:
     return key
 
 
+def _is_advanced_axis_selector(key: Any) -> bool:
+    """Return True for list-like row/column selectors."""
+    if isinstance(key, np.ndarray):
+        return key.ndim > 0
+    return isinstance(key, (list, tuple))
+
+
+def _as_position_list(key: Any) -> list[int]:
+    """Normalize a list-like row/column selector into integer positions."""
+    arr = np.asarray(key)
+    if arr.dtype == np.bool_:
+        return np.nonzero(arr)[0].tolist()
+    return [int(item) for item in arr.tolist()]
+
+
 class SeriesMatrixIndexingMixin:
     """Mixin for SeriesMatrix indexing and slicing operations."""
 
@@ -108,8 +123,17 @@ class SeriesMatrixIndexingMixin:
         ci = _resolve_label_key(c, self.col_index)
 
         # 4. Perform actual ndarray slicing
-        new_key = (ri, ci, s)
-        result = cast(Any, super()).__getitem__(new_key)
+        if _is_advanced_axis_selector(ri) and _is_advanced_axis_selector(ci):
+            ri_pos = _as_position_list(ri)
+            ci_pos = _as_position_list(ci)
+            result = self.view(np.ndarray)[np.ix_(ri_pos, ci_pos)][:, :, s]
+            meta_ri: Any = ri_pos
+            meta_ci: Any = ci_pos
+        else:
+            new_key = (ri, ci, s)
+            result = cast(Any, super()).__getitem__(new_key)
+            meta_ri = ri
+            meta_ci = ci
 
         if not isinstance(result, np.ndarray):
             return result
@@ -134,20 +158,25 @@ class SeriesMatrixIndexingMixin:
                 result = result.view(np.ndarray).reshape(new_shape).view(type(self))
 
         # 5. Slice internal metadata
-        new_meta = self.meta[ri, ci]
+        if _is_advanced_axis_selector(meta_ri) and _is_advanced_axis_selector(meta_ci):
+            new_meta = self.meta[
+                np.ix_(_as_position_list(meta_ri), _as_position_list(meta_ci))
+            ]
+        else:
+            new_meta = self.meta[meta_ri, meta_ci]
 
         # Restore metadata dimensions
         if new_meta.ndim < 2:
             meta_shape = list(new_meta.shape)
-            if isinstance(ci, (int, np.integer)):
+            if isinstance(meta_ci, (int, np.integer)):
                 meta_shape.insert(1, 1)
-            if isinstance(ri, (int, np.integer)):
+            if isinstance(meta_ri, (int, np.integer)):
                 meta_shape.insert(0, 1)
 
             if len(meta_shape) != new_meta.ndim:
                 new_meta = new_meta.reshape(meta_shape)
-        new_rows = _slice_metadata_dict(self.rows, ri, "row")
-        new_cols = _slice_metadata_dict(self.cols, ci, "col")
+        new_rows = _slice_metadata_dict(self.rows, meta_ri, "row")
+        new_cols = _slice_metadata_dict(self.cols, meta_ci, "col")
 
         # 6. Slice xindex
         if self.xindex is not None:

--- a/gwexpy/types/series_matrix_indexing.py
+++ b/gwexpy/types/series_matrix_indexing.py
@@ -271,6 +271,5 @@ class SeriesMatrixIndexingMixin:
         ri = [self.row_index(k) for k in row_keys]
         ci = [self.col_index(k) for k in col_keys]
 
-        # Apply row and column lists separately to get the Cartesian submatrix,
-        # not NumPy's pairwise advanced-indexing result.
-        return self[ri, :, :][:, ci, :]
+        # Direct row/column list selection is Cartesian for SeriesMatrix.
+        return self[ri, ci, :]

--- a/gwexpy/types/seriesmatrix_base.py
+++ b/gwexpy/types/seriesmatrix_base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import warnings
 from collections import OrderedDict
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Optional, cast
 
 import numpy as np
@@ -46,6 +47,30 @@ _ADD_SUB_COMPARISON_UFUNCS = {
     np.greater,
     np.greater_equal,
 }
+_UNSET = object()
+
+
+def _copy_xindex(xindex: Any) -> Any:
+    """Copy an x-axis index without assuming a specific index implementation."""
+    if xindex is None:
+        return None
+    try:
+        return xindex.copy()
+    except (IndexError, KeyError, TypeError, ValueError, AttributeError):
+        return deepcopy(xindex)
+
+
+def _copy_metadata_matrix(meta: MetaDataMatrix) -> MetaDataMatrix:
+    """Deep-copy a metadata matrix and its per-cell metadata entries."""
+    return MetaDataMatrix(deepcopy(np.asarray(meta, dtype=object)))
+
+
+def _copy_metadata_dict(meta: MetaDataDict, key_prefix: str) -> MetaDataDict:
+    """Deep-copy row or column metadata while preserving keys."""
+    items = OrderedDict()
+    for key, value in meta.items():
+        items[key] = MetaData(**dict(value))
+    return MetaDataDict(items, expected_size=len(items), key_prefix=key_prefix)
 
 
 class PerformanceWarning(RuntimeWarning):
@@ -86,15 +111,20 @@ class SeriesMatrix(  # type: ignore[misc]
         dx: u.Quantity | None = None,
         x0: u.Quantity | None = None,
         xunit: UnitLike = None,
-        name: str = "",
-        epoch: float = 0.0,
-        attrs: dict[str, Any] | None = None,
+        name: str | object = _UNSET,
+        epoch: float | object = _UNSET,
+        attrs: dict[str, Any] | None | object = _UNSET,
     ) -> SeriesMatrix:
         """Create a SeriesMatrix with normalized inputs and metadata."""
         if unit is not None:
             if units is not None:
                 raise ValueError("give only one of unit or units")
             units = unit
+
+        source_matrix = data if isinstance(data, SeriesMatrix) else None
+        explicit_units = units is not None
+        explicit_names = names is not None
+        explicit_channels = channels is not None
 
         if xindex is not None and xunit is not None:
             try:
@@ -116,39 +146,52 @@ class SeriesMatrix(  # type: ignore[misc]
             xunit=xunit,
         )
 
-        if meta is not None:
-            if not isinstance(meta, MetaDataMatrix):
-                try:
-                    meta = MetaDataMatrix(meta)
-                except (TypeError, ValueError) as e:
-                    raise TypeError(
-                        "meta must be a MetaDataMatrix or a 2D array-like of MetaData/dict"
-                    ) from e
-            if units is None:
-                data_attrs["unit"] = None
-            if names is None:
-                data_attrs["name"] = None
-            if channels is None:
-                data_attrs["channel"] = None
-            _check_attribute_consistency(data_attrs=data_attrs, meta=meta)
-            units_arr, names_arr, channels_arr = _fill_missing_attributes(
-                data_attrs=data_attrs, meta=meta
-            )
+        if meta is None and source_matrix is not None:
+            meta_matrix = _copy_metadata_matrix(source_matrix.meta)
+            if explicit_units:
+                meta_matrix.units = data_attrs["unit"]
+            if explicit_names:
+                meta_matrix.names = data_attrs["name"]
+            if explicit_channels:
+                meta_matrix.channels = data_attrs["channel"]
         else:
-            units_arr = data_attrs.get("unit", None)
-            names_arr = data_attrs.get("name", None)
-            channels_arr = data_attrs.get("channel", None)
+            if meta is not None:
+                if not isinstance(meta, MetaDataMatrix):
+                    try:
+                        meta = MetaDataMatrix(meta)
+                    except (TypeError, ValueError) as e:
+                        raise TypeError(
+                            "meta must be a MetaDataMatrix or a 2D array-like of MetaData/dict"
+                        ) from e
+                if units is None:
+                    data_attrs["unit"] = None
+                if names is None:
+                    data_attrs["name"] = None
+                if channels is None:
+                    data_attrs["channel"] = None
+                _check_attribute_consistency(data_attrs=data_attrs, meta=meta)
+                units_arr, names_arr, channels_arr = _fill_missing_attributes(
+                    data_attrs=data_attrs, meta=meta
+                )
+            else:
+                units_arr = data_attrs.get("unit", None)
+                names_arr = data_attrs.get("name", None)
+                channels_arr = data_attrs.get("channel", None)
 
-        meta_matrix = _make_meta_matrix(
-            shape=value_array.shape[:2],
-            units=units_arr,
-            names=names_arr,
-            channels=channels_arr,
-        )
+            meta_matrix = _make_meta_matrix(
+                shape=value_array.shape[:2],
+                units=units_arr,
+                names=names_arr,
+                channels=channels_arr,
+            )
 
         if xindex is None:
             if detected_xindex is not None:
-                xindex = detected_xindex
+                xindex = (
+                    _copy_xindex(detected_xindex)
+                    if source_matrix is not None
+                    else detected_xindex
+                )
             else:
                 if value_array.shape[2] == 0 and dx is None and x0 is None:
                     xindex = np.asarray([])
@@ -173,16 +216,41 @@ class SeriesMatrix(  # type: ignore[misc]
 
         obj.meta = meta_matrix
         N, M = value_array.shape[:2]
+        if source_matrix is not None:
+            if rows is None and getattr(source_matrix, "rows", None) is not None:
+                rows = _copy_metadata_dict(source_matrix.rows, "row")
+            if cols is None and getattr(source_matrix, "cols", None) is not None:
+                cols = _copy_metadata_dict(source_matrix.cols, "col")
         if isinstance(rows, dict) and not isinstance(rows, OrderedDict):
             rows = OrderedDict(rows)
         if isinstance(cols, dict) and not isinstance(cols, OrderedDict):
             cols = OrderedDict(cols)
+        if name is _UNSET:
+            name = (
+                getattr(source_matrix, "name", "")
+                if source_matrix is not None
+                else ""
+            )
+        if epoch is _UNSET:
+            epoch = (
+                getattr(source_matrix, "epoch", 0.0)
+                if source_matrix is not None
+                else 0.0
+            )
+        if attrs is _UNSET:
+            attrs = (
+                deepcopy(getattr(source_matrix, "attrs", {}))
+                if source_matrix is not None
+                else {}
+            )
+        elif attrs is None:
+            attrs = {}
         obj.rows = MetaDataDict(cast(Any, rows), expected_size=N, key_prefix="row")
         obj.cols = MetaDataDict(cast(Any, cols), expected_size=M, key_prefix="col")
         obj.xindex = xindex
-        obj.name = name
-        obj.epoch = epoch
-        obj.attrs = attrs or {}
+        obj.name = cast(str, name)
+        obj.epoch = cast(float, epoch)
+        obj.attrs = cast(dict[str, Any], attrs) or {}
 
         return obj
 

--- a/gwexpy/types/seriesmatrix_base.py
+++ b/gwexpy/types/seriesmatrix_base.py
@@ -69,7 +69,7 @@ def _copy_metadata_dict(meta: MetaDataDict, key_prefix: str) -> MetaDataDict:
     """Deep-copy row or column metadata while preserving keys."""
     items = OrderedDict()
     for key, value in meta.items():
-        items[key] = MetaData(**dict(value))
+        items[key] = MetaData(**deepcopy(dict(value)))
     return MetaDataDict(items, expected_size=len(items), key_prefix=key_prefix)
 
 

--- a/gwexpy/types/seriesmatrix_base.py
+++ b/gwexpy/types/seriesmatrix_base.py
@@ -47,7 +47,13 @@ _ADD_SUB_COMPARISON_UFUNCS = {
     np.greater,
     np.greater_equal,
 }
-_UNSET = object()
+
+
+class _UnsetType:
+    """Sentinel type for omitted constructor arguments."""
+
+
+_UNSET = _UnsetType()
 
 
 def _copy_xindex(xindex: Any) -> Any:
@@ -111,9 +117,9 @@ class SeriesMatrix(  # type: ignore[misc]
         dx: u.Quantity | None = None,
         x0: u.Quantity | None = None,
         xunit: UnitLike = None,
-        name: str | object = _UNSET,
-        epoch: float | object = _UNSET,
-        attrs: dict[str, Any] | None | object = _UNSET,
+        name: str | _UnsetType = _UNSET,
+        epoch: float | _UnsetType = _UNSET,
+        attrs: dict[str, Any] | None | _UnsetType = _UNSET,
     ) -> SeriesMatrix:
         """Create a SeriesMatrix with normalized inputs and metadata."""
         if unit is not None:
@@ -227,9 +233,7 @@ class SeriesMatrix(  # type: ignore[misc]
             cols = OrderedDict(cols)
         if name is _UNSET:
             name = (
-                getattr(source_matrix, "name", "")
-                if source_matrix is not None
-                else ""
+                getattr(source_matrix, "name", "") if source_matrix is not None else ""
             )
         if epoch is _UNSET:
             epoch = (

--- a/gwexpy/types/seriesmatrix_validation.py
+++ b/gwexpy/types/seriesmatrix_validation.py
@@ -210,8 +210,8 @@ def _expand_key(key, ndim):
     if not isinstance(key, tuple):
         key = (key,)
     key_list = list(key)
-    if Ellipsis in key_list:
-        ell_idx = key_list.index(Ellipsis)
+    ell_idx = next((idx for idx, item in enumerate(key_list) if item is Ellipsis), None)
+    if ell_idx is not None:
         n_missing = ndim - (len(key_list) - 1)
         key_list = (
             key_list[:ell_idx] + [slice(None)] * n_missing + key_list[ell_idx + 1 :]

--- a/gwexpy/types/seriesmatrix_validation.py
+++ b/gwexpy/types/seriesmatrix_validation.py
@@ -730,7 +730,7 @@ def _handle_seriesmatrix(data, units, names, channels, shape, xindex, dx, x0, xu
         name_default=data.names.copy(),
         channel_default=data.channels.copy(),
     )
-    return arr, _pack_attrs(unit_arr, name_arr, channel_arr), None
+    return arr, _pack_attrs(unit_arr, name_arr, channel_arr), data.xindex
 
 
 # ---------------------------------------------------------------------------
@@ -804,17 +804,17 @@ def _normalize_input(
         where attr_dict contains per-cell unit/name/channel arrays.
 
     """
-    type_key = _detect_input_type(data)
+    from .seriesmatrix import SeriesMatrix
+
+    if isinstance(data, SeriesMatrix):
+        type_key = "seriesmatrix"
+    else:
+        type_key = _detect_input_type(data)
 
     # SeriesMatrix requires a lazy import, so handle the "unknown" fallback
     # and the explicit SeriesMatrix check here.
     if type_key == "unknown":
-        from .seriesmatrix import SeriesMatrix
-
-        if isinstance(data, SeriesMatrix):
-            type_key = "seriesmatrix"
-        else:
-            raise TypeError(f"Unsupported data type for SeriesMatrix: {type(data)}")
+        raise TypeError(f"Unsupported data type for SeriesMatrix: {type(data)}")
 
     handler = _NORMALIZE_HANDLERS[type_key]
     return handler(data, units, names, channels, shape, xindex, dx, x0, xunit)

--- a/gwexpy/types/seriesmatrix_validation.py
+++ b/gwexpy/types/seriesmatrix_validation.py
@@ -227,7 +227,11 @@ def _slice_metadata_dict(meta_dict, key, prefix):
     if isinstance(key, slice):
         subset = items[key]
     elif isinstance(key, (list, np.ndarray, tuple)):
-        subset = [items[int(i)] for i in key]
+        key_arr = np.asarray(key)
+        if key_arr.dtype == np.bool_:
+            subset = [items[int(i)] for i in np.nonzero(key_arr)[0]]
+        else:
+            subset = [items[int(i)] for i in key]
     elif isinstance(key, (int, np.integer)):
         subset = [items[int(key)]]
     else:
@@ -730,6 +734,19 @@ def _handle_seriesmatrix(data, units, names, channels, shape, xindex, dx, x0, xu
         name_default=data.names.copy(),
         channel_default=data.channels.copy(),
     )
+    if units is not None:
+        arr = arr.astype(np.result_type(arr, float), copy=True)
+        N, M = data.units.shape
+        for i in range(N):
+            for j in range(M):
+                try:
+                    arr[i, j] = u.Quantity(arr[i, j], data.units[i, j]).to_value(
+                        unit_arr[i, j]
+                    )
+                except (u.UnitConversionError, TypeError, ValueError) as e:
+                    raise u.UnitConversionError(
+                        f"Unit conversion failed at ({i},{j}): {e}"
+                    )
     return arr, _pack_attrs(unit_arr, name_arr, channel_arr), data.xindex
 
 

--- a/tests/types/test_series_matrix_indexing.py
+++ b/tests/types/test_series_matrix_indexing.py
@@ -136,6 +136,40 @@ class TestGetItemLabelBased:
         result = tsm[:, keys, :]
         assert result.shape == (2, 2, 10)
 
+    def test_int_row_list_and_int_col_list_are_cartesian(self):
+        data = np.arange(3 * 4 * 5, dtype=float).reshape(3, 4, 5)
+        sm = SeriesMatrix(
+            data,
+            xindex=np.arange(5),
+            rows={"r0": {}, "r1": {}, "r2": {}},
+            cols={"c0": {}, "c1": {}, "c2": {}, "c3": {}},
+        )
+
+        result = sm[[0, 2], [1, 3], :]
+
+        assert result.shape == (2, 2, 5)
+        expected = data[np.ix_([0, 2], [1, 3], np.arange(5))]
+        np.testing.assert_array_equal(result.value, expected)
+        assert result.row_keys() == ("r0", "r2")
+        assert result.col_keys() == ("c1", "c3")
+
+    def test_label_row_list_and_label_col_list_are_cartesian(self):
+        data = np.arange(3 * 4 * 5, dtype=float).reshape(3, 4, 5)
+        sm = SeriesMatrix(
+            data,
+            xindex=np.arange(5),
+            rows={"r0": {}, "r1": {}, "r2": {}},
+            cols={"c0": {}, "c1": {}, "c2": {}, "c3": {}},
+        )
+
+        result = sm[["r0", "r2"], ["c1", "c3"], :]
+
+        assert result.shape == (2, 2, 5)
+        expected = data[np.ix_([0, 2], [1, 3], np.arange(5))]
+        np.testing.assert_array_equal(result.value, expected)
+        assert result.row_keys() == ("r0", "r2")
+        assert result.col_keys() == ("c1", "c3")
+
 
 # ---------------------------------------------------------------------------
 # __setitem__

--- a/tests/types/test_series_matrix_indexing.py
+++ b/tests/types/test_series_matrix_indexing.py
@@ -6,6 +6,7 @@ import pytest
 from astropy import units as u
 
 from gwexpy.timeseries import TimeSeriesMatrix
+from gwexpy.types.metadata import MetaData, MetaDataMatrix
 from gwexpy.types.seriesmatrix import SeriesMatrix
 
 
@@ -202,19 +203,41 @@ class TestLoc:
 # ---------------------------------------------------------------------------
 
 class TestSubmatrix:
-    def test_submatrix_code_path(self):
-        # submatrix normalizes single string to list, then calls row_index
-        # Test the string normalization (lines 235-238)
-        tsm = _make_tsm()
-        row_key = tsm.row_keys()[0]   # e.g. 'row0'
-        col_key = tsm.col_keys()[0]   # e.g. 'col0'
-        # submatrix(['row0'], ['col0']) → ri=[0], ci=[0] → self[[0], [0], :]
-        # But self[[0], [0], :] triggers list branch in __getitem__ which calls row_index(0) → error
-        # Just test single-string normalization by checking it runs the normalize path
-        try:
-            tsm.submatrix(row_key, col_key)
-        except (KeyError, TypeError):
-            pass  # known issue with integer list fallback in __getitem__
+    def test_submatrix_label_selection_preserves_cartesian_shape_and_metadata(self):
+        data = np.arange(3 * 4 * 5, dtype=float).reshape(3, 4, 5)
+        meta_arr = np.empty((3, 4), dtype=object)
+        for i in range(3):
+            for j in range(4):
+                meta_arr[i, j] = MetaData(unit=u.m, name=f"elem-{i}-{j}")
+        sm = SeriesMatrix(
+            data,
+            xindex=u.Quantity(np.arange(5, dtype=float), u.s),
+            meta=MetaDataMatrix(meta_arr),
+            rows={
+                "r0": {"name": "row zero"},
+                "r1": {"name": "row one"},
+                "r2": {"name": "row two"},
+            },
+            cols={
+                "c0": {"name": "col zero"},
+                "c1": {"name": "col one"},
+                "c2": {"name": "col two"},
+                "c3": {"name": "col three"},
+            },
+        )
+
+        result = sm.submatrix(["r0", "r2"], ["c1", "c3"])
+
+        assert result.shape == (2, 2, 5)
+        expected = data[np.ix_([0, 2], [1, 3], np.arange(5))]
+        np.testing.assert_array_equal(result.value, expected)
+        np.testing.assert_array_equal(result.xindex.value, np.arange(5, dtype=float))
+        assert result.xindex.unit == u.s
+        assert result.row_keys() == ("r0", "r2")
+        assert result.col_keys() == ("c1", "c3")
+        assert result.rows["r2"].name == "row two"
+        assert result.cols["c3"].name == "col three"
+        assert result.meta[1, 1].name == "elem-2-3"
 
     def test_getitem_non_array_result(self):
         # Line 121 — result not np.ndarray → return early

--- a/tests/types/test_series_matrix_indexing.py
+++ b/tests/types/test_series_matrix_indexing.py
@@ -194,6 +194,40 @@ class TestGetItemLabelBased:
         expected = data[np.ix_([0, 2], [1, 3], np.arange(5))]
         np.testing.assert_array_equal(result.value, expected)
 
+    def test_boolean_row_mask_with_col_slice_preserves_metadata(self):
+        data = np.arange(3 * 4 * 5, dtype=float).reshape(3, 4, 5)
+        sm = SeriesMatrix(
+            data,
+            xindex=np.arange(5),
+            rows={"r0": {}, "r1": {}, "r2": {}},
+            cols={"c0": {}, "c1": {}, "c2": {}, "c3": {}},
+        )
+
+        result = sm[[True, False, True], :, :]
+
+        assert result.shape == (2, 4, 5)
+        np.testing.assert_array_equal(result.value, data[[True, False, True], :, :])
+        assert result.row_keys() == ("r0", "r2")
+        assert result.col_keys() == ("c0", "c1", "c2", "c3")
+
+    def test_boolean_col_mask_with_row_slice_preserves_metadata(self):
+        data = np.arange(3 * 4 * 5, dtype=float).reshape(3, 4, 5)
+        sm = SeriesMatrix(
+            data,
+            xindex=np.arange(5),
+            rows={"r0": {}, "r1": {}, "r2": {}},
+            cols={"c0": {}, "c1": {}, "c2": {}, "c3": {}},
+        )
+
+        result = sm[:, [False, True, False, True], :]
+
+        assert result.shape == (3, 2, 5)
+        np.testing.assert_array_equal(
+            result.value, data[:, [False, True, False, True], :]
+        )
+        assert result.row_keys() == ("r0", "r1", "r2")
+        assert result.col_keys() == ("c1", "c3")
+
     @pytest.mark.parametrize(
         ("row_selector", "col_selector", "expected_shape"),
         [

--- a/tests/types/test_series_matrix_indexing.py
+++ b/tests/types/test_series_matrix_indexing.py
@@ -1,4 +1,5 @@
 """Tests for gwexpy/types/series_matrix_indexing.py."""
+
 from __future__ import annotations
 
 import numpy as np
@@ -18,6 +19,7 @@ def _make_tsm(n_rows=2, n_cols=3, n_t=10):
 # ---------------------------------------------------------------------------
 # __getitem__ — single cell access
 # ---------------------------------------------------------------------------
+
 
 class TestGetItemSingleCell:
     def test_single_cell_int_int(self):
@@ -48,6 +50,7 @@ class TestGetItemSingleCell:
 # ---------------------------------------------------------------------------
 # __getitem__ — slice / non-scalar selection
 # ---------------------------------------------------------------------------
+
 
 class TestGetItemSlice:
     def test_row_slice(self):
@@ -106,6 +109,7 @@ class TestGetItemSlice:
 # ---------------------------------------------------------------------------
 # __getitem__ — label-based (string) indexing
 # ---------------------------------------------------------------------------
+
 
 class TestGetItemLabelBased:
     def test_row_string_indexing(self):
@@ -170,10 +174,43 @@ class TestGetItemLabelBased:
         assert result.row_keys() == ("r0", "r2")
         assert result.col_keys() == ("c1", "c3")
 
+    def test_ndarray_integer_row_list_and_col_list_are_cartesian(self):
+        data = np.arange(3 * 4 * 5, dtype=float).reshape(3, 4, 5)
+        sm = SeriesMatrix(data, xindex=np.arange(5))
+
+        result = sm[np.array([0, 2]), np.array([1, 3]), ...]
+
+        assert result.shape == (2, 2, 5)
+        expected = data[np.ix_([0, 2], [1, 3], np.arange(5))]
+        np.testing.assert_array_equal(result.value, expected)
+
+    def test_ndarray_boolean_row_mask_and_col_mask_are_cartesian(self):
+        data = np.arange(3 * 4 * 5, dtype=float).reshape(3, 4, 5)
+        sm = SeriesMatrix(data, xindex=np.arange(5))
+
+        result = sm[np.array([True, False, True]), np.array([False, True, False, True])]
+
+        assert result.shape == (2, 2, 5)
+        expected = data[np.ix_([0, 2], [1, 3], np.arange(5))]
+        np.testing.assert_array_equal(result.value, expected)
+
+    def test_wrong_length_boolean_mask_raises(self):
+        sm = SeriesMatrix(np.zeros((3, 4, 5)), xindex=np.arange(5))
+
+        with pytest.raises(IndexError, match="selector length mismatch"):
+            sm[[True, False], [1, 3], :]
+
+    def test_non_integer_numeric_selector_raises(self):
+        sm = SeriesMatrix(np.zeros((3, 4, 5)), xindex=np.arange(5))
+
+        with pytest.raises(TypeError, match="integer positions"):
+            sm[[0.0, 2.0], [1, 3], :]
+
 
 # ---------------------------------------------------------------------------
 # __setitem__
 # ---------------------------------------------------------------------------
+
 
 class TestSetItem:
     def test_setitem_plain_value(self):
@@ -209,10 +246,47 @@ class TestSetItem:
         tsm[row_key, col_key, :] = 99.0
         assert np.all(tsm.view(np.ndarray)[0, 0, :] == 99.0)
 
+    def test_setitem_row_list_and_col_list_scalar_is_cartesian(self):
+        data = np.arange(3 * 4 * 5, dtype=float).reshape(3, 4, 5)
+        sm = SeriesMatrix(data.copy(), xindex=np.arange(5))
+
+        sm[[0, 2], [1, 3], :] = -1.0
+
+        expected = data.copy()
+        expected[
+            np.array([0, 2])[:, np.newaxis], np.array([1, 3])[np.newaxis, :], :
+        ] = -1.0
+        np.testing.assert_array_equal(sm.value, expected)
+
+    def test_setitem_row_list_and_col_list_shaped_value_is_cartesian(self):
+        sm = SeriesMatrix(np.zeros((3, 4, 5)), xindex=np.arange(5))
+        values = np.arange(2 * 2 * 5, dtype=float).reshape(2, 2, 5)
+
+        sm[[0, 2], [1, 3], :] = values
+
+        np.testing.assert_array_equal(sm.value[0, 1], values[0, 0])
+        np.testing.assert_array_equal(sm.value[0, 3], values[0, 1])
+        np.testing.assert_array_equal(sm.value[2, 1], values[1, 0])
+        np.testing.assert_array_equal(sm.value[2, 3], values[1, 1])
+        assert np.all(sm.value[1, :, :] == 0.0)
+
+    def test_setitem_wrong_length_boolean_mask_raises(self):
+        sm = SeriesMatrix(np.zeros((3, 4, 5)), xindex=np.arange(5))
+
+        with pytest.raises(IndexError, match="selector length mismatch"):
+            sm[[True, False], [1, 3], :] = 1.0
+
+    def test_setitem_non_integer_numeric_selector_raises(self):
+        sm = SeriesMatrix(np.zeros((3, 4, 5)), xindex=np.arange(5))
+
+        with pytest.raises(TypeError, match="integer positions"):
+            sm[[0.0, 2.0], [1, 3], :] = 1.0
+
 
 # ---------------------------------------------------------------------------
 # loc property
 # ---------------------------------------------------------------------------
+
 
 class TestLoc:
     def test_loc_getitem(self):
@@ -235,6 +309,7 @@ class TestLoc:
 # ---------------------------------------------------------------------------
 # submatrix
 # ---------------------------------------------------------------------------
+
 
 class TestSubmatrix:
     def test_submatrix_label_selection_preserves_cartesian_shape_and_metadata(self):

--- a/tests/types/test_series_matrix_indexing.py
+++ b/tests/types/test_series_matrix_indexing.py
@@ -194,6 +194,31 @@ class TestGetItemLabelBased:
         expected = data[np.ix_([0, 2], [1, 3], np.arange(5))]
         np.testing.assert_array_equal(result.value, expected)
 
+    @pytest.mark.parametrize(
+        ("row_selector", "col_selector", "expected_shape"),
+        [
+            ([], [1, 3], (0, 2, 5)),
+            ([0, 2], [], (2, 0, 5)),
+            (np.array([], dtype=int), np.array([1, 3]), (0, 2, 5)),
+        ],
+    )
+    def test_empty_integer_row_or_col_list_returns_empty_cartesian_submatrix(
+        self, row_selector, col_selector, expected_shape
+    ):
+        data = np.arange(3 * 4 * 5, dtype=float).reshape(3, 4, 5)
+        sm = SeriesMatrix(
+            data,
+            xindex=np.arange(5),
+            rows={"r0": {}, "r1": {}, "r2": {}},
+            cols={"c0": {}, "c1": {}, "c2": {}, "c3": {}},
+        )
+
+        result = sm[row_selector, col_selector, :]
+
+        assert result.shape == expected_shape
+        expected = data[np.ix_(list(row_selector), list(col_selector), np.arange(5))]
+        np.testing.assert_array_equal(result.value, expected)
+
     def test_wrong_length_boolean_mask_raises(self):
         sm = SeriesMatrix(np.zeros((3, 4, 5)), xindex=np.arange(5))
 
@@ -269,6 +294,24 @@ class TestSetItem:
         np.testing.assert_array_equal(sm.value[2, 1], values[1, 0])
         np.testing.assert_array_equal(sm.value[2, 3], values[1, 1])
         assert np.all(sm.value[1, :, :] == 0.0)
+
+    @pytest.mark.parametrize(
+        ("row_selector", "col_selector"),
+        [
+            ([], [1, 3]),
+            ([0, 2], []),
+            (np.array([], dtype=int), np.array([1, 3])),
+        ],
+    )
+    def test_setitem_empty_integer_row_or_col_list_is_noop(
+        self, row_selector, col_selector
+    ):
+        data = np.arange(3 * 4 * 5, dtype=float).reshape(3, 4, 5)
+        sm = SeriesMatrix(data.copy(), xindex=np.arange(5))
+
+        sm[row_selector, col_selector, :] = -1.0
+
+        np.testing.assert_array_equal(sm.value, data)
 
     def test_setitem_wrong_length_boolean_mask_raises(self):
         sm = SeriesMatrix(np.zeros((3, 4, 5)), xindex=np.arange(5))

--- a/tests/types/test_seriesmatrix_fixes.py
+++ b/tests/types/test_seriesmatrix_fixes.py
@@ -172,6 +172,50 @@ def test_constructor_from_seriesmatrix_preserves_axis_and_metadata():
     assert source.attrs["nested"]["version"] == 1
 
 
+def test_constructor_from_seriesmatrix_converts_explicit_unit_override():
+    """Explicit unit overrides convert values instead of only relabeling metadata."""
+    source = SeriesMatrix(
+        np.array([[[1.0, 2.0], [3.0, 4.0]]]),
+        xindex=np.array([0.0, 1.0]),
+        units=[[u.m, u.m]],
+    )
+
+    cloned = SeriesMatrix(source, units=[[u.cm, u.cm]])
+
+    np.testing.assert_allclose(cloned.value, [[[100.0, 200.0], [300.0, 400.0]]])
+    assert cloned.meta[0, 0].unit == u.cm
+    assert cloned.meta[0, 1].unit == u.cm
+
+
+def test_constructor_from_seriesmatrix_rejects_incompatible_unit_override():
+    """Explicit unit overrides must be convertible from the source cell units."""
+    source = SeriesMatrix(
+        np.array([[[1.0, 2.0]]]),
+        xindex=np.array([0.0, 1.0]),
+        units=[[u.m]],
+    )
+
+    with pytest.raises(u.UnitConversionError):
+        SeriesMatrix(source, units=[[u.s]])
+
+
+def test_constructor_from_seriesmatrix_deep_copies_nested_row_col_metadata():
+    """Nested row/column metadata payloads are isolated on clone."""
+    source = SeriesMatrix(
+        np.zeros((1, 1, 2)),
+        xindex=np.array([0.0, 1.0]),
+        rows={"r0": {"payload": {"tags": ["source"]}}},
+        cols={"c0": {"payload": {"limits": {"low": 1}}}},
+    )
+
+    cloned = SeriesMatrix(source)
+    cloned.rows["r0"]["payload"]["tags"].append("clone")
+    cloned.cols["c0"]["payload"]["limits"]["low"] = 99
+
+    assert source.rows["r0"]["payload"]["tags"] == ["source"]
+    assert source.cols["c0"]["payload"]["limits"]["low"] == 1
+
+
 def test_constructor_from_seriesmatrix_allows_explicit_xindex_override():
     """An explicit xindex overrides the source SeriesMatrix sample axis."""
     data = np.ones((1, 1, 3), dtype=float)

--- a/tests/types/test_seriesmatrix_fixes.py
+++ b/tests/types/test_seriesmatrix_fixes.py
@@ -114,6 +114,80 @@ def test_basic_import_and_instantiation():
     assert sm.name == "test_matrix", f"Name incorrect: {sm.name}"
 
 
+def test_constructor_from_seriesmatrix_preserves_axis_and_metadata():
+    """Constructing from SeriesMatrix preserves axis and metadata invariants."""
+    data = np.arange(24, dtype=float).reshape(2, 3, 4)
+    xindex = u.Quantity([10.0, 20.0, 30.0, 40.0], u.s)
+    meta_arr = np.empty((2, 3), dtype=object)
+    for i in range(2):
+        for j in range(3):
+            meta_arr[i, j] = MetaData(
+                unit=u.m,
+                name=f"elem-{i}-{j}",
+                channel=f"H1:TEST_{i}_{j}",
+            )
+
+    source = SeriesMatrix(
+        data,
+        xindex=xindex,
+        meta=MetaDataMatrix(meta_arr),
+        rows={
+            "north": {"name": "north row", "unit": u.m, "role": "sensor"},
+            "south": {"name": "south row", "unit": u.m, "role": "witness"},
+        },
+        cols={
+            "inphase": {"name": "I", "unit": u.V, "role": "signal"},
+            "quadrature": {"name": "Q", "unit": u.V, "role": "signal"},
+            "null": {"name": "N", "unit": u.V, "role": "control"},
+        },
+        name="source-matrix",
+        epoch=123.5,
+        attrs={"nested": {"version": 1}},
+    )
+    for i in range(2):
+        for j in range(3):
+            source.meta[i, j]["tag"] = f"tag-{i}-{j}"
+
+    cloned = SeriesMatrix(source)
+
+    np.testing.assert_allclose(cloned.value, source.value)
+    np.testing.assert_allclose(cloned.xindex.value, xindex.value)
+    assert cloned.xindex.unit == u.s
+    assert cloned.row_keys() == ("north", "south")
+    assert cloned.col_keys() == ("inphase", "quadrature", "null")
+    assert cloned.rows["north"]["role"] == "sensor"
+    assert cloned.cols["null"]["role"] == "control"
+    assert cloned.meta[1, 2].unit == u.m
+    assert cloned.meta[1, 2].name == "elem-1-2"
+    assert cloned.meta[1, 2]["tag"] == "tag-1-2"
+    assert cloned.name == "source-matrix"
+    assert cloned.epoch == 123.5
+    assert cloned.attrs == {"nested": {"version": 1}}
+
+    cloned.meta[1, 2]["tag"] = "changed"
+    cloned.rows["north"]["role"] = "changed"
+    cloned.attrs["nested"]["version"] = 2
+    assert source.meta[1, 2]["tag"] == "tag-1-2"
+    assert source.rows["north"]["role"] == "sensor"
+    assert source.attrs["nested"]["version"] == 1
+
+
+def test_constructor_from_seriesmatrix_allows_explicit_xindex_override():
+    """An explicit xindex overrides the source SeriesMatrix sample axis."""
+    data = np.ones((1, 1, 3), dtype=float)
+    meta = MetaDataMatrix([[MetaData(unit=u.m, name="source")]])
+    source = SeriesMatrix(data, xindex=u.Quantity([0, 1, 2], u.s), meta=meta)
+    source.meta[0, 0]["tag"] = "kept"
+    override_xindex = u.Quantity([0, 100, 200], u.ms)
+
+    cloned = SeriesMatrix(source, xindex=override_xindex, name="override")
+
+    np.testing.assert_allclose(cloned.xindex.value, override_xindex.value)
+    assert cloned.xindex.unit == u.ms
+    assert cloned.meta[0, 0]["tag"] == "kept"
+    assert cloned.name == "override"
+
+
 def test_array_ufunc_comparison_returns_bool():
     """Ensure comparison ufunc results use boolean dtype."""
     data = np.arange(6, dtype=float).reshape(1, 2, 3)


### PR DESCRIPTION
## Summary

- Preserve xindex, row/column metadata, attrs, name, epoch, and per-element metadata when constructing a SeriesMatrix from an existing SeriesMatrix.
- Fix submatrix label selection so resolved integer positions are not reinterpreted as labels and row/column selections produce the Cartesian submatrix.
- Add focused regression coverage for construction and submatrix metadata/axis invariants.

## Validation

- git diff --check
- ruff check gwexpy/types/seriesmatrix_base.py gwexpy/types/seriesmatrix_validation.py gwexpy/types/series_matrix_indexing.py tests/types/test_seriesmatrix_fixes.py tests/types/test_series_matrix_indexing.py
- mypy gwexpy/types/seriesmatrix_base.py gwexpy/types/seriesmatrix_validation.py gwexpy/types/series_matrix_indexing.py
- targeted pytest: 124 passed, 5 warnings
- python -m pytest tests/types -q: 610 passed, 4 skipped, 7 warnings

## Notes

- Focused first implementation PR for Issue #244 after the audit plan.
- Does not touch I/O registry/docs work for #248.

Refs #244