### PR TITLE
[AGENT:docs] Define to_matrix family contracts

### DIFF
--- a/docs/developers/plans/2026-04-26-to-matrix-axis-unit-contract-audit.md
+++ b/docs/developers/plans/2026-04-26-to-matrix-axis-unit-contract-audit.md
@@ -1,7 +1,7 @@
 # to_matrix Axis And Per-Element Unit Contract Audit
 
 Date: 2026-04-26
-Issue: #246, "Audit to_matrix axis and per-element unit contracts across core containers"
+Issue: #270, "Define and test family-specific to_matrix contracts"
 Mode: audit-first only; no runtime behavior changes in this pass.
 
 ## Constraints
@@ -16,7 +16,7 @@ Mode: audit-first only; no runtime behavior changes in this pass.
 
 ## Inputs Reviewed
 
-- Issue #246 body.
+- Issue #270 scope and reviewer blockers for family-specific contract docs/tests.
 - The latest #244 SeriesMatrix audit findings.
 - The merged #243 / #258 MetaData and MetaDataMatrix audit plan.
 - `gwexpy/timeseries/collections.py`
@@ -46,6 +46,30 @@ families:
 
 This split may be intentional, but it should be documented as a family-specific
 contract and tested accordingly.
+
+## Developer Contract Table
+
+This table records the current family-specific contract that downstream code
+can rely on until a later, physics-reviewed runtime change explicitly narrows
+or broadens it.
+
+| Family | Supported collection entry point | Axis comparison and alignment | Resampling and tolerance | Per-element value-unit policy | Global matrix-unit policy | Row/column metadata and round trip |
+| --- | --- | --- | --- | --- | --- | --- |
+| `TimeSeries` | `TimeSeriesDict.to_matrix()` and `TimeSeriesList.to_matrix()` | Aligns every series onto a common time grid through `align_timeseries_collection()`; axes do not need exact equality when the requested overlap/alignment succeeds. | `align="intersection"` is the default. Alignment kwargs, including resampling tolerance where supported by the helper, are delegated to `align_timeseries_collection()`. There is no SeriesMatrix-style exact time-axis comparison at collection conversion time. | Source `TimeSeries.unit` values are not written into `MetaDataMatrix`; reconstructed elements from `to_dict()`/`to_list()` are dimensionless under the current path. Source channels are likewise not preserved in per-cell metadata. | No explicit global matrix unit is set by collection conversion. | Dict keys are written to per-cell names through `channel_names`, but row keys remain generated (`row0`, `row1`, ...), so `to_matrix().to_dict()` does not preserve original dict keys as dictionary keys. List element names become per-cell names when available; list rows are generated. |
+| `FrequencySeries` | `FrequencySeriesDict.to_matrix()` only | Requires equal sample length only. Frequency coordinate values and frequency-axis units are not compared; the output frequency axis is taken from the first element. | No resampling and no tolerance parameter. Same-length, different frequency coordinates are accepted under the current contract. | Each element's `unit`, `name`, and `channel` are stored in `MetaDataMatrix` and restored by `to_dict()`/`to_list()`. | No explicit global matrix unit is set by collection conversion. | Dict keys become row keys and survive `to_matrix().to_dict()`. The single column is named `value`; `to_list()` flattens rows in insertion order. `FrequencySeriesList` currently has no `to_matrix()` method. |
+| `Spectrogram` | `SpectrogramDict.to_matrix()` and `SpectrogramList.to_matrix()` | Requires identical shape, identical times after conversion to the first time-axis unit, and identical frequencies after conversion to the first frequency-axis unit. | No resampling and no tolerance parameter; axis values are compared with exact equality after unit conversion. | Each element's `unit`, `name`, and `channel` are stored in `MetaDataMatrix` and restored by `to_dict()`/`to_list()`. | The matrix `unit` is the first element unit only when all element units are equal; mixed units set the global matrix unit to `None`. | Dict keys become row keys and survive `to_matrix().to_dict()`. List rows are generated (`batch0`, `batch1`, ... for 3D matrices), while `to_list()` preserves element metadata in flattened order. |
+| Field containers | No SeriesMatrix-style collection `to_matrix()` API | `FieldList`/`FieldDict` validation uses field-specific axis compatibility rather than SeriesMatrix conversion. | Field validation uses field tolerances for coordinate values; this is separate from collection `to_matrix()` semantics. | Component units remain on fields; `VectorField.to_array()`/`TensorField.to_array()` return raw arrays without a `MetaDataMatrix`. | Not applicable. | Not applicable to SeriesMatrix round trips. |
+
+Current contract decisions for this audit pass:
+
+- `TimeSeries` source value units and channels are documented as not preserved
+  in `MetaDataMatrix` by collection `to_matrix()` today. Preserving them would
+  be a runtime/data-model change and should be handled in a separate
+  physics-reviewed PR.
+- `FrequencySeriesDict.to_matrix()` is documented and tested as length-only
+  today. Enforcing frequency-axis equality after unit conversion would be a
+  runtime behavior change and should be split from this documentation/test
+  contract PR.
 
 ## Current Contract Summary
 
@@ -207,6 +231,8 @@ contract and tested accordingly.
 ## Audit Notes
 
 - This file records source/test inspection and current contract risks only.
-- No runtime code, tests, or public docs behavior changed in this pass.
+- No runtime code behavior changed in this pass.
+- This pass updates public/docs contract coverage and adds focused contract tests
+  in `tests/types/test_to_matrix_family_contracts.py`.
 - Later behavior changes should be split by container family so tests can encode
   the intended contract before broadening guarantees.

--- a/docs/developers/plans/2026-04-26-to-matrix-axis-unit-contract-audit.md
+++ b/docs/developers/plans/2026-04-26-to-matrix-axis-unit-contract-audit.md
@@ -79,6 +79,9 @@ Current contract decisions for this audit pass:
   `align_timeseries_collection()`. That helper computes a common time grid,
   standardizes time-like axes to seconds/common units, and can resample through
   `TimeSeries.asfreq(..., tolerance=tolerance)`.
+- For mixed sampling steps, `align_timeseries_collection()` selects the
+  coarsest available grid (`max(dt)`) as the target time grid before
+  resampling.
 - This is an alignment contract, not strict equality. Different but overlapping
   axes may succeed after alignment.
 - Mismatch errors exist for empty input, no overlap, incompatible or non-time-like
@@ -99,6 +102,8 @@ Current contract decisions for this audit pass:
 - Axis behavior: `FrequencySeriesDict.to_matrix()` checks only
   `len(fs) == n_samp`. It does not compare `fs.frequencies` values or frequency
   units between elements.
+- HIGH RISK: same-length but different frequency coordinates are silently
+  accepted today; this should be prioritized in the next contract PR.
 - The output uses the first series' frequency axis unconditionally.
 - Length mismatch raises a clear `ValueError`; same-length but different
   frequency coordinates or convertible units are silently accepted.

--- a/docs/web/en/user_guide/gwpy_added_api_index_en.md
+++ b/docs/web/en/user_guide/gwpy_added_api_index_en.md
@@ -24,6 +24,18 @@ If you want the migration entry point first, go back to the [Migration Guide for
 | Conversion method | `FrequencySeriesDict.to_matrix()` -> `FrequencySeriesMatrix` | Stable | turns collections of frequency-series objects into a container suited for pairwise and batch analysis | [FrequencySeriesDict](../reference/FrequencySeriesDict.md), [FrequencySeriesMatrix](../reference/FrequencySeriesMatrix.md) |
 | Conversion method | `SpectrogramDict.to_matrix()` / `SpectrogramList.to_matrix()` -> `SpectrogramMatrix` | Stable | lets time-frequency collections move into a matrix-style container for downstream processing | [SpectrogramDict](../reference/SpectrogramDict.md), [SpectrogramList](../reference/SpectrogramList.md), [SpectrogramMatrix](../reference/SpectrogramMatrix.md) |
 
+#### Family-specific `to_matrix()` contract (current stable behavior)
+
+`to_matrix()` is intentionally family-specific today. Use this table as the
+public contract for what conversion checks and metadata guarantees are applied.
+
+| Family | Collection entry points | Axis policy | Resampling / tolerance | Unit policy | Label / round-trip notes |
+| --- | --- | --- | --- | --- | --- |
+| `TimeSeries` | `TimeSeriesDict.to_matrix()` and `TimeSeriesList.to_matrix()` | Aligns onto a common time grid through `align_timeseries_collection()`; exact axis equality is not required when alignment succeeds. | `align="intersection"` default; forwards alignment kwargs (including `method` and `tolerance`) to the alignment helper. | Source `TimeSeries.unit` is not carried into per-cell matrix metadata by this conversion path; reconstructed elements are dimensionless unless metadata is set separately. | Dict keys are written into element names; generated row keys (`row0`, `row1`, ...) are used for round-trip dict keys. |
+| `FrequencySeries` | `FrequencySeriesDict.to_matrix()` | Checks sample length equality only; frequency coordinate values are taken from the first element. | No resampling and no tolerance parameter. | Per-element `unit` / `name` / `channel` are preserved in matrix metadata and restored by round trip. | Dict keys are preserved as row keys; single output column is `value`. |
+| `Spectrogram` | `SpectrogramDict.to_matrix()` and `SpectrogramList.to_matrix()` | Requires equal shape plus equal time/frequency axes after conversion to the first axis unit. | No resampling and no tolerance parameter; comparisons are exact after unit conversion. | Per-element `unit` / `name` / `channel` are preserved; global matrix unit is set only when all elements share the same unit. | Dict keys are preserved as row keys; list rows are generated (`batch0`, `batch1`, ...). |
+| Fields | No SeriesMatrix `to_matrix()` collection API | Uses `FieldList` / `FieldDict` validation rules instead of SeriesMatrix conversion. | Field validation has its own axis tolerance checks. | Units stay on field objects; `to_array()` returns raw arrays. | Not a SeriesMatrix round-trip path. |
+
 ### Added Methods
 
 | API Kind | Representative API | Stability | What it adds relative to GWpy | Details |

--- a/tests/segments/test_flag.py
+++ b/tests/segments/test_flag.py
@@ -1,1 +1,6 @@
+import pytest
 from gwpy.segments.tests.test_flag import *  # noqa: F403
+
+TestDataQualityFlag.test_fetch_open_data = pytest.mark.network(  # noqa: F405
+    TestDataQualityFlag.test_fetch_open_data  # noqa: F405
+)

--- a/tests/types/test_to_matrix_family_contracts.py
+++ b/tests/types/test_to_matrix_family_contracts.py
@@ -12,6 +12,7 @@ from gwexpy.timeseries.collections import TimeSeriesDict, TimeSeriesList
 
 
 def _channel_text(channel) -> str:
+    # channel may be a Channel object; normalize to string for comparisons.
     return str(channel)
 
 
@@ -127,6 +128,7 @@ def test_timeseriesdict_to_matrix_tolerance_controls_shifted_grid_matching():
     )
 
     assert strict.value[0, 0].shape == (3,)
+    # method=None does not interpolate outside the shifted grid, so values stay NaN.
     assert np.isnan(strict.value[0, 0]).all()
     assert np.array_equal(tolerant.times.to_value(u.s), [1.01, 2.01, 3.01])
     assert np.array_equal(tolerant.value[0, 0], [2.0, 3.0, 4.0])

--- a/tests/types/test_to_matrix_family_contracts.py
+++ b/tests/types/test_to_matrix_family_contracts.py
@@ -5,6 +5,7 @@ import pytest
 from astropy import units as u
 
 from gwexpy.frequencyseries import FrequencySeries, FrequencySeriesDict
+from gwexpy.frequencyseries.collections import FrequencySeriesList
 from gwexpy.spectrogram import Spectrogram, SpectrogramDict, SpectrogramList
 from gwexpy.timeseries import TimeSeries
 from gwexpy.timeseries.collections import TimeSeriesDict, TimeSeriesList
@@ -125,6 +126,7 @@ def test_timeseriesdict_to_matrix_tolerance_controls_shifted_grid_matching():
         tolerance=0.02,
     )
 
+    assert strict.value[0, 0].shape == (3,)
     assert np.isnan(strict.value[0, 0]).all()
     assert np.array_equal(tolerant.times.to_value(u.s), [1.01, 2.01, 3.01])
     assert np.array_equal(tolerant.value[0, 0], [2.0, 3.0, 4.0])
@@ -170,6 +172,10 @@ def test_frequencyseriesdict_to_matrix_is_length_only_and_preserves_metadata_rou
     ]
     assert [series.name for series in restored_list] == ["freq-a", "freq-b"]
     assert [series.unit for series in restored_list] == [u.V, u.A]
+
+
+def test_frequencyserieslist_has_no_to_matrix_contract():
+    assert not hasattr(FrequencySeriesList, "to_matrix")
 
 
 def test_spectrogramdict_to_matrix_roundtrip_preserves_row_keys_units_and_channels():

--- a/tests/types/test_to_matrix_family_contracts.py
+++ b/tests/types/test_to_matrix_family_contracts.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from astropy import units as u
+
+from gwexpy.frequencyseries import FrequencySeries, FrequencySeriesDict
+from gwexpy.spectrogram import Spectrogram, SpectrogramDict, SpectrogramList
+from gwexpy.timeseries import TimeSeries
+from gwexpy.timeseries.collections import TimeSeriesDict, TimeSeriesList
+
+
+def _channel_text(channel) -> str:
+    return str(channel)
+
+
+def test_timeseriesdict_to_matrix_roundtrip_uses_names_not_row_keys_or_source_units():
+    ts_a = TimeSeries(
+        [1.0, 2.0, 3.0],
+        t0=0,
+        dt=1,
+        unit=u.m,
+        name="source-a",
+        channel="H1:TS_A",
+    )
+    ts_b = TimeSeries(
+        [4.0, 5.0, 6.0],
+        t0=0,
+        dt=1,
+        unit=u.cm,
+        name="source-b",
+        channel="H1:TS_B",
+    )
+
+    matrix = TimeSeriesDict({"a": ts_a, "b": ts_b}).to_matrix()
+
+    assert matrix.row_keys() == ("row0", "row1")
+    assert matrix.col_keys() == ("col0",)
+    assert matrix.names.tolist() == [["a"], ["b"]]
+    assert matrix.meta.units.tolist() == [
+        [u.dimensionless_unscaled],
+        [u.dimensionless_unscaled],
+    ]
+    assert "H1:TS_A" not in [_channel_text(ch) for ch in matrix.meta.channels.flat]
+    assert "H1:TS_B" not in [_channel_text(ch) for ch in matrix.meta.channels.flat]
+
+    restored_dict = matrix.to_dict()
+    restored_list = matrix.to_list()
+
+    assert list(restored_dict.keys()) == ["row0", "row1"]
+    assert [series.name for series in restored_dict.values()] == ["a", "b"]
+    assert [series.unit for series in restored_dict.values()] == [
+        u.dimensionless_unscaled,
+        u.dimensionless_unscaled,
+    ]
+    assert [series.name for series in restored_list] == ["a", "b"]
+
+
+def test_timeserieslist_to_matrix_roundtrip_keeps_element_names_but_not_units_or_channels():
+    ts_a = TimeSeries(
+        [1.0, 2.0, 3.0],
+        t0=0,
+        dt=1,
+        unit=u.V,
+        name="sensor-a",
+        channel="H1:LIST_A",
+    )
+    ts_b = TimeSeries(
+        [4.0, 5.0, 6.0],
+        t0=0,
+        dt=1,
+        unit=u.A,
+        name="sensor-b",
+        channel="H1:LIST_B",
+    )
+
+    matrix = TimeSeriesList([ts_a, ts_b]).to_matrix()
+
+    assert matrix.row_keys() == ("row0", "row1")
+    assert matrix.names.tolist() == [["sensor-a"], ["sensor-b"]]
+    assert matrix.meta.units.tolist() == [
+        [u.dimensionless_unscaled],
+        [u.dimensionless_unscaled],
+    ]
+    assert "H1:LIST_A" not in [_channel_text(ch) for ch in matrix.meta.channels.flat]
+    assert "H1:LIST_B" not in [_channel_text(ch) for ch in matrix.meta.channels.flat]
+
+    restored = matrix.to_list()
+    assert [series.name for series in restored] == ["sensor-a", "sensor-b"]
+    assert [series.unit for series in restored] == [
+        u.dimensionless_unscaled,
+        u.dimensionless_unscaled,
+    ]
+
+
+def test_timeseriesdict_to_matrix_aligns_intersection_without_requiring_identical_axes():
+    ts_a = TimeSeries([1.0, 2.0, 3.0, 4.0], t0=0, dt=1, unit=u.m)
+    ts_b = TimeSeries([10.0, 20.0, 30.0, 40.0], t0=1, dt=1, unit=u.m)
+
+    matrix = TimeSeriesDict({"a": ts_a, "b": ts_b}).to_matrix()
+
+    assert np.array_equal(matrix.times.to_value(u.s), [1.0, 2.0, 3.0])
+    assert np.array_equal(matrix.value[0, 0], [2.0, 3.0, 4.0])
+    assert np.array_equal(matrix.value[1, 0], [10.0, 20.0, 30.0])
+
+
+def test_timeserieslist_to_matrix_resamples_to_coarsest_dt_grid():
+    ts_fast = TimeSeries([0.0, 1.0, 2.0, 3.0, 4.0, 5.0], t0=0, dt=1, unit=u.m)
+    ts_slow = TimeSeries([10.0, 20.0, 30.0], t0=0, dt=2, unit=u.m)
+
+    matrix = TimeSeriesList([ts_fast, ts_slow]).to_matrix()
+
+    assert np.array_equal(matrix.times.to_value(u.s), [0.0, 2.0, 4.0])
+    assert np.array_equal(matrix.value[0, 0], [0.0, 2.0, 4.0])
+    assert np.array_equal(matrix.value[1, 0], [10.0, 20.0, 30.0])
+
+
+def test_timeseriesdict_to_matrix_tolerance_controls_shifted_grid_matching():
+    ts_ref = TimeSeries([1.0, 2.0, 3.0, 4.0], t0=0, dt=1, unit=u.m)
+    ts_shifted = TimeSeries([10.0, 20.0, 30.0, 40.0], t0=1.01, dt=1, unit=u.m)
+
+    strict = TimeSeriesDict({"a": ts_ref, "b": ts_shifted}).to_matrix(method=None)
+    tolerant = TimeSeriesDict({"a": ts_ref, "b": ts_shifted}).to_matrix(
+        method="nearest",
+        tolerance=0.02,
+    )
+
+    assert np.isnan(strict.value[0, 0]).all()
+    assert np.array_equal(tolerant.times.to_value(u.s), [1.01, 2.01, 3.01])
+    assert np.array_equal(tolerant.value[0, 0], [2.0, 3.0, 4.0])
+    assert np.array_equal(tolerant.value[1, 0], [10.0, 20.0, 30.0])
+
+
+def test_frequencyseriesdict_to_matrix_is_length_only_and_preserves_metadata_roundtrip():
+    fs_a = FrequencySeries(
+        [1.0, 2.0, 3.0],
+        frequencies=[0.0, 1.0, 2.0] * u.Hz,
+        unit=u.V,
+        name="freq-a",
+        channel="H1:FS_A",
+    )
+    fs_b = FrequencySeries(
+        [4.0, 5.0, 6.0],
+        frequencies=[10.0, 11.0, 12.0] * u.Hz,
+        unit=u.A,
+        name="freq-b",
+        channel="H1:FS_B",
+    )
+
+    matrix = FrequencySeriesDict({"fa": fs_a, "fb": fs_b}).to_matrix()
+
+    assert matrix.row_keys() == ("fa", "fb")
+    assert matrix.col_keys() == ("value",)
+    assert np.array_equal(matrix.frequencies.to_value(u.Hz), [0.0, 1.0, 2.0])
+    assert matrix.names.tolist() == [["freq-a"], ["freq-b"]]
+    assert matrix.meta.units.tolist() == [[u.V], [u.A]]
+    assert [_channel_text(ch) for ch in matrix.meta.channels.flat] == [
+        "H1:FS_A",
+        "H1:FS_B",
+    ]
+
+    restored_dict = matrix.to_dict()
+    restored_list = matrix.to_list()
+
+    assert list(restored_dict.keys()) == ["fa", "fb"]
+    assert [series.unit for series in restored_dict.values()] == [u.V, u.A]
+    assert [_channel_text(series.channel) for series in restored_dict.values()] == [
+        "H1:FS_A",
+        "H1:FS_B",
+    ]
+    assert [series.name for series in restored_list] == ["freq-a", "freq-b"]
+    assert [series.unit for series in restored_list] == [u.V, u.A]
+
+
+def test_spectrogramdict_to_matrix_roundtrip_preserves_row_keys_units_and_channels():
+    times = [0.0, 1.0] * u.s
+    freqs = [10.0, 20.0, 30.0] * u.Hz
+    sg_a = Spectrogram(
+        np.ones((2, 3)),
+        times=times,
+        frequencies=freqs,
+        unit=u.V,
+        name="spec-a",
+        channel="H1:SG_A",
+    )
+    sg_b = Spectrogram(
+        np.ones((2, 3)) * 2.0,
+        times=times,
+        frequencies=freqs,
+        unit=u.A,
+        name="spec-b",
+        channel="H1:SG_B",
+    )
+
+    matrix = SpectrogramDict({"sa": sg_a, "sb": sg_b}).to_matrix()
+
+    assert matrix.row_keys() == ("sa", "sb")
+    assert matrix.unit is None
+    assert [meta.name for meta in matrix.meta.flat] == ["spec-a", "spec-b"]
+    assert [meta.unit for meta in matrix.meta.flat] == [u.V, u.A]
+    assert [_channel_text(meta.channel) for meta in matrix.meta.flat] == [
+        "H1:SG_A",
+        "H1:SG_B",
+    ]
+
+    restored_dict = matrix.to_dict()
+    restored_list = matrix.to_list()
+
+    assert list(restored_dict.keys()) == ["sa", "sb"]
+    assert [spectrogram.unit for spectrogram in restored_dict.values()] == [u.V, u.A]
+    assert [_channel_text(sg.channel) for sg in restored_dict.values()] == [
+        "H1:SG_A",
+        "H1:SG_B",
+    ]
+    assert [spectrogram.name for spectrogram in restored_list] == ["spec-a", "spec-b"]
+
+
+def test_spectrogramlist_to_matrix_uses_generated_rows_but_preserves_element_metadata():
+    times = [0.0, 1.0] * u.s
+    freqs = [10.0, 20.0, 30.0] * u.Hz
+    sg_a = Spectrogram(
+        np.ones((2, 3)),
+        times=times,
+        frequencies=freqs,
+        unit=u.V,
+        name="list-spec-a",
+        channel="H1:SGL_A",
+    )
+    sg_b = Spectrogram(
+        np.ones((2, 3)) * 2.0,
+        times=times,
+        frequencies=freqs,
+        unit=u.V,
+        name="list-spec-b",
+        channel="H1:SGL_B",
+    )
+
+    matrix = SpectrogramList([sg_a, sg_b]).to_matrix()
+
+    assert matrix.row_keys() == ("batch0", "batch1")
+    assert matrix.unit == u.V
+    assert [meta.name for meta in matrix.meta.flat] == [
+        "list-spec-a",
+        "list-spec-b",
+    ]
+    assert [_channel_text(meta.channel) for meta in matrix.meta.flat] == [
+        "H1:SGL_A",
+        "H1:SGL_B",
+    ]
+
+    restored = matrix.to_list()
+    assert [spectrogram.name for spectrogram in restored] == [
+        "list-spec-a",
+        "list-spec-b",
+    ]
+    assert [_channel_text(sg.channel) for sg in restored] == [
+        "H1:SGL_A",
+        "H1:SGL_B",
+    ]
+
+
+def test_spectrogramlist_to_matrix_accepts_convertible_frequency_axis_units():
+    times = [0.0, 1.0] * u.s
+    freqs_hz = [100.0, 200.0, 300.0] * u.Hz
+    freqs_khz = [0.1, 0.2, 0.3] * u.kHz
+
+    sg_hz = Spectrogram(np.ones((2, 3)), times=times, frequencies=freqs_hz, unit=u.V)
+    sg_khz = Spectrogram(
+        np.ones((2, 3)) * 2.0,
+        times=times,
+        frequencies=freqs_khz,
+        unit=u.A,
+    )
+
+    matrix = SpectrogramList([sg_hz, sg_khz]).to_matrix()
+
+    assert np.array_equal(matrix.frequencies.to_value(u.Hz), [100.0, 200.0, 300.0])
+
+
+def test_spectrogramlist_to_matrix_rejects_tiny_frequency_axis_differences_without_tolerance():
+    times = [0.0, 1.0] * u.s
+    freqs_ref = [10.0, 20.0, 30.0] * u.Hz
+    freqs_offset = [10.0 + 1e-12, 20.0, 30.0] * u.Hz
+
+    sg_ref = Spectrogram(np.ones((2, 3)), times=times, frequencies=freqs_ref, unit=u.V)
+    sg_offset = Spectrogram(
+        np.ones((2, 3)),
+        times=times,
+        frequencies=freqs_offset,
+        unit=u.V,
+    )
+
+    with pytest.raises(ValueError, match="Frequencies mismatch"):
+        SpectrogramList([sg_ref, sg_offset]).to_matrix()
+
+
+def test_spectrogramdict_to_matrix_rejects_tiny_time_axis_differences_without_tolerance():
+    times_ref = [0.0, 1.0] * u.s
+    times_offset = [0.0, 1.0 + 1e-12] * u.s
+    freqs = [10.0, 20.0, 30.0] * u.Hz
+
+    sg_ref = Spectrogram(
+        np.ones((2, 3)),
+        times=times_ref,
+        frequencies=freqs,
+        unit=u.V,
+    )
+    sg_offset = Spectrogram(
+        np.ones((2, 3)),
+        times=times_offset,
+        frequencies=freqs,
+        unit=u.V,
+    )
+
+    with pytest.raises(ValueError, match="Times mismatch"):
+        SpectrogramDict({"a": sg_ref, "b": sg_offset}).to_matrix()


### PR DESCRIPTION
Closes #270

## Summary
- Added a public-facing family-specific to_matrix() contract table.
- Updated the developer audit plan to target #270 and reflect the docs/tests pass.
- Added focused tests for TimeSeries, FrequencySeries, and Spectrogram to_matrix() contracts, including labels, units, channels, alignment/resampling, tolerance behavior, and Spectrogram axis strictness.
- Marked the inherited GWOSC open-data segment test as network-only so the non-network Core I/O contract gate does not attempt live gwosc.org access.

## Validation
- rtk git diff --check
- rtk ruff check tests/types/test_to_matrix_family_contracts.py
- rtk env MPLCONFIGDIR=/tmp pytest -q tests/types/test_to_matrix_family_contracts.py tests/timeseries/test_collections_batch.py tests/frequencyseries/test_frequencyseries_containers.py tests/spectrogram/test_to_matrix_semantics.py -> 62 passed, 4 warnings

## Notes
- Docs/tests only; no runtime behavior changes.
- Final review approved this as closing #270 once staged.
