### PR TITLE
[AGENT:validation] Preserve SeriesMatrix round-trip metadata

### DIFF
--- a/docs/developers/plans/2026-04-26-core-data-model-roundtrip-metadata-audit.md
+++ b/docs/developers/plans/2026-04-26-core-data-model-roundtrip-metadata-audit.md
@@ -176,10 +176,34 @@ Mode: audit-first only; no runtime behavior changes in this pass.
 - #246 defines the `to_matrix()` axis/unit/per-element metadata contract before
   round-trip paths can promise preservation of those converted objects.
 
+## Wave 1 Contract Test Update
+
+Date: 2026-04-27
+Issue: #271
+
+- Added focused SeriesMatrix-family contract tests for `SeriesMatrix`,
+  `TimeSeriesMatrix`, and `FrequencySeriesMatrix` copy, typed view, pickle,
+  HDF5, pandas DataFrame, and CSV paths.
+- The tests assert the metadata-preserving paths keep values, sample-axis
+  values/units, matrix `name`, `epoch`, JSON attrs, per-element
+  units/names/channels, and row/column metadata.
+- The tests explicitly mark typed views as metadata-preserving but aliased:
+  values and metadata remain available, while `meta`, `rows`, `cols`, and
+  `attrs` are shared by reference.
+- The tests explicitly mark `to_pandas()` and CSV writes as value exports:
+  numeric values, sample index values, and row/column keys are preserved in
+  tabular form, while element metadata, row/column metadata payloads, `attrs`,
+  `epoch`, and reconstructable sample-axis unit metadata are intentionally
+  absent.
+- A narrow `SeriesMatrix` pickle state fix now preserves the same metadata
+  contract for `SeriesMatrix`, `TimeSeriesMatrix`, and `FrequencySeriesMatrix`
+  without changing public file I/O behavior.
+
 ## Audit Notes
 
-- This file records source/test inspection and current contract risks only.
+- The original 2026-04-26 audit content records source/test inspection and
+  current contract risks only.
 - No runtime code, tests, public docs, commits, or behavior changed as part of
-  the audit content.
+  the original audit content; later sections may record follow-up PR work.
 - Follow-up changes should explicitly mark intentional metadata loss versus
   regression candidates.

--- a/docs/web/en/reference/SeriesMatrix.md
+++ b/docs/web/en/reference/SeriesMatrix.md
@@ -43,6 +43,20 @@ The detailed generated API continues below on this page.
 
 <!-- reference-summary:end -->
 
+## Round-Trip Metadata Contract
+
+Use `copy()`, Python pickle, or `to_hdf5()` / `read(..., format="hdf5")` when a
+`SeriesMatrix`-family object must preserve matrix values, the sample axis,
+per-element units/names/channels, row and column metadata, `name`, `epoch`, and
+JSON-serializable `attrs`.
+
+`to_pandas()` and `write(..., format="csv")` / `write(..., format="parquet")`
+are value exports. They preserve the numeric values, sample index values, and
+row/column keys flattened into tabular labels, but they do not preserve
+per-element metadata, row/column metadata payloads, `attrs`, `epoch`, or the
+sample-axis unit as reconstructable object metadata. Prefer HDF5 for
+metadata-preserving interchange.
+
 
 **Inherits from:** RegularityMixin, InteropMixin, SeriesMatrixCoreMixin, SeriesMatrixIndexingMixin, SeriesMatrixIOMixin, SeriesMatrixMathMixin, SeriesMatrixAnalysisMixin, SeriesMatrixStructureMixin, SeriesMatrixVisualizationMixin, SeriesMatrixValidationMixin, StatisticalMethodsMixin, ndarray
 
@@ -532,6 +546,11 @@ to_hdf5(self, filepath, **kwargs)
 
 Write matrix to HDF5 file.
 
+This is the preferred metadata-preserving file path for `SeriesMatrix` objects:
+values, sample-axis values and unit, element metadata, row/column metadata,
+`name`, `epoch`, and JSON-serializable `attrs` are part of the round-trip
+contract.
+
 ### `to_jax`
 
 ```python
@@ -554,7 +573,12 @@ Convert matrix to an appropriate collection list (e.g. TimeSeriesList).
 to_pandas(self, format='wide')
 ```
 
-Convert matrix to a pandas DataFrame.
+Convert matrix values to a pandas DataFrame.
+
+This is a value export, not an object metadata round-trip. The DataFrame keeps
+numeric values, sample index values, and row/column keys in wide or long form,
+but drops element metadata, row/column metadata payloads, `attrs`, `epoch`, and
+reconstructable sample-axis unit metadata.
 
 ### `to_series_1Dlist`
 
@@ -662,6 +686,10 @@ write(self, target, format=None, **kwargs)
 
 Write matrix to file.
 
+`format="hdf5"` preserves the object metadata contract described above. CSV and
+parquet writes use `to_pandas(format="wide")` and should be treated as
+value-only exports.
+
 ### `x0`
 
 Starting value of the sample axis.
@@ -681,4 +709,3 @@ Full extent of the sample axis as a tuple (start, end).
 ### `xunit`
 
 _No documentation available._
-

--- a/gwexpy/types/seriesmatrix_base.py
+++ b/gwexpy/types/seriesmatrix_base.py
@@ -282,6 +282,25 @@ class SeriesMatrix(  # type: ignore[misc]
             if key.startswith("_gwex_") and key not in self.__dict__:
                 self.__dict__[key] = val
 
+    def __reduce__(self) -> tuple[Any, ...]:
+        """Include SeriesMatrix metadata in ndarray-subclass pickle state."""
+        picked = list(super().__reduce__())
+        matrix_state = {k: v for k, v in self.__dict__.items() if k != "_value"}
+        picked[2] = picked[2] + (matrix_state,)
+        return tuple(picked)
+
+    def __setstate__(self, state: tuple[Any, ...]) -> None:
+        """Restore SeriesMatrix metadata from pickle state."""
+        if state and isinstance(state[-1], dict):
+            matrix_state = state[-1]
+            ndarray_state = state[:-1]
+        else:
+            matrix_state = {}
+            ndarray_state = state
+        super().__setstate__(ndarray_state)
+        self.__dict__.update(matrix_state)
+        self._value = self.view(np.ndarray)
+
     def __array_ufunc__(
         self, ufunc: Any, method: str, *inputs: Any, **kwargs: Any
     ) -> Any:

--- a/gwexpy/types/seriesmatrix_base.py
+++ b/gwexpy/types/seriesmatrix_base.py
@@ -37,6 +37,16 @@ from .seriesmatrix_validation import (
 
 logger = logging.getLogger(__name__)
 
+_SERIESMATRIX_PICKLE_METADATA_FIELDS = (
+    "_xindex",
+    "meta",
+    "rows",
+    "cols",
+    "name",
+    "epoch",
+    "attrs",
+)
+
 _ADD_SUB_COMPARISON_UFUNCS = {
     np.add,
     np.subtract,
@@ -285,8 +295,13 @@ class SeriesMatrix(  # type: ignore[misc]
     def __reduce__(self) -> tuple[Any, ...]:
         """Include SeriesMatrix metadata in ndarray-subclass pickle state."""
         picked = list(super().__reduce__())
-        matrix_state = {k: v for k, v in self.__dict__.items() if k != "_value"}
-        picked[2] = picked[2] + (matrix_state,)
+        matrix_state = {
+            key: value
+            for key, value in self.__dict__.items()
+            if key in _SERIESMATRIX_PICKLE_METADATA_FIELDS
+        }
+        base_state = picked[2] if isinstance(picked[2], tuple) else ()
+        picked[2] = base_state + (matrix_state,)
         return tuple(picked)
 
     def __setstate__(self, state: tuple[Any, ...]) -> None:

--- a/gwexpy/types/seriesmatrix_base.py
+++ b/gwexpy/types/seriesmatrix_base.py
@@ -321,6 +321,9 @@ class SeriesMatrix(  # type: ignore[misc]
 
     def __reduce_ex__(self, protocol: SupportsIndex) -> tuple[Any, ...]:
         """Include SeriesMatrix metadata using the active pickle protocol."""
+        reducer = type(self).__reduce__
+        if reducer is not SeriesMatrix.__reduce__:
+            return cast(Any, reducer)(self)
         return self._reduce_with_protocol(protocol.__index__())
 
     def __reduce__(self) -> tuple[Any, ...]:

--- a/gwexpy/types/seriesmatrix_base.py
+++ b/gwexpy/types/seriesmatrix_base.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import logging
+import pickle
 import warnings
 from collections import OrderedDict
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Optional, SupportsIndex, cast
 
 import numpy as np
 from astropy import units as u
@@ -87,6 +88,20 @@ def _copy_metadata_dict(meta: MetaDataDict, key_prefix: str) -> MetaDataDict:
     for key, value in meta.items():
         items[key] = MetaData(**deepcopy(dict(value)))
     return MetaDataDict(items, expected_size=len(items), key_prefix=key_prefix)
+
+
+def _pickle_safe_attrs(attrs: Any, protocol: int) -> dict[str, Any]:
+    """Return attrs entries that can be serialized by pickle."""
+    if not isinstance(attrs, dict):
+        return {}
+    safe_attrs = {}
+    for key, value in attrs.items():
+        try:
+            pickle.dumps((key, value), protocol=protocol)
+        except Exception:
+            continue
+        safe_attrs[key] = value
+    return safe_attrs
 
 
 class PerformanceWarning(RuntimeWarning):
@@ -292,17 +307,25 @@ class SeriesMatrix(  # type: ignore[misc]
             if key.startswith("_gwex_") and key not in self.__dict__:
                 self.__dict__[key] = val
 
-    def __reduce__(self) -> tuple[Any, ...]:
+    def _reduce_with_protocol(self, protocol: int) -> tuple[Any, ...]:
         """Include SeriesMatrix metadata in ndarray-subclass pickle state."""
-        picked = list(super().__reduce__())
+        picked = list(np.ndarray.__reduce__(self))
         matrix_state = {
-            key: value
+            key: _pickle_safe_attrs(value, protocol) if key == "attrs" else value
             for key, value in self.__dict__.items()
             if key in _SERIESMATRIX_PICKLE_METADATA_FIELDS
         }
         base_state = picked[2] if isinstance(picked[2], tuple) else ()
         picked[2] = base_state + (matrix_state,)
         return tuple(picked)
+
+    def __reduce_ex__(self, protocol: SupportsIndex) -> tuple[Any, ...]:
+        """Include SeriesMatrix metadata using the active pickle protocol."""
+        return self._reduce_with_protocol(protocol.__index__())
+
+    def __reduce__(self) -> tuple[Any, ...]:
+        """Include SeriesMatrix metadata for legacy pickle callers."""
+        return self._reduce_with_protocol(pickle.DEFAULT_PROTOCOL)
 
     def __setstate__(self, state: tuple[Any, ...]) -> None:
         """Restore SeriesMatrix metadata from pickle state."""

--- a/tests/types/test_series_matrix_roundtrip_contracts.py
+++ b/tests/types/test_series_matrix_roundtrip_contracts.py
@@ -146,6 +146,19 @@ def test_pickle_roundtrip_preserves_matrix_metadata_contract(matrix_cls):
 
 
 @pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)
+def test_setstate_backward_compat_without_metadata_dict(matrix_cls):
+    matrix = _make_matrix(matrix_cls)
+    reconstruct, args, state = matrix.__reduce__()
+    old_state = state[:-1]
+
+    restored = reconstruct(*args)
+    restored.__setstate__(old_state)
+
+    assert isinstance(restored, matrix_cls)
+    np.testing.assert_array_equal(restored.view(np.ndarray), matrix.view(np.ndarray))
+
+
+@pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)
 def test_hdf5_roundtrip_preserves_matrix_metadata_contract(tmp_path, matrix_cls):
     pytest.importorskip("h5py")
     matrix = _make_matrix(matrix_cls)

--- a/tests/types/test_series_matrix_roundtrip_contracts.py
+++ b/tests/types/test_series_matrix_roundtrip_contracts.py
@@ -84,20 +84,20 @@ def _assert_metadata_contract(restored: SeriesMatrix, expected: SeriesMatrix) ->
 
     assert list(restored.rows.keys()) == list(expected.rows.keys())
     assert list(restored.cols.keys()) == list(expected.cols.keys())
-    assert restored.rows["rowA"].name == "row_a"
-    assert restored.rows["rowA"].unit == u.m
-    assert str(restored.rows["rowA"].channel) == "H1:ROW_A"
-    assert restored.cols["colY"].name == "col_y"
-    assert restored.cols["colY"].unit == u.kg
-    assert str(restored.cols["colY"].channel) == "L1:COL_Y"
+    assert restored.rows["rowA"].name == expected.rows["rowA"].name
+    assert restored.rows["rowA"].unit == expected.rows["rowA"].unit
+    assert str(restored.rows["rowA"].channel) == str(expected.rows["rowA"].channel)
+    assert restored.cols["colY"].name == expected.cols["colY"].name
+    assert restored.cols["colY"].unit == expected.cols["colY"].unit
+    assert str(restored.cols["colY"].channel) == str(expected.cols["colY"].channel)
 
     assert restored.meta.shape == expected.meta.shape
-    assert restored.meta[0, 0].name == "elem_r0c0"
-    assert restored.meta[0, 0].unit == u.m
-    assert str(restored.meta[0, 0].channel) == "H1:E00"
-    assert restored.meta[1, 1].name == "elem_r1c1"
-    assert restored.meta[1, 1].unit == u.kg
-    assert str(restored.meta[1, 1].channel) == "L1:E11"
+    assert restored.meta[0, 0].name == expected.meta[0, 0].name
+    assert restored.meta[0, 0].unit == expected.meta[0, 0].unit
+    assert str(restored.meta[0, 0].channel) == str(expected.meta[0, 0].channel)
+    assert restored.meta[1, 1].name == expected.meta[1, 1].name
+    assert restored.meta[1, 1].unit == expected.meta[1, 1].unit
+    assert str(restored.meta[1, 1].channel) == str(expected.meta[1, 1].channel)
 
 
 def _xindex_values(matrix: SeriesMatrix) -> np.ndarray:
@@ -156,6 +156,27 @@ def test_setstate_backward_compat_without_metadata_dict(matrix_cls):
 
     assert isinstance(restored, matrix_cls)
     np.testing.assert_array_equal(restored.view(np.ndarray), matrix.view(np.ndarray))
+    assert restored.xindex is None
+    assert not hasattr(restored, "meta")
+    assert not hasattr(restored, "rows")
+    assert not hasattr(restored, "cols")
+    assert not hasattr(restored, "name")
+    assert not hasattr(restored, "epoch")
+    assert not hasattr(restored, "attrs")
+
+
+def test_pickle_ignores_runtime_gwex_attributes_not_in_metadata_contract():
+    matrix = _make_matrix(SeriesMatrix)
+
+    def callback() -> None:
+        return None
+
+    matrix._gwex_runtime_callback = callback
+
+    restored = pickle.loads(pickle.dumps(matrix))
+
+    _assert_metadata_contract(restored, matrix)
+    assert not hasattr(restored, "_gwex_runtime_callback")
 
 
 @pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)

--- a/tests/types/test_series_matrix_roundtrip_contracts.py
+++ b/tests/types/test_series_matrix_roundtrip_contracts.py
@@ -1,0 +1,222 @@
+"""Round-trip metadata contracts for SeriesMatrix-family containers."""
+from __future__ import annotations
+
+import pickle
+
+import numpy as np
+import pytest
+from astropy import units as u
+
+from gwexpy.frequencyseries import FrequencySeriesMatrix
+from gwexpy.timeseries import TimeSeriesMatrix
+from gwexpy.types import MetaData, MetaDataDict, MetaDataMatrix, SeriesMatrix
+
+MATRIX_CLASSES = (SeriesMatrix, TimeSeriesMatrix, FrequencySeriesMatrix)
+
+
+def _metadata_matrix() -> MetaDataMatrix:
+    return MetaDataMatrix(
+        [
+            [
+                MetaData(name="elem_r0c0", unit=u.m, channel="H1:E00"),
+                MetaData(name="elem_r0c1", unit=u.s, channel="H1:E01"),
+            ],
+            [
+                MetaData(name="elem_r1c0", unit=u.Hz, channel="L1:E10"),
+                MetaData(name="elem_r1c1", unit=u.kg, channel="L1:E11"),
+            ],
+        ]
+    )
+
+
+def _rows() -> MetaDataDict:
+    return MetaDataDict(
+        {
+            "rowA": MetaData(name="row_a", unit=u.m, channel="H1:ROW_A"),
+            "rowB": MetaData(name="row_b", unit=u.s, channel="L1:ROW_B"),
+        },
+        expected_size=2,
+        key_prefix="row",
+    )
+
+
+def _cols() -> MetaDataDict:
+    return MetaDataDict(
+        {
+            "colX": MetaData(name="col_x", unit=u.Hz, channel="H1:COL_X"),
+            "colY": MetaData(name="col_y", unit=u.kg, channel="L1:COL_Y"),
+        },
+        expected_size=2,
+        key_prefix="col",
+    )
+
+
+def _make_matrix(matrix_cls: type[SeriesMatrix]) -> SeriesMatrix:
+    data = np.arange(2 * 2 * 5, dtype=float).reshape(2, 2, 5)
+    kwargs = {
+        "meta": _metadata_matrix(),
+        "rows": _rows(),
+        "cols": _cols(),
+        "name": "roundtrip-contract",
+        "epoch": 1234.5,
+        "attrs": {"pipeline": "wave1", "version": 271},
+    }
+    if matrix_cls is TimeSeriesMatrix:
+        return matrix_cls(data, times=np.arange(5) * u.s, **kwargs)
+    if matrix_cls is FrequencySeriesMatrix:
+        return matrix_cls(data, frequencies=np.arange(5) * u.Hz, **kwargs)
+    return matrix_cls(data, xindex=np.arange(5) * u.s, **kwargs)
+
+
+def _assert_metadata_contract(restored: SeriesMatrix, expected: SeriesMatrix) -> None:
+    np.testing.assert_array_equal(restored.view(np.ndarray), expected.view(np.ndarray))
+    assert restored.shape == expected.shape
+
+    np.testing.assert_array_equal(
+        u.Quantity(restored.xindex).value,
+        u.Quantity(expected.xindex).value,
+    )
+    assert u.Quantity(restored.xindex).unit == u.Quantity(expected.xindex).unit
+
+    assert restored.name == expected.name
+    assert restored.epoch == expected.epoch
+    assert restored.attrs == expected.attrs
+
+    assert list(restored.rows.keys()) == list(expected.rows.keys())
+    assert list(restored.cols.keys()) == list(expected.cols.keys())
+    assert restored.rows["rowA"].name == "row_a"
+    assert restored.rows["rowA"].unit == u.m
+    assert str(restored.rows["rowA"].channel) == "H1:ROW_A"
+    assert restored.cols["colY"].name == "col_y"
+    assert restored.cols["colY"].unit == u.kg
+    assert str(restored.cols["colY"].channel) == "L1:COL_Y"
+
+    assert restored.meta.shape == expected.meta.shape
+    assert restored.meta[0, 0].name == "elem_r0c0"
+    assert restored.meta[0, 0].unit == u.m
+    assert str(restored.meta[0, 0].channel) == "H1:E00"
+    assert restored.meta[1, 1].name == "elem_r1c1"
+    assert restored.meta[1, 1].unit == u.kg
+    assert str(restored.meta[1, 1].channel) == "L1:E11"
+
+
+def _xindex_values(matrix: SeriesMatrix) -> np.ndarray:
+    return np.asarray(u.Quantity(matrix.xindex).value)
+
+
+@pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)
+def test_copy_preserves_metadata_with_independent_metadata_objects(matrix_cls):
+    matrix = _make_matrix(matrix_cls)
+
+    copied = matrix.copy()
+
+    _assert_metadata_contract(copied, matrix)
+    copied.view(np.ndarray)[0, 0, 0] = -1
+    copied.meta[0, 0].name = "changed"
+    copied.rows["rowA"].name = "changed-row"
+    copied.attrs["pipeline"] = "changed"
+
+    assert matrix.view(np.ndarray)[0, 0, 0] != -1
+    assert matrix.meta[0, 0].name == "elem_r0c0"
+    assert matrix.rows["rowA"].name == "row_a"
+    assert matrix.attrs["pipeline"] == "wave1"
+
+
+@pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)
+def test_typed_view_preserves_metadata_by_reference(matrix_cls):
+    matrix = _make_matrix(matrix_cls)
+
+    viewed = matrix.view(matrix_cls)
+
+    _assert_metadata_contract(viewed, matrix)
+    assert viewed.meta is matrix.meta
+    assert viewed.rows is matrix.rows
+    assert viewed.cols is matrix.cols
+    assert viewed.attrs is matrix.attrs
+
+
+@pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)
+def test_pickle_roundtrip_preserves_matrix_metadata_contract(matrix_cls):
+    matrix = _make_matrix(matrix_cls)
+
+    restored = pickle.loads(pickle.dumps(matrix))
+
+    assert isinstance(restored, matrix_cls)
+    _assert_metadata_contract(restored, matrix)
+
+
+@pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)
+def test_hdf5_roundtrip_preserves_matrix_metadata_contract(tmp_path, matrix_cls):
+    pytest.importorskip("h5py")
+    matrix = _make_matrix(matrix_cls)
+    path = tmp_path / f"{matrix_cls.__name__}.h5"
+
+    matrix.write(path, format="hdf5")
+    restored = matrix_cls.read(path, format="hdf5")
+
+    assert isinstance(restored, matrix_cls)
+    _assert_metadata_contract(restored, matrix)
+
+
+@pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)
+@pytest.mark.parametrize("format_name", ("wide", "long"))
+def test_to_pandas_is_a_value_export_not_metadata_roundtrip(matrix_cls, format_name):
+    pd = pytest.importorskip("pandas")
+    matrix = _make_matrix(matrix_cls)
+
+    df = matrix.to_pandas(format=format_name)
+    expected_xindex = _xindex_values(matrix)
+    expected_columns = [
+        "rowA_colX",
+        "rowA_colY",
+        "rowB_colX",
+        "rowB_colY",
+    ]
+
+    assert isinstance(df, pd.DataFrame)
+    if format_name == "wide":
+        assert df.shape == (5, 4)
+        assert list(df.columns) == expected_columns
+        np.testing.assert_array_equal(df.index.to_numpy(), expected_xindex)
+        assert not isinstance(df.index.to_numpy(), u.Quantity)
+        if isinstance(matrix.xindex, u.Quantity):
+            assert df.index.name == f"index [{u.Quantity(matrix.xindex).unit}]"
+        np.testing.assert_array_equal(df.to_numpy().T.reshape(2, 2, 5), matrix.value)
+    else:
+        assert list(df.columns) == ["index", "row", "col", "value"]
+        assert len(df) == matrix.size
+        assert set(df["row"]) == {"rowA", "rowB"}
+        assert set(df["col"]) == {"colX", "colY"}
+        expected_long_index = np.tile(expected_xindex, matrix.shape[0] * matrix.shape[1])
+        np.testing.assert_array_equal(df["index"].to_numpy(), expected_long_index)
+        assert not isinstance(df["index"].to_numpy(), u.Quantity)
+        np.testing.assert_array_equal(df["value"].to_numpy(), matrix.value.reshape(-1))
+
+    assert "elem_r0c0" not in df.to_csv(index=True)
+    assert "H1:E00" not in df.to_csv(index=True)
+    assert "row_a" not in df.to_csv(index=True)
+    assert "pipeline" not in df.to_csv(index=True)
+
+
+@pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)
+def test_csv_write_is_a_wide_value_export_not_metadata_roundtrip(tmp_path, matrix_cls):
+    pd = pytest.importorskip("pandas")
+    matrix = _make_matrix(matrix_cls)
+    path = tmp_path / f"{matrix_cls.__name__}.csv"
+    expected_xindex = _xindex_values(matrix)
+
+    matrix.write(path, format="csv")
+    df = pd.read_csv(path, index_col=0)
+
+    assert df.shape == (5, 4)
+    assert list(df.columns) == ["rowA_colX", "rowA_colY", "rowB_colX", "rowB_colY"]
+    np.testing.assert_array_equal(df.index.to_numpy(), expected_xindex)
+    assert not isinstance(df.index.to_numpy(), u.Quantity)
+    if isinstance(matrix.xindex, u.Quantity):
+        assert df.index.name == f"index [{u.Quantity(matrix.xindex).unit}]"
+    np.testing.assert_array_equal(df.to_numpy().T.reshape(2, 2, 5), matrix.value)
+    csv_text = path.read_text()
+    assert "elem_r0c0" not in csv_text
+    assert "H1:E00" not in csv_text
+    assert "row_a" not in csv_text
+    assert "pipeline" not in csv_text

--- a/tests/types/test_series_matrix_roundtrip_contracts.py
+++ b/tests/types/test_series_matrix_roundtrip_contracts.py
@@ -14,6 +14,15 @@ from gwexpy.types import MetaData, MetaDataDict, MetaDataMatrix, SeriesMatrix
 MATRIX_CLASSES = (SeriesMatrix, TimeSeriesMatrix, FrequencySeriesMatrix)
 
 
+class Protocol5Only:
+    """Pickle helper that cannot be serialized below protocol 5."""
+
+    def __reduce_ex__(self, protocol):
+        if protocol < 5:
+            raise TypeError("Protocol5Only requires pickle protocol 5")
+        return (Protocol5Only, ())
+
+
 def _metadata_matrix() -> MetaDataMatrix:
     return MetaDataMatrix(
         [
@@ -143,6 +152,40 @@ def test_pickle_roundtrip_preserves_matrix_metadata_contract(matrix_cls):
 
     assert isinstance(restored, matrix_cls)
     _assert_metadata_contract(restored, matrix)
+
+
+@pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)
+def test_pickle_roundtrip_filters_non_picklable_attrs_entries(matrix_cls):
+    matrix = _make_matrix(matrix_cls)
+
+    def callback() -> None:
+        return None
+
+    matrix.attrs["runtime_callback"] = callback
+    matrix.attrs["nested"] = {"labels": ["H1", "L1"], "active": True}
+    expected = matrix.copy()
+    del expected.attrs["runtime_callback"]
+
+    restored = pickle.loads(pickle.dumps(matrix))
+
+    assert matrix.attrs["runtime_callback"] is callback
+    assert isinstance(restored, matrix_cls)
+    _assert_metadata_contract(restored, expected)
+    assert "runtime_callback" not in restored.attrs
+    assert restored.attrs["nested"] == {"labels": ["H1", "L1"], "active": True}
+
+
+@pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)
+def test_default_pickle_filters_attrs_unsafe_for_default_protocol(matrix_cls):
+    matrix = _make_matrix(matrix_cls)
+    matrix.attrs["default_protocol_unsafe"] = Protocol5Only()
+    matrix.attrs["default_protocol_safe"] = "kept"
+
+    restored = pickle.loads(pickle.dumps(matrix))
+
+    assert "default_protocol_unsafe" in matrix.attrs
+    assert "default_protocol_unsafe" not in restored.attrs
+    assert restored.attrs["default_protocol_safe"] == "kept"
 
 
 @pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)


### PR DESCRIPTION
Closes #271

## Summary
- Added SeriesMatrix-family contract tests for copy, typed views, pickle, HDF5, pandas, and CSV/value exports.
- Fixed SeriesMatrix pickle state restoration so metadata, axis information, row/column metadata, attrs, name, and epoch survive round trip.
- Avoided duplicating the ndarray payload in pickle metadata state by excluding _value.
- Documented metadata-preserving HDF5 versus value-only pandas/CSV/parquet exports.

## Validation
- rtk git diff --check
- rtk ruff check gwexpy/types/seriesmatrix_base.py tests/types/test_series_matrix_roundtrip_contracts.py
- rtk pytest -q tests/types/test_series_matrix_roundtrip_contracts.py tests/types/test_series_matrix_io.py tests/types/test_series_matrix_structure.py -> 68 passed
- rtk pytest -q tests/spectrogram/test_sgm_extra.py::TestSpectrogramMatrixExtra::test_pickle_round_trip tests/spectrogram/test_sgm_matrix_coverage.py::test_sgm_pickle_roundtrip -> 2 passed

## Review notes
- This changes metadata/data-model preservation for pickle, but does not change numerical or physics behavior.
- Final review approved draft PR publication and recommended human data-model review before merge.