### PR TITLE
[AGENT:validation] Audit collection API contracts

### DIFF
--- a/docs/developers/plans/2026-04-27-collection-api-contract-audit.md
+++ b/docs/developers/plans/2026-04-27-collection-api-contract-audit.md
@@ -1,0 +1,162 @@
+# Collection API Contract Audit
+
+Date: 2026-04-27
+Issue: #289, "Audit collection API ordering mapping and metadata contracts"
+Mode: audit-first; docs and regression tests only.
+
+## Constraints
+
+- This pass records current collection behavior for release readiness. It does
+  not change runtime behavior.
+- `.agent/AGENTS.md` requirements on unit, axis, and metadata preservation were
+  reviewed. Behavior that changes physics-facing metadata, axis comparison, or
+  serialization semantics must be split into a follow-up with human review.
+- #270 and #271 already cover family-specific `to_matrix()` and matrix
+  round-trip persistence. This audit focuses on collection-level ordering,
+  delegation, mutability, key mapping, and metadata boundaries outside broad
+  matrix behavior changes.
+
+## Inputs Reviewed
+
+- `gwexpy/types/mixin/_collection_mixin.py`
+- `gwexpy/timeseries/collections.py`
+- `gwexpy/frequencyseries/collections.py`
+- `gwexpy/spectrogram/collections.py`
+- `gwexpy/histogram/collections.py`
+- `gwexpy/io/hdf5_collection.py`
+- `gwexpy/io/collection_dir.py`
+- Existing collection tests under `tests/types/`, `tests/timeseries/`,
+  `tests/frequencyseries/`, `tests/spectrogram/`, `tests/histogram/`, and
+  `tests/io/`.
+
+## Collection Contract Table
+
+| Surface | Ordering contract | Delegation return contract | Mutability contract | Metadata and key contract |
+| --- | --- | --- | --- | --- |
+| Shared `DictMapMixin` helpers | Iterate in current mapping insertion order. | `_make_dict_map_method()` returns `self.__class__()` unless `result_class_path` is supplied; `_make_dict_plain_method()` returns native `dict`. | Delegated methods construct a new result container. Exceptions from element methods propagate. | Mixins do not inspect units, names, channels, axes, or metadata. Concrete collections own those guarantees. |
+| Shared `ListMapMixin` helpers | Iterate in current list order. | `_make_list_map_method()` returns `self.__class__()` unless `result_class_path` is supplied; `_make_list_plain_method()` returns native `list`. | Delegated methods construct a new result container. Exceptions from element methods propagate. | Mixins do not inspect metadata. If a list map is used for scalar-returning methods, list validation may reject the scalar result. |
+| `TimeSeriesDict` / `TimeSeriesList` | Dict keys and list order are preserved when mapping over entries. `to_matrix()` consumes that order. | Many statistical methods convert through `to_matrix()` and return arrays. Rolling and signal methods return collection types. | `crop()` returns a new collection. It delegates `copy` to each underlying series crop. | `TimeSeriesDict.to_matrix()` writes dict keys to `channel_names`, but row keys remain generated. Current conversion does not preserve per-element value units or channels in matrix metadata. |
+| `FrequencySeriesDict` / `FrequencySeriesList` | Dict/list insertion order is preserved. `FrequencySeriesDict.to_matrix()` uses dict order for rows. | Dict map methods return `FrequencySeriesDict` or native `dict` depending on helper. List map methods return `FrequencySeriesList`. | `FrequencySeriesDict.crop()` mutates and returns `self`; `FrequencySeriesList.crop()` returns a new list collection. | `FrequencySeriesDict.to_matrix()` preserves row keys and per-element unit/name/channel metadata. `FrequencySeriesList` has no `to_matrix()` contract today. |
+| `SpectrogramDict` / `SpectrogramList` | Dict/list insertion order is preserved. Dict `to_matrix()` uses keys as rows; list `to_matrix()` uses generated rows. | Batch methods return dict/list collection types except explicit tensor/backend conversion helpers, which return native dict/list values. | `crop()` defaults to copy and supports in-place operation through `copy=False` or legacy `inplace` forms. | `to_matrix()` preserves per-element unit/name/channel metadata. A global matrix unit is set only when all entries share the same value unit. |
+| `HistogramDict` / `HistogramList` | Dict/list insertion order is preserved by map helpers and HDF5/list writes. | `HistogramDict` scalar/statistical helpers return native `dict`. `HistogramList` currently uses collection-map helpers for several scalar/statistical methods. | Map helpers construct new containers. HDF5 readers skip unreadable entries under the existing tolerant read policy. | Histogram collection manifests preserve collection order. List statistical helper behavior is a current limitation when scalar results fail list validation. |
+| HDF5 collection manifests | Writers store `gwexpy_order`; readers use it before falling back to file keys. | Not applicable. | Reads skip unreadable entries for expected parsing exceptions. | Dict writes sanitize physical HDF5 object names and store original keys in `gwexpy_keymap`; list writes store positional string keys. |
+| Directory collection manifests | Manifest entries preserve explicit order. No-manifest fallback sorts matching `*.csv` / `*.txt` filenames. | Not applicable. | Directory overwrite behavior is explicit. | Manifest entries preserve original keys and optional per-entry metadata. No-manifest fallback uses filename stems as keys. |
+
+## Ordering And Key Semantics
+
+Collection methods follow Python insertion/list order. That order is observable
+in mixin-generated methods, matrix row construction, HDF5 manifest order, and
+directory collection manifests.
+
+Dict-style matrix conversion is uneven by family:
+
+- `FrequencySeriesDict.to_matrix()` uses dict keys as matrix row keys and keeps
+  the single column key as `"value"`.
+- `SpectrogramDict.to_matrix()` uses dict keys as matrix row keys.
+- `TimeSeriesDict.to_matrix()` writes dict keys into element names through
+  `channel_names`, while matrix row keys remain generated labels such as
+  `"row0"`, `"row1"`.
+
+This pass treats those differences as current contracts to document, not as
+runtime behavior to normalize.
+
+## Delegation And Container Return Semantics
+
+Shared mixin helpers have two explicit return families:
+
+- map helpers return collection-like containers suitable for element methods
+  that return another element of the same family;
+- plain helpers return native `dict` or `list` for scalar, ndarray, backend, or
+  summary outputs.
+
+Concrete collections are not fully uniform in which helper they use. In
+particular, `HistogramList` currently uses list map helpers for several
+statistical methods whose element-level return values are quantities, and the
+list validation path rejects those quantity values. That behavior is now
+baselined as a limitation instead of being silently changed in this audit PR.
+
+## Mutability Contracts
+
+Mutability differs across families:
+
+- `TimeSeriesDict.crop()` and `TimeSeriesList.crop()` return new collection
+  containers.
+- `FrequencySeriesDict.crop()` mutates and returns `self`, matching its current
+  GWpy-like behavior.
+- `FrequencySeriesList.crop()` returns a new list collection through the shared
+  list map helper.
+- `SpectrogramDict.crop()` and `SpectrogramList.crop()` default to copied
+  collections and support in-place operation through `copy=False`; deprecated
+  `inplace` compatibility is handled by `_resolve_crop_compat_args()`.
+
+These differences are user-observable and should not be unified without a
+separate behavior-change PR.
+
+## Error Propagation And Tolerant Reads
+
+Mixin-generated delegation does not catch element-method exceptions. The first
+raised exception propagates to the caller.
+
+Collection readers are different: HDF5 collection readers skip entries that
+fail with expected parsing exceptions such as `KeyError`, `ValueError`,
+`TypeError`, or `OSError`. Tightening tolerant reads into strict failure would
+be a behavior change and should be split from this audit.
+
+## Metadata Contracts
+
+The shared mixins preserve ordering and container shape but do not preserve or
+interpret physical metadata. Metadata policy belongs to concrete collection
+implementations.
+
+Current high-level metadata boundaries:
+
+- `TimeSeries` collection matrix conversion preserves key-derived element names
+  but not per-element value units or channels.
+- `FrequencySeriesDict.to_matrix()` preserves row keys plus per-element
+  unit/name/channel metadata.
+- `SpectrogramDict/List.to_matrix()` preserves per-element unit/name/channel
+  metadata and sets a global matrix unit only when all entries share the same
+  value unit.
+- HDF5 and directory collection manifests preserve collection-level keys and
+  ordering. Per-entry serialization details remain owned by the entry reader and
+  writer.
+
+## Regression Test Plan
+
+This audit adds focused regression coverage for:
+
+- shared dict/list mixin ordering, return-class, plain-return, and exception
+  propagation behavior;
+- `TimeSeriesDict/List.to_matrix()` ordering and current metadata loss;
+- `FrequencySeriesDict.to_matrix()` row/key and per-entry metadata behavior;
+- current absence of `FrequencySeriesList.to_matrix()`;
+- `SpectrogramDict/List` copy/matrix row-name behavior;
+- current `HistogramList` scalar/statistical helper limitation;
+- directory no-manifest fallback sorting.
+
+Suggested focused command:
+
+```bash
+rtk pytest -q \
+  tests/types/test_collection_mixin.py \
+  tests/timeseries/test_collections_batch.py \
+  tests/frequencyseries/test_frequencyseries_containers.py \
+  tests/spectrogram/test_collections.py \
+  tests/histogram/test_histogram_collections.py \
+  tests/io/test_collection_dir.py \
+  tests/io/test_hdf5_collection.py
+```
+
+## Behavior Changes Deferred From First PR
+
+- Enforce frequency-axis equality in `FrequencySeriesDict.to_matrix()`.
+- Add `FrequencySeriesList.to_matrix()`.
+- Preserve `TimeSeries` value units/channels through `TimeSeriesDict/List` matrix
+  conversion.
+- Normalize crop mutability across collection families.
+- Change HDF5 tolerant read behavior to strict failure.
+- Change HDF5 key sanitization, collision suffixes, manifest names, or manifest
+  schema.
+- Fix `HistogramList` scalar/statistical return behavior before maintainers
+  decide whether those methods should return native `list` values or another
+  collection-like result.

--- a/tests/frequencyseries/test_frequencyseries_containers.py
+++ b/tests/frequencyseries/test_frequencyseries_containers.py
@@ -58,6 +58,32 @@ def test_frequencyseriesdict_crop_maps_to_elements_and_returns_dict():
         d.crop(0, 1, unexpected=True)
 
 
+def test_frequencyseriesdict_to_matrix_preserves_key_order_and_metadata():
+    fs1 = FrequencySeries(
+        [1, 2, 3],
+        frequencies=[10, 20, 30] * u.Hz,
+        unit=u.m,
+        name="n1",
+    )
+    fs2 = FrequencySeries(
+        [4, 5, 6],
+        frequencies=[1, 2, 3] * u.kHz,
+        unit=u.s,
+        name="n2",
+    )
+    d = FrequencySeriesDict({"zeta": fs1, "alpha": fs2})
+
+    matrix = d.to_matrix()
+
+    assert matrix.shape == (2, 1, 3)
+    assert matrix.row_keys() == ("zeta", "alpha")
+    assert matrix.col_keys() == ("value",)
+    assert list(matrix.channel_names) == ["n1", "n2"]
+    assert matrix.units[0, 0] == u.m
+    assert matrix.units[1, 0] == u.s
+    assert np.array_equal(matrix.frequencies.value, fs1.frequencies.value)
+
+
 def test_frequencyseriesdict_plot_separate_axes_count_matches():
     d = FrequencySeriesDict(
         {"a": _make_frequencyseries(), "b": _make_frequencyseries(2.0)}
@@ -81,6 +107,26 @@ def test_frequencyserieslist_slice_returns_same_type():
     sliced = fsl[:1]
     assert isinstance(sliced, FrequencySeriesList)
     assert len(sliced) == 1
+
+
+def test_frequencyserieslist_crop_preserves_list_order_and_container_type():
+    fsl = FrequencySeriesList(
+        _make_frequencyseries(name="first"),
+        _make_frequencyseries(2.0, name="second"),
+    )
+
+    cropped = fsl.crop(2, 5)
+
+    assert isinstance(cropped, FrequencySeriesList)
+    assert cropped is not fsl
+    assert [item.name for item in cropped] == ["first", "second"]
+    assert [len(item) for item in cropped] == [3, 3]
+
+
+def test_frequencyserieslist_has_no_to_matrix_contract():
+    fsl = FrequencySeriesList(_make_frequencyseries())
+
+    assert not hasattr(fsl, "to_matrix")
 
 
 def test_frequencyserieslist_copy_deepcopy_value_not_shared():

--- a/tests/histogram/test_histogram_collections.py
+++ b/tests/histogram/test_histogram_collections.py
@@ -48,6 +48,7 @@ def test_histogram_dict_integral():
 
     # Dictionary plain method mapping
     assert type(res) is dict
+    assert list(res) == ["a", "b"]
     assert "a" in res
     assert "b" in res
 
@@ -57,6 +58,15 @@ def test_histogram_dict_integral():
 
     assert val_a.value == 15
     assert val_b.value == 35
+
+
+def test_histogram_list_statistical_methods_currently_use_map_contract():
+    h1 = Histogram([10, 20], [0, 1, 2], unit="count")
+    h2 = Histogram([30, 40], [0, 1, 2], unit="count")
+    hl = HistogramList([h1, h2])
+
+    with pytest.raises(TypeError, match="Cannot append type"):
+        hl.mean()
 
 
 def test_histogram_collections_hdf5(tmp_path):

--- a/tests/io/test_collection_dir.py
+++ b/tests/io/test_collection_dir.py
@@ -223,11 +223,12 @@ class TestIterCollectionDirEntries:
     def test_no_manifest_infers_from_csv(self, tmp_path):
         dp = tmp_path / "col"
         dp.mkdir()
-        (dp / "channel_a.csv").write_text("1,2,3")
         (dp / "channel_b.csv").write_text("4,5,6")
+        (dp / "channel_a.csv").write_text("1,2,3")
         fmt, pairs = iter_collection_dir_entries(dp)
         assert fmt == "csv"
         assert len(pairs) == 2
+        assert [key for key, _, _ in pairs] == ["channel_a", "channel_b"]
 
     def test_no_manifest_no_csv_raises(self, tmp_path):
         dp = tmp_path / "col"

--- a/tests/spectrogram/test_collections.py
+++ b/tests/spectrogram/test_collections.py
@@ -190,6 +190,7 @@ class TestSpectrogramListCrop:
         sg = _make_sg()
         sl = SpectrogramList([sg])
         result = sl.crop(2.0, 7.0)
+        assert result is not sl
         assert isinstance(result, SpectrogramList)
 
     def test_crop_inplace(self):
@@ -241,6 +242,7 @@ class TestSpectrogramListToMatrix:
         sl = SpectrogramList([sg1, sg2])
         matrix = sl.to_matrix()
         assert matrix.shape[0] == 2
+        assert list(matrix.channel_names) == ["a", "b"]
 
     def test_to_matrix_empty(self):
         # Lines 368-369
@@ -322,6 +324,7 @@ class TestSpectrogramDictCrop:
         sg = _make_sg()
         sd = SpectrogramDict({"a": sg})
         result = sd.crop(2.0, 7.0)
+        assert result is not sd
         assert isinstance(result, SpectrogramDict)
         assert "a" in result
 
@@ -344,6 +347,22 @@ class TestSpectrogramDictReduce:
         sd = SpectrogramDict({"a": _make_sg()})
         reduced = sd.__reduce_ex__(4)
         assert reduced[0] is dict
+
+
+class TestSpectrogramDictToMatrixContract:
+    def test_to_matrix_preserves_dict_key_order_as_rows(self):
+        sd = SpectrogramDict(
+            {
+                "zeta": _make_sg(name="sg-zeta"),
+                "alpha": _make_sg(name="sg-alpha"),
+            }
+        )
+
+        matrix = sd.to_matrix()
+
+        assert matrix.row_keys() == ("zeta", "alpha")
+        assert list(matrix.channel_names) == ["sg-zeta", "sg-alpha"]
+        assert matrix.unit == u.m
 
 
 class TestSpectrogramDictWrite:

--- a/tests/timeseries/test_collections_batch.py
+++ b/tests/timeseries/test_collections_batch.py
@@ -38,13 +38,17 @@ def test_timeserieslist_value_at_returns_list():
     assert res[1].to_value(u.m) == pytest.approx(5.0)
 
 
-def test_timeseriesdict_to_matrix_shape():
-    ts1 = _make_series([0, 1, 2, 3, 4])
-    ts2 = _make_series([10, 11, 12, 13, 14])
-    td = TimeSeriesDict({"a": ts1, "b": ts2})
+def test_timeseriesdict_to_matrix_shape_and_key_order_contract():
+    ts1 = _make_series([0, 1, 2, 3, 4], unit=u.m)
+    ts2 = _make_series([10, 11, 12, 13, 14], unit=u.s)
+    td = TimeSeriesDict({"beta": ts1, "alpha": ts2})
 
     mat = td.to_matrix()
     assert mat.shape == (2, 1, 5)
+    assert list(mat.channel_names) == ["beta", "alpha"]
+    assert mat.row_keys() == ("row0", "row1")
+    assert mat.col_keys() == ("col0",)
+    assert all(unit == u.dimensionless_unscaled for unit in mat.units.ravel())
 
 
 # --- TimeSeriesDict: statistical methods via to_matrix ---
@@ -99,6 +103,8 @@ def test_timeseriesdict_crop():
     td = TimeSeriesDict({"a": ts1, "b": ts2})
 
     cropped = td.crop(start=2, end=7)
+    assert cropped is not td
+    assert list(cropped) == ["a", "b"]
     assert cropped["a"].shape[0] == 5
     assert cropped["b"].shape[0] == 5
 
@@ -150,12 +156,14 @@ def test_timeseriesdict_resample_signal():
 # --- TimeSeriesList: to_matrix ---
 
 def test_timeserieslist_to_matrix_shape():
-    tl = TimeSeriesList([
-        _make_series([1.0, 2.0, 3.0]),
-        _make_series([4.0, 5.0, 6.0]),
-    ])
+    ts1 = _make_series([1.0, 2.0, 3.0])
+    ts2 = _make_series([4.0, 5.0, 6.0])
+    ts1.name = "first"
+    ts2.name = "second"
+    tl = TimeSeriesList([ts1, ts2])
     mat = tl.to_matrix()
     assert mat.shape == (2, 1, 3)
+    assert list(mat.channel_names) == ["first", "second"]
 
 
 # --- TimeSeriesList: crop ---
@@ -166,6 +174,7 @@ def test_timeserieslist_crop():
         _make_series(np.arange(10.0) * 2, t0=0, dt=1),
     ])
     cropped = tl.crop(start=3, end=7)
+    assert cropped is not tl
     assert cropped[0].shape[0] == 4
     assert cropped[1].shape[0] == 4
 

--- a/tests/types/test_collection_mixin.py
+++ b/tests/types/test_collection_mixin.py
@@ -1,44 +1,136 @@
-from collections import UserList
+from __future__ import annotations
 
-from gwexpy.types.mixin._collection_mixin import ListMapMixin, _make_list_map_method
+from collections import OrderedDict, UserList
+
+import pytest
+
+from gwexpy.types.mixin._collection_mixin import (
+    DictMapMixin,
+    ListMapMixin,
+    _make_dict_map_method,
+    _make_dict_plain_method,
+    _make_list_map_method,
+    _make_list_plain_method,
+)
 
 
 class _Item:
     def __init__(self, value: int):
         self.value = value
 
-    def bump(self, amount: int = 1):
-        return self.value + amount
+    def scaled(self, factor: int = 1) -> _Item:
+        return _Item(self.value * factor)
+
+    def scalar(self) -> int:
+        return self.value
+
+    def fail(self) -> None:
+        raise RuntimeError(f"boom {self.value}")
+
+
+class _DictCollection(DictMapMixin, OrderedDict[str, _Item]):
+    scaled = _make_dict_map_method("scaled")
+    scalar = _make_dict_plain_method("scalar")
+    fail = _make_dict_plain_method("fail")
+
+
+class _DictWithOrderedResult(DictMapMixin, OrderedDict[str, _Item]):
+    scaled = _make_dict_map_method(
+        "scaled",
+        result_class_path="collections.OrderedDict",
+    )
+
+
+class _ListCollection(ListMapMixin, list[_Item]):
+    scaled = _make_list_map_method("scaled")
+    scalar = _make_list_plain_method("scalar")
+    fail = _make_list_plain_method("fail")
+
+
+class _ListWithPlainResult(ListMapMixin, list[_Item]):
+    scaled = _make_list_map_method("scaled", result_class_path="builtins.list")
 
 
 class _UserListResult(UserList):
     pass
 
 
-class _Container(ListMapMixin, UserList):
-    bump = _make_list_map_method(
-        "bump",
+class _ListWithCustomResult(ListMapMixin, UserList):
+    scaled = _make_list_map_method(
+        "scaled",
         result_class_path="tests.types.test_collection_mixin._UserListResult",
     )
 
 
-class _ContainerNoPath(ListMapMixin, UserList):
-    bump = _make_list_map_method("bump")
+def test_dict_map_helper_preserves_order_and_returns_collection_type():
+    collection = _DictCollection([("b", _Item(2)), ("a", _Item(1))])
+
+    result = collection.scaled(10)
+
+    assert isinstance(result, _DictCollection)
+    assert list(result) == ["b", "a"]
+    assert [item.value for item in result.values()] == [20, 10]
+    assert [item.value for item in collection.values()] == [2, 1]
 
 
-def test_make_list_map_method_supports_userlist_result_class_path():
-    container = _Container([_Item(1), _Item(2)])
+def test_dict_plain_helper_returns_native_dict_and_propagates_errors():
+    collection = _DictCollection([("b", _Item(2)), ("a", _Item(1))])
 
-    out = container.bump(amount=3)
+    result = collection.scalar()
 
-    assert isinstance(out, _UserListResult)
-    assert out == [4, 5]
+    assert type(result) is dict
+    assert list(result) == ["b", "a"]
+    assert result == {"b": 2, "a": 1}
+
+    with pytest.raises(RuntimeError, match="boom 2"):
+        collection.fail()
 
 
-def test_make_list_map_method_supports_userlist_without_result_path():
-    container = _ContainerNoPath([_Item(3), _Item(4)])
+def test_dict_map_helper_can_return_configured_result_class():
+    collection = _DictWithOrderedResult([("b", _Item(2)), ("a", _Item(1))])
 
-    out = container.bump(amount=2)
+    result = collection.scaled(3)
 
-    assert isinstance(out, _ContainerNoPath)
-    assert out == [5, 6]
+    assert type(result) is OrderedDict
+    assert list(result) == ["b", "a"]
+    assert [item.value for item in result.values()] == [6, 3]
+
+
+def test_list_map_helper_preserves_order_and_returns_collection_type():
+    collection = _ListCollection([_Item(2), _Item(1)])
+
+    result = collection.scaled(10)
+
+    assert isinstance(result, _ListCollection)
+    assert [item.value for item in result] == [20, 10]
+    assert [item.value for item in collection] == [2, 1]
+
+
+def test_list_plain_helper_returns_native_list_and_propagates_errors():
+    collection = _ListCollection([_Item(2), _Item(1)])
+
+    result = collection.scalar()
+
+    assert type(result) is list
+    assert result == [2, 1]
+
+    with pytest.raises(RuntimeError, match="boom 2"):
+        collection.fail()
+
+
+def test_list_map_helper_can_return_configured_result_class():
+    collection = _ListWithPlainResult([_Item(2), _Item(1)])
+
+    result = collection.scaled(3)
+
+    assert type(result) is list
+    assert [item.value for item in result] == [6, 3]
+
+
+def test_list_map_helper_can_return_custom_imported_result_class():
+    collection = _ListWithCustomResult([_Item(2), _Item(1)])
+
+    result = collection.scaled(3)
+
+    assert isinstance(result, _UserListResult)
+    assert [item.value for item in result] == [6, 3]


### PR DESCRIPTION
## Summary
- Adds a developer audit for collection ordering, delegation, mutability, metadata, and manifest contracts.
- Adds regression tests for shared collection mixins and family-specific collection baselines across TimeSeries, FrequencySeries, Spectrogram, Histogram, and directory manifests.
- Keeps runtime behavior unchanged and defers behavior changes such as FrequencySeries axis tightening and TimeSeries metadata preservation.

Closes #289.

## Test Plan
- `rtk pytest -q tests/types/test_collection_mixin.py tests/timeseries/test_collections_batch.py tests/frequencyseries/test_frequencyseries_containers.py tests/spectrogram/test_collections.py tests/histogram/test_histogram_collections.py tests/io/test_collection_dir.py tests/io/test_hdf5_collection.py` => 164 passed
- `rtk ruff check tests/types/test_collection_mixin.py tests/timeseries/test_collections_batch.py tests/frequencyseries/test_frequencyseries_containers.py tests/spectrogram/test_collections.py tests/histogram/test_histogram_collections.py tests/io/test_collection_dir.py` => no issues
- `rtk git diff --check` => clean

## Audit Manifest
```yaml
agent_tag: validation
skills_used:
  - superpowers:using-superpowers
  - phased-milestone-planner
  - superpowers:subagent-driven-development
  - superpowers:test-driven-development
  - superpowers:verification-before-completion
  - github:yeet
commands:
  - rtk pytest -q tests/types/test_collection_mixin.py tests/timeseries/test_collections_batch.py tests/frequencyseries/test_frequencyseries_containers.py tests/spectrogram/test_collections.py tests/histogram/test_histogram_collections.py tests/io/test_collection_dir.py tests/io/test_hdf5_collection.py
  - rtk ruff check tests/types/test_collection_mixin.py tests/timeseries/test_collections_batch.py tests/frequencyseries/test_frequencyseries_containers.py tests/spectrogram/test_collections.py tests/histogram/test_histogram_collections.py tests/io/test_collection_dir.py
  - rtk git diff --check
check_physics: not run; docs/test-only contract baseline with no runtime physics behavior changes
files_changed:
  - docs/developers/plans/2026-04-27-collection-api-contract-audit.md
  - tests/types/test_collection_mixin.py
  - tests/timeseries/test_collections_batch.py
  - tests/frequencyseries/test_frequencyseries_containers.py
  - tests/spectrogram/test_collections.py
  - tests/histogram/test_histogram_collections.py
  - tests/io/test_collection_dir.py
review:
  spec_review: approved
  code_quality_review: approved
```
