### PR TITLE
[AGENT:validation] Enforce SeriesMatrix matmul xindex equality

### DIFF
--- a/gwexpy/types/series_matrix_math.py
+++ b/gwexpy/types/series_matrix_math.py
@@ -113,7 +113,8 @@ class SeriesMatrixMathMixin:
         Unit-aware axes are compared after conversion to a shared unit. If one
         side is unitless, its raw numeric values are compared with the other
         side's values in that side's unit. Numeric axes use a relative
-        tolerance of 1e-9 with no absolute tolerance; two missing axes skip the
+        tolerance of 1e-9 with no absolute tolerance, so zero-valued
+        coordinates still require exact equality; two missing axes skip the
         check.
         """
         if left is None or right is None:

--- a/gwexpy/types/series_matrix_math.py
+++ b/gwexpy/types/series_matrix_math.py
@@ -7,6 +7,8 @@ from astropy import units as u
 
 from .metadata import MetaData, MetaDataMatrix
 
+_XINDEX_RTOL = 1e-9
+
 
 class SeriesMatrixMathMixin:
     """Mixin for SeriesMatrix math operations (linear algebra)."""
@@ -110,7 +112,9 @@ class SeriesMatrixMathMixin:
 
         Unit-aware axes are compared after conversion to a shared unit. If one
         side is unitless, its raw numeric values are compared with the other
-        side's values in that side's unit; two missing axes skip the check.
+        side's values in that side's unit. Numeric axes use a relative
+        tolerance of 1e-9 with no absolute tolerance; two missing axes skip the
+        check.
         """
         if left is None or right is None:
             return left is right
@@ -125,9 +129,35 @@ class SeriesMatrixMathMixin:
             return np.asarray(axis)
 
         try:
-            return bool(np.array_equal(_axis_values(left), _axis_values(right)))
+            left_values = np.asarray(_axis_values(left))
+            right_values = np.asarray(_axis_values(right))
+            if left_values.shape != right_values.shape:
+                return False
+            return bool(
+                np.allclose(
+                    left_values,
+                    right_values,
+                    rtol=_XINDEX_RTOL,
+                    atol=0.0,
+                )
+            )
         except (u.UnitConversionError, TypeError, ValueError, AttributeError):
             return False
+
+    @staticmethod
+    def _xindex_summary(axis: Any) -> str:
+        """Return a compact diagnostic summary for a sample axis."""
+        if axis is None:
+            return "None"
+        unit = getattr(axis, "unit", None)
+        unit_text = f", unit={unit}" if unit is not None else ""
+        try:
+            values = np.asarray(axis)
+            preview = np.ravel(values)[:3]
+            length = len(values)
+        except (IndexError, KeyError, TypeError, ValueError, AttributeError):
+            return repr(axis)
+        return f"starts with {preview!r} (len={length}{unit_text})"
 
     def __matmul__(self, other):
         """Perform matrix multiplication while broadcasting over the sample axis."""
@@ -138,7 +168,11 @@ class SeriesMatrixMathMixin:
         if self._value.shape[2] != other._value.shape[2]:
             raise ValueError("Sample axis length mismatch in matrix multiplication")
         if not self._xindex_equal(self.xindex, other.xindex):
-            raise ValueError("xindex mismatch in matrix multiplication")
+            raise ValueError(
+                "xindex mismatch in matrix multiplication: "
+                f"left xindex {self._xindex_summary(self.xindex)}, "
+                f"right xindex {self._xindex_summary(other.xindex)}"
+            )
         if self._value.shape[1] != other._value.shape[0]:
             raise ValueError(
                 f"Matrix dimension mismatch: ({self._value.shape[0]}, {self._value.shape[1]}) @ ({other._value.shape[0]}, {other._value.shape[1]})"

--- a/gwexpy/types/series_matrix_math.py
+++ b/gwexpy/types/series_matrix_math.py
@@ -104,6 +104,26 @@ class SeriesMatrixMathMixin:
             inv_stack[idx] = cls._invert_with_rescale(mat)
         return inv_stack
 
+    @staticmethod
+    def _xindex_equal(left: Any, right: Any) -> bool:
+        """Return True when two sample axes represent the same coordinates."""
+        if left is None or right is None:
+            return left is right
+
+        base_unit = getattr(left, "unit", None)
+        if base_unit is None:
+            base_unit = getattr(right, "unit", None)
+
+        def _axis_values(axis: Any) -> Any:
+            if base_unit is not None and hasattr(axis, "to_value"):
+                return axis.to_value(base_unit)
+            return np.asarray(axis)
+
+        try:
+            return bool(np.array_equal(_axis_values(left), _axis_values(right)))
+        except (u.UnitConversionError, TypeError, ValueError, AttributeError):
+            return False
+
     def __matmul__(self, other):
         """Perform matrix multiplication while broadcasting over the sample axis."""
         if not isinstance(other, type(self)):
@@ -112,6 +132,8 @@ class SeriesMatrixMathMixin:
 
         if self._value.shape[2] != other._value.shape[2]:
             raise ValueError("Sample axis length mismatch in matrix multiplication")
+        if not self._xindex_equal(self.xindex, other.xindex):
+            raise ValueError("xindex mismatch in matrix multiplication")
         if self._value.shape[1] != other._value.shape[0]:
             raise ValueError(
                 f"Matrix dimension mismatch: ({self._value.shape[0]}, {self._value.shape[1]}) @ ({other._value.shape[0]}, {other._value.shape[1]})"

--- a/gwexpy/types/series_matrix_math.py
+++ b/gwexpy/types/series_matrix_math.py
@@ -106,7 +106,12 @@ class SeriesMatrixMathMixin:
 
     @staticmethod
     def _xindex_equal(left: Any, right: Any) -> bool:
-        """Return True when two sample axes represent the same coordinates."""
+        """Return True when two sample axes represent the same coordinates.
+
+        Unit-aware axes are compared after conversion to a shared unit. If one
+        side is unitless, its raw numeric values are compared with the other
+        side's values in that side's unit; two missing axes skip the check.
+        """
         if left is None or right is None:
             return left is right
 

--- a/tests/types/test_series_matrix_math.py
+++ b/tests/types/test_series_matrix_math.py
@@ -150,7 +150,25 @@ class TestMatMul:
     def test_matmul_xindex_mismatch_raises(self, square_matrix_2x2):
         """Same sample length is not enough; sample-axis coordinates must match."""
         other = SeriesMatrix(np.random.randn(2, 2, 10), xindex=np.linspace(1, 10, 10))
-        with pytest.raises(ValueError, match="xindex mismatch"):
+        with pytest.raises(ValueError, match="left xindex .* right xindex"):
+            square_matrix_2x2 @ other
+
+    def test_matmul_accepts_nearly_equal_floating_xindex(self, square_matrix_2x2):
+        """Small relative floating differences should not reject matching axes."""
+        xindex = np.linspace(0, 9, 10)
+        xindex[1:] += xindex[1:] * 1e-12
+        other = SeriesMatrix(np.random.randn(2, 2, 10), xindex=xindex)
+
+        result = square_matrix_2x2 @ other
+
+        np.testing.assert_allclose(result.xindex, square_matrix_2x2.xindex)
+
+    def test_matmul_raises_when_one_xindex_is_none(self, square_matrix_2x2):
+        """A missing sample axis on only one operand is a mismatch."""
+        other = SeriesMatrix(np.random.randn(2, 2, 10), xindex=np.linspace(0, 9, 10))
+        other.xindex = None
+
+        with pytest.raises(ValueError, match="right xindex None"):
             square_matrix_2x2 @ other
 
     def test_matmul_accepts_xindex_equal_after_unit_conversion(self):
@@ -164,6 +182,7 @@ class TestMatMul:
         result = left @ right
 
         np.testing.assert_array_equal(result.xindex.to_value(u.s), [0.0, 1.0, 2.0])
+        assert result.xindex is left.xindex
         np.testing.assert_array_equal(result._value, np.full((2, 2, 3), 2.0))
 
 

--- a/tests/types/test_series_matrix_math.py
+++ b/tests/types/test_series_matrix_math.py
@@ -147,6 +147,25 @@ class TestMatMul:
         with pytest.raises(ValueError, match="Sample axis length mismatch"):
             square_matrix_2x2 @ other
 
+    def test_matmul_xindex_mismatch_raises(self, square_matrix_2x2):
+        """Same sample length is not enough; sample-axis coordinates must match."""
+        other = SeriesMatrix(np.random.randn(2, 2, 10), xindex=np.linspace(1, 10, 10))
+        with pytest.raises(ValueError, match="xindex mismatch"):
+            square_matrix_2x2 @ other
+
+    def test_matmul_accepts_xindex_equal_after_unit_conversion(self):
+        """Equivalent sample-axis coordinates with different units are compatible."""
+        left = SeriesMatrix(np.ones((2, 2, 3)), xindex=np.array([0.0, 1.0, 2.0]) * u.s)
+        right = SeriesMatrix(
+            np.ones((2, 2, 3)),
+            xindex=np.array([0.0, 1000.0, 2000.0]) * u.ms,
+        )
+
+        result = left @ right
+
+        np.testing.assert_array_equal(result.xindex.to_value(u.s), [0.0, 1.0, 2.0])
+        np.testing.assert_array_equal(result._value, np.full((2, 2, 3), 2.0))
+
 
 class TestDeterminant:
     """Tests for det() method."""


### PR DESCRIPTION
Refs #269

## Summary
- Enforce sample-axis coordinate equality in SeriesMatrix matrix multiplication.
- Same-length operands with different xindex coordinates now raise ValueError instead of multiplying and inheriting the left-hand xindex.
- Preserve compatible behavior for equivalent unit-aware axes, e.g. seconds versus milliseconds representing the same coordinates.

## Why
The prior behavior only checked sample length. That allowed matrices on different sample axes to be multiplied silently, producing a result labeled with the left-hand xindex. This PR makes that physics-facing axis invariant explicit.

## Validation
- rtk env MPLCONFIGDIR=/tmp/matplotlib-gwexpy-269 pytest -q tests/types/test_series_matrix_math.py -> 45 passed, 2 warnings
- rtk env MPLCONFIGDIR=/tmp/matplotlib-gwexpy-269 pytest -q tests/types/test_seriesmatrix_fixes.py tests/types/test_series_matrix_indexing.py -> 84 passed, 5 warnings
- rtk ruff check gwexpy/types/series_matrix_math.py tests/types/test_series_matrix_math.py
- rtk mypy gwexpy/types/series_matrix_math.py
- rtk git diff --check

## Review notes
- This is intentionally physics-sensitive/public behavior: SeriesMatrix __matmul__ now rejects mismatched sample-axis coordinates.
- Human sign-off was given to publish this draft PR after the Wave 1 stop report.
- This is a focused slice and does not close all #269 candidate work items.