### PR TITLE
[AGENT:validation] Audit standalone series contracts

### DIFF
--- a/docs/developers/plans/2026-04-27-frequencyseries-spectrogram-standalone-contract-audit.md
+++ b/docs/developers/plans/2026-04-27-frequencyseries-spectrogram-standalone-contract-audit.md
@@ -1,0 +1,140 @@
+# FrequencySeries And Spectrogram Standalone Contract Audit
+
+Date: 2026-04-27
+Issue: #292, "Audit FrequencySeries and Spectrogram standalone class contracts"
+Mode: audit-first; docs and regression tests only.
+
+## Scope And Non-Goals
+
+This audit records current standalone public-class behavior for:
+
+- `gwexpy/frequencyseries/frequencyseries.py`
+- `gwexpy/frequencyseries/bifrequencymap.py`
+- `gwexpy/spectrogram/spectrogram.py`
+
+The scope intentionally excludes collection, matrix, I/O, and plot-specific
+contract changes already covered by adjacent issues. This pass does not change
+runtime behavior. Return-class changes, axis-unit conversion changes, metadata
+policy changes, or physics-facing numerical interpretation changes should be
+split into follow-up PRs with human review where appropriate.
+
+## Inputs Reviewed
+
+- `FrequencySeries` construction, indexing, view/copy behavior, `_gwex_*`
+  attribute propagation, phase helpers, dB conversion, rebinning, and
+  quadrature combination.
+- `BifrequencyMap` axis construction, indexing, slicing, crop, propagation, and
+  nearest-bin helper behavior.
+- `Spectrogram` indexing, view/copy behavior, phase helpers, rebinning,
+  normalization, cleaning, and conversion to one-dimensional list containers.
+- Existing tests under `tests/frequencyseries/` and `tests/spectrogram/`.
+
+## FrequencySeries Contracts
+
+- `FrequencySeries.__new__()` drops transient `fmin` and `fmax` keyword
+  arguments before delegating to the GWpy constructor.
+- Scalar indexing returns an `astropy.units.Quantity`; slice and typed-view paths
+  return gwexpy `FrequencySeries` objects.
+- `view(np.ndarray)` returns a bare ndarray; `view(type(fs))` shares the same
+  data buffer and preserves GWpy metadata such as name, channel, and epoch.
+- Custom `_gwex_*` attributes propagate through slicing through
+  `__array_finalize__`.
+- `phase()`, `angle()`, `degree()`, and `to_db()` return gwexpy
+  `FrequencySeries` objects and preserve frequency axis, channel, and epoch
+  while updating unit/name according to the helper.
+- `rebin(width)` averages only complete bins, truncates trailing incomplete
+  bins, and preserves unit, name, channel, and epoch.
+- `quadrature_sum()` returns a gwexpy `FrequencySeries` on the left-hand
+  frequency axis and epoch, but currently drops channel metadata.
+
+## BifrequencyMap Contracts
+
+- `from_points(data, f2, f1)` maps rows to `frequency2`/`xindex` and columns to
+  `frequency1`/`yindex`. Bare numeric axes default to Hz.
+- Scalar indexing returns `Quantity`; two-dimensional slices return
+  `BifrequencyMap`; one-dimensional row slices currently return GWpy `Series`.
+- `propagate()` accepts GWpy-compatible `FrequencySeries` input and currently
+  returns GWpy `FrequencySeries`, not gwexpy `FrequencySeries`.
+- `propagate(interpolate=False)` checks only input length, multiplies by matrix
+  rows, outputs on `frequency2`, sets unit to `map.unit * input.unit`, and does
+  not preserve input channel or epoch.
+- `get_slice(at, axis=...)` chooses the nearest bin using raw `.value`
+  comparison. Quantity units are not converted before nearest-bin selection.
+- `crop()` uses inclusive lower and upper bounds and preserves unit/name.
+- `inverse()` swaps the two frequency axes and inverts non-dimensionless units.
+
+## Spectrogram Contracts
+
+- Indexing follows inherited GWpy return classes for one-dimensional slices:
+  `sg[i]` returns GWpy `FrequencySeries`, `sg[:, j]` returns GWpy `TimeSeries`,
+  `sg[i, j]` returns `Quantity`, and two-dimensional slices return gwexpy
+  `Spectrogram`.
+- `copy()` produces independent data; typed views share data; ndarray views are
+  bare ndarrays.
+- `radian()` and `degree()` return real-valued gwexpy `Spectrogram` objects,
+  preserve axes/channel, set units to rad/deg, and apply phase suffixes to
+  names.
+- `rebin(dt, df)` averages only complete time/frequency bins and truncates
+  trailing incomplete bins. It preserves unit/name/channel and constructs
+  explicit rebinned axes from bin centers.
+- `normalize()` returns a dimensionless gwexpy `Spectrogram` and preserves
+  name/channel.
+- `clean(return_mask=True)` returns `(Spectrogram, bool mask)` and preserves the
+  original unit/name/channel on the cleaned spectrogram.
+- `to_timeseries_list()` and `to_frequencyseries_list()` return gwexpy list
+  containers with gwexpy element classes, copied element data, inherited
+  unit/channel, epochs equivalent to the source GPS time, and generated names
+  based on the fixed frequency or time bin.
+
+## Current Behavior Baselines
+
+This pass adds regression coverage in:
+
+- `tests/frequencyseries/test_standalone_contracts.py`
+- `tests/spectrogram/test_standalone_contracts.py`
+
+The tests intentionally baseline current return-class boundaries where gwexpy
+objects delegate to inherited GWpy behavior. These are not necessarily ideal
+public API choices, but changing them would be user-visible and should not be
+mixed into this audit-first PR.
+
+## Known Risky Behavior Changes
+
+Do not include these in the first #292 audit PR:
+
+- Switch inherited one-dimensional `Spectrogram` slices from GWpy classes to
+  gwexpy classes.
+- Change `BifrequencyMap.propagate()`, `get_slice()`, `diagonal()`, or
+  `convolute()` return classes from GWpy `FrequencySeries` to gwexpy
+  `FrequencySeries`.
+- Add unit conversion to `BifrequencyMap.get_slice()` nearest-bin selection.
+- Change `BifrequencyMap` interpolation tolerance, inclusive crop bounds, or
+  channel/epoch loss.
+- Change `Spectrogram` row-slice epoch behavior inherited from GWpy.
+- Change `FrequencySeries.quadrature_sum()` channel propagation.
+
+## Recommended Follow-Ups
+
+1. Decide whether standalone helpers that currently return GWpy series should
+   instead return gwexpy classes.
+2. Decide whether `BifrequencyMap.get_slice()` should convert quantity units
+   before nearest-bin lookup.
+3. Decide whether `FrequencySeries.quadrature_sum()` and `BifrequencyMap`
+   projection helpers should preserve channel/epoch metadata.
+4. Add release notes if any follow-up changes public return classes or metadata
+   propagation.
+
+## Verification
+
+Suggested focused command:
+
+```bash
+rtk pytest -q \
+  tests/frequencyseries/test_standalone_contracts.py \
+  tests/spectrogram/test_standalone_contracts.py \
+  tests/frequencyseries/test_fs_methods.py \
+  tests/frequencyseries/test_bifrequencymap_logic.py \
+  tests/spectrogram/test_getitem.py \
+  tests/spectrogram/test_spectrogram_core.py \
+  tests/spectrogram/test_to_series_list.py
+```

--- a/tests/frequencyseries/test_standalone_contracts.py
+++ b/tests/frequencyseries/test_standalone_contracts.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from astropy import units as u
+from astropy.units import Quantity
+from gwpy.frequencyseries import FrequencySeries as GwpyFrequencySeries
+from gwpy.types.series import Series as GwpySeries
+
+from gwexpy.frequencyseries import BifrequencyMap, FrequencySeries
+
+
+def _make_frequencyseries() -> FrequencySeries:
+    return FrequencySeries(
+        [1 + 1j, 2 + 0j, 3 - 1j],
+        frequencies=[0, 1, 2] * u.Hz,
+        unit=u.m,
+        name="sig",
+        channel="H1:TEST",
+        epoch=1234567890,
+    )
+
+
+def _make_bifrequency_map() -> BifrequencyMap:
+    return BifrequencyMap.from_points(
+        np.array([[1, 2, 3], [4, 5, 6]], dtype=float),
+        f2=[10, 20],
+        f1=[1, 2, 3],
+        unit=u.s,
+        name="map",
+    )
+
+
+def test_frequencyseries_constructor_filters_noise_range_kwargs():
+    fs = FrequencySeries(
+        [1, 2, 3],
+        df=1 * u.Hz,
+        fmin=10,
+        fmax=20,
+        unit=u.m,
+    )
+
+    assert isinstance(fs, FrequencySeries)
+    assert fs.unit == u.m
+
+
+def test_frequencyseries_indexing_views_and_gwex_attrs_contract():
+    fs = _make_frequencyseries()
+    fs._gwex_marker = {"source": "contract"}  # noqa: SLF001
+
+    scalar = fs[1]
+    sliced = fs[1:]
+    ndarray_view = fs.view(np.ndarray)
+    typed_view = fs.view(type(fs))
+
+    assert isinstance(scalar, Quantity)
+    assert scalar.unit == u.m
+    assert isinstance(sliced, FrequencySeries)
+    assert sliced._gwex_marker == {"source": "contract"}  # noqa: SLF001
+    assert type(ndarray_view) is np.ndarray
+    assert isinstance(typed_view, FrequencySeries)
+    assert np.shares_memory(fs.value, typed_view.value)
+    assert typed_view.name == "sig"
+    assert str(typed_view.channel) == "H1:TEST"
+    assert typed_view.epoch == fs.epoch
+
+
+def test_frequencyseries_phase_db_rebin_and_quadrature_metadata_contracts():
+    fs = _make_frequencyseries()
+
+    phase = fs.phase()
+    degree = fs.degree()
+    decibel = fs.to_db()
+
+    assert isinstance(phase, FrequencySeries)
+    assert phase.unit == u.rad
+    assert phase.name == "sig_phase"
+    assert str(phase.channel) == "H1:TEST"
+    assert phase.epoch == fs.epoch
+    assert degree.unit == u.deg
+    assert degree.name == "sig_phase_deg"
+    assert decibel.unit == u.dB
+    assert decibel.name == "sig_db"
+
+    rebinned = FrequencySeries(
+        [1, 2, 3, 4, 5],
+        frequencies=[0, 1, 2, 3, 4] * u.Hz,
+        unit=u.m,
+        name="rb",
+        channel="H1:TEST",
+        epoch=fs.epoch,
+    ).rebin(2 * u.Hz)
+    assert isinstance(rebinned, FrequencySeries)
+    assert rebinned.value.tolist() == [1.5, 3.5]
+    assert rebinned.frequencies.value.tolist() == [0.5, 2.5]
+    assert rebinned.frequencies.unit == u.Hz
+    assert rebinned.unit == u.m
+    assert rebinned.name == "rb"
+    assert str(rebinned.channel) == "H1:TEST"
+
+    other = FrequencySeries(
+        [1, 1, 1],
+        frequencies=fs.frequencies,
+        unit=u.m,
+        name="other",
+        channel="H1:OTHER",
+        epoch=fs.epoch,
+    )
+    combined = fs.quadrature_sum(other)
+    assert isinstance(combined, FrequencySeries)
+    assert combined.unit == u.m
+    assert combined.epoch == fs.epoch
+    assert combined.channel is None
+
+
+def test_bifrequencymap_axes_indexing_and_crop_contracts():
+    bmap = _make_bifrequency_map()
+
+    assert bmap.frequency2.value.tolist() == [10, 20]
+    assert bmap.frequency2.unit == u.Hz
+    assert bmap.frequency1.value.tolist() == [1, 2, 3]
+    assert bmap.frequency1.unit == u.Hz
+    assert isinstance(bmap[0, 0], Quantity)
+    assert bmap[0, 0].unit == u.s
+    assert isinstance(bmap[:, :], BifrequencyMap)
+    assert type(bmap[0, :]) is GwpySeries
+
+    cropped = bmap.crop(low=1, high=2, low2=20, high2=20)
+    assert isinstance(cropped, BifrequencyMap)
+    assert cropped.shape == (1, 2)
+    assert cropped.frequency1.value.tolist() == [1, 2]
+    assert cropped.frequency1.unit == u.Hz
+    assert cropped.frequency2.value.tolist() == [20]
+    assert cropped.frequency2.unit == u.Hz
+    assert cropped.unit == u.s
+    assert cropped.name == "map"
+
+
+def test_bifrequencymap_projection_helpers_return_gwpy_frequencyseries():
+    bmap = _make_bifrequency_map()
+    input_spectrum = FrequencySeries(
+        [1, 1, 1],
+        frequencies=[100, 200, 300] * u.Hz,
+        unit=u.m,
+        name="input",
+        channel="H1:IN",
+        epoch=123,
+    )
+
+    projected = bmap.propagate(input_spectrum, interpolate=False)
+
+    assert type(projected) is GwpyFrequencySeries
+    assert projected.value.tolist() == [6, 15]
+    assert projected.frequencies.value.tolist() == [10, 20]
+    assert projected.frequencies.unit == u.Hz
+    assert projected.unit == u.m * u.s
+    assert projected.name == "Projected: map x input"
+    assert projected.channel is None
+    assert projected.epoch is None
+
+    diagonal = bmap.diagonal()
+    assert type(diagonal) is GwpyFrequencySeries
+    assert diagonal.unit == u.s
+    assert diagonal.name == "map (diagonal mean)"
+
+    convolved = bmap.convolute(input_spectrum, interpolate=False)
+    assert type(convolved) is GwpyFrequencySeries
+    assert convolved.value.tolist() == [6, 15]
+    assert convolved.frequencies.value.tolist() == [10, 20]
+    assert convolved.unit == u.Hz * u.m * u.s
+    assert convolved.channel is None
+    assert convolved.epoch is None
+
+    nearest = bmap.get_slice(2 * u.kHz, axis="f1")
+    assert type(nearest) is GwpyFrequencySeries
+    assert nearest.value.tolist() == [2, 5]
+    assert nearest.frequencies.value.tolist() == [10, 20]
+    assert nearest.frequencies.unit == u.Hz
+    assert nearest.name == "map (at f1=2 Hz)"
+
+    with pytest.raises(ValueError, match="axis must be"):
+        bmap.get_slice(1, axis="bad")

--- a/tests/spectrogram/test_standalone_contracts.py
+++ b/tests/spectrogram/test_standalone_contracts.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from astropy import units as u
+from astropy.units import Quantity
+from gwpy.frequencyseries import FrequencySeries as GwpyFrequencySeries
+from gwpy.timeseries import TimeSeries as GwpyTimeSeries
+
+from gwexpy.frequencyseries import FrequencySeries, FrequencySeriesList
+from gwexpy.spectrogram import Spectrogram
+from gwexpy.timeseries import TimeSeries, TimeSeriesList
+
+
+def _make_complex_spectrogram() -> Spectrogram:
+    data = np.arange(12, dtype=float).reshape(3, 4) + 1j
+    return Spectrogram(
+        data,
+        times=[100, 101, 102] * u.s,
+        frequencies=[10, 20, 30, 40] * u.Hz,
+        unit=u.m,
+        name="spec",
+        channel="H1:TEST",
+    )
+
+
+def _make_real_spectrogram() -> Spectrogram:
+    return Spectrogram(
+        np.arange(35, dtype=float).reshape(5, 7),
+        dt=1 * u.s,
+        f0=10 * u.Hz,
+        df=1 * u.Hz,
+        unit=u.m,
+        name="real",
+        channel="H1:TEST",
+    )
+
+
+def test_spectrogram_indexing_return_types_contract():
+    sg = _make_complex_spectrogram()
+
+    row = sg[0]
+    column = sg[:, 1]
+    scalar = sg[0, 1]
+    submatrix = sg[:2, :2]
+
+    assert type(row) is GwpyFrequencySeries
+    assert row.unit == u.m
+    assert str(row.channel) == "H1:TEST"
+    assert type(column) is GwpyTimeSeries
+    assert column.unit == u.m
+    assert str(column.channel) == "H1:TEST"
+    assert isinstance(scalar, Quantity)
+    assert scalar.unit == u.m
+    assert isinstance(submatrix, Spectrogram)
+    assert submatrix.shape == (2, 2)
+    assert submatrix.unit == u.m
+
+
+def test_spectrogram_copy_and_view_contracts():
+    sg = _make_complex_spectrogram()
+
+    copied = sg.copy()
+    ndarray_view = sg.view(np.ndarray)
+    typed_view = sg.view(type(sg))
+
+    assert isinstance(copied, Spectrogram)
+    assert not np.shares_memory(sg.value, copied.value)
+    assert type(ndarray_view) is np.ndarray
+    assert isinstance(typed_view, Spectrogram)
+    assert np.shares_memory(sg.value, typed_view.value)
+    assert typed_view.name == "spec"
+    assert str(typed_view.channel) == "H1:TEST"
+
+
+def test_spectrogram_phase_normalize_clean_and_rebin_metadata_contracts():
+    complex_sg = _make_complex_spectrogram()
+
+    phase = complex_sg.radian()
+    degree = complex_sg.degree()
+
+    assert isinstance(phase, Spectrogram)
+    assert phase.unit == u.rad
+    assert phase.name == "spec_phase"
+    assert str(phase.channel) == "H1:TEST"
+    assert phase.shape == complex_sg.shape
+    assert phase.value.dtype == np.dtype("float64")
+    assert degree.unit == u.deg
+    assert degree.name == "spec_phase_deg"
+
+    real_sg = _make_real_spectrogram()
+    normalized = real_sg.normalize(method="mean")
+    cleaned, mask = real_sg.clean(return_mask=True)
+    rebinned = real_sg.rebin(dt=2 * u.s, df=3 * u.Hz)
+
+    assert normalized.unit == u.dimensionless_unscaled
+    assert normalized.name == "real"
+    assert str(normalized.channel) == "H1:TEST"
+    assert cleaned.unit == u.m
+    assert cleaned.name == "real"
+    assert str(cleaned.channel) == "H1:TEST"
+    assert mask.shape == real_sg.shape
+    assert mask.dtype == np.dtype("bool")
+    assert rebinned.shape == (2, 2)
+    assert rebinned.times.value.tolist() == [0.5, 2.5]
+    assert rebinned.times.unit == u.s
+    assert rebinned.frequencies.value.tolist() == [11, 14]
+    assert rebinned.frequencies.unit == u.Hz
+    assert rebinned.value.tolist() == [[4.5, 7.5], [18.5, 21.5]]
+    assert rebinned.unit == u.m
+    assert rebinned.name == "real"
+    assert str(rebinned.channel) == "H1:TEST"
+
+
+def test_spectrogram_to_series_list_contracts():
+    sg = _make_complex_spectrogram()
+
+    ts_list, frequencies = sg.to_timeseries_list()
+    fs_list, times = sg.to_frequencyseries_list()
+
+    assert isinstance(ts_list, TimeSeriesList)
+    assert frequencies.value.tolist() == [10, 20, 30, 40]
+    assert frequencies.unit == u.Hz
+    assert len(ts_list) == 4
+    assert all(isinstance(item, TimeSeries) for item in ts_list)
+    assert ts_list[0].unit == u.m
+    assert str(ts_list[0].channel) == "H1:TEST"
+    assert ts_list[0].epoch.gps == pytest.approx(sg.epoch.gps)
+    assert ts_list[0].name == "spec_f10.0 Hz"
+    assert not np.shares_memory(ts_list[0].value, sg.value)
+
+    assert isinstance(fs_list, FrequencySeriesList)
+    assert times.value.tolist() == [100, 101, 102]
+    assert times.unit == u.s
+    assert len(fs_list) == 3
+    assert all(isinstance(item, FrequencySeries) for item in fs_list)
+    assert fs_list[0].unit == u.m
+    assert str(fs_list[0].channel) == "H1:TEST"
+    assert fs_list[0].epoch.gps == pytest.approx(sg.epoch.gps)
+    assert fs_list[0].name == "spec_t100.0 s"
+    assert not np.shares_memory(fs_list[0].value, sg.value)


### PR DESCRIPTION
## Summary
- Adds a developer audit for standalone FrequencySeries, Spectrogram, and BifrequencyMap public contracts.
- Adds focused contract tests for construction, indexing, view/copy behavior, metadata preservation, helper return classes, rebinning, and current BifrequencyMap projection behavior.
- Keeps runtime behavior unchanged and defers return-class, axis-unit, and metadata-policy behavior changes to follow-ups.

Closes #292.

## Test Plan
- `rtk pytest -q tests/frequencyseries/test_standalone_contracts.py tests/spectrogram/test_standalone_contracts.py tests/frequencyseries/test_fs_methods.py tests/frequencyseries/test_bifrequencymap_logic.py tests/spectrogram/test_getitem.py tests/spectrogram/test_spectrogram_core.py tests/spectrogram/test_to_series_list.py` => 143 passed
- `rtk ruff check tests/frequencyseries/test_standalone_contracts.py tests/spectrogram/test_standalone_contracts.py` => no issues
- `rtk git diff --check` => clean

## Audit Manifest
```yaml
agent_tag: validation
skills_used:
  - superpowers:using-superpowers
  - phased-milestone-planner
  - superpowers:subagent-driven-development
  - superpowers:test-driven-development
  - superpowers:verification-before-completion
  - github:yeet
commands:
  - rtk pytest -q tests/frequencyseries/test_standalone_contracts.py tests/spectrogram/test_standalone_contracts.py tests/frequencyseries/test_fs_methods.py tests/frequencyseries/test_bifrequencymap_logic.py tests/spectrogram/test_getitem.py tests/spectrogram/test_spectrogram_core.py tests/spectrogram/test_to_series_list.py
  - rtk ruff check tests/frequencyseries/test_standalone_contracts.py tests/spectrogram/test_standalone_contracts.py
  - rtk git diff --check
check_physics: not run; docs/test-only contract baseline with no runtime physics behavior changes
files_changed:
  - docs/developers/plans/2026-04-27-frequencyseries-spectrogram-standalone-contract-audit.md
  - tests/frequencyseries/test_standalone_contracts.py
  - tests/spectrogram/test_standalone_contracts.py
review:
  spec_review: approved
  code_quality_review: approved after requested changes
```
