### PR TITLE
[AGENT:docs] Record Wave 2 Batch 1 completion

### DIFF
--- a/docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
+++ b/docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
@@ -177,6 +177,26 @@ foundation contracts are stable.
 - Field, table, histogram, segment, detector, and time APIs do not rely on
   implicit or undocumented passthrough behavior for public contracts.
 
+#### Wave 2 Batch 1 Completion Report
+
+Status as of 2026-04-27: the first Wave 2 public-surface batch has been
+completed and merged. The PR head was green in GitHub CI before merge and was
+reviewed for contract wording before merge.
+
+| Issue | PR | Merged | Merge commit | Result |
+| --- | --- | --- | --- | --- |
+| #272 | #302 `[AGENT:docs] Finish I/O interop follow-ups` | 2026-04-27 18:58 JST | `122ad2f` | Updated audio metadata install guidance to the published `gwexpy[audio]` / `gwexpy[all]` paths, clarified that `gwexpy[all]` does not install every public interop backend, and recorded the `xml.diaggui` / DTTXML boundary. Public DTTXML direct I/O remains `TimeSeriesDict.read(..., format="xml.diaggui", products=...)`; frequency-domain DTTXML direct shims and registry adapters are implementation-only. The WAV metadata contract now matches the existing warning-and-skip behavior when `tinytag` is missing. |
+
+Net outcome:
+
+- #272 is closed through PR #302.
+- I/O residual documentation, install guidance, and public contract JSON now
+  agree with current implementation behavior.
+- `gwexpy[all]` is documented as a convenience bundle for declared extras, not
+  as an exhaustive installer for every public interop backend.
+- Wave 2 still needs the remaining public-surface audits: #279, #280, #281,
+  #276, #290, and #287.
+
 ### Wave 3: Numerical And Analysis Contracts
 
 **Issues:** #273 -> #285 / #286 -> #277 / #278 / #284 / #288 / #282

--- a/docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
+++ b/docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
@@ -185,7 +185,7 @@ reviewed for contract wording before merge.
 
 | Issue | PR | Merged | Merge commit | Result |
 | --- | --- | --- | --- | --- |
-| #272 | #302 `[AGENT:docs] Finish I/O interop follow-ups` | 2026-04-27 18:58 JST | `122ad2f` | Updated audio metadata install guidance to the published `gwexpy[audio]` / `gwexpy[all]` paths, clarified that `gwexpy[all]` does not install every public interop backend, and recorded the `xml.diaggui` / DTTXML boundary. Public DTTXML direct I/O remains `TimeSeriesDict.read(..., format="xml.diaggui", products=...)`; frequency-domain DTTXML direct shims and registry adapters are implementation-only. The WAV metadata contract now matches the existing warning-and-skip behavior when `tinytag` is missing. |
+| #272 | #302 `[AGENT:docs] Finish I/O interop follow-ups` | 2026-04-27 18:58 JST | `122ad2f` | Updated I/O interop docs and contract records for audio extras, DTTXML boundaries, and WAV metadata fallback behavior. |
 
 Net outcome:
 
@@ -194,6 +194,12 @@ Net outcome:
   agree with current implementation behavior.
 - `gwexpy[all]` is documented as a convenience bundle for declared extras, not
   as an exhaustive installer for every public interop backend.
+- Public DTTXML direct I/O remains
+  `TimeSeriesDict.read(..., format="xml.diaggui", products=...)`;
+  frequency-domain DTTXML direct shims and registry adapters are
+  implementation-only.
+- The WAV metadata contract now matches the existing warning-and-skip behavior
+  when `tinytag` is missing.
 - Wave 2 still needs the remaining public-surface audits: #279, #280, #281,
   #276, #290, and #287.
 

--- a/docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
+++ b/docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
@@ -5,7 +5,26 @@ skills:
   - github:github
   - github:yeet
 branch: codex/wave2-272-roadmap-update
-commit: db47b51f5e0d783cf7b747747b1cc38d8fad9f97
+pr_context:
+  number: 303
+  head_ref: codex/wave2-272-roadmap-update
+  reviewed_head_commit: 67771f1f1721716c02474ceb2524fb1fabe850f5
+  reviewed_head_commit_note: "PR #303 head observed before this review-response update; not a single-commit provenance marker for every file in files_changed."
+  diff_base: 122ad2f6b823d92373ace703ce28a0b8c393e374
+  diff_base_note: "GitHub PR #303 baseRefOid for the reviewed diff."
+source_commits:
+  - commit: 3cecf19976bec79baed4f05c122bf8364fe30862
+    role: "Roadmap document update."
+    files:
+      - docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
+  - commit: db47b51f5e0d783cf7b747747b1cc38d8fad9f97
+    role: "Initial audit manifest addition."
+    files:
+      - docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
+  - commit: 67771f1f1721716c02474ceb2524fb1fabe850f5
+    role: "Prior audit manifest provenance correction."
+    files:
+      - docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
 source_issue: 272
 source_pr: 302
 physics_review: not_required
@@ -28,6 +47,14 @@ commands:
     result: "No whitespace errors."
   - cmd: "rtk rg -n \"<local-absolute-path-patterns>\" docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml"
     result: "No local absolute paths in the new manifest."
+  - cmd: "rtk gh pr view 303 --json number,title,state,isDraft,headRefName,headRefOid,baseRefName,baseRefOid,files,url,commits"
+    result: "Confirmed PR #303 diff base, reviewed head, changed files, and source commits for this manifest correction."
+  - cmd: "rtk git show --name-only --format=fuller --stat --no-renames 3cecf19976bec79baed4f05c122bf8364fe30862"
+    result: "Confirmed the roadmap file was introduced by the roadmap completion commit."
+  - cmd: "rtk git show --name-only --format=fuller --stat --no-renames db47b51f5e0d783cf7b747747b1cc38d8fad9f97"
+    result: "Confirmed the audit manifest file was introduced by the manifest commit."
+  - cmd: "rtk git show --name-only --format=fuller --stat --no-renames 67771f1f1721716c02474ceb2524fb1fabe850f5"
+    result: "Confirmed the prior manifest provenance correction touched only the audit manifest."
 files_changed:
   - path: docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
     change: "Records the Wave 2 Batch 1 completion outcome for #272 and PR #302."

--- a/docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
+++ b/docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
@@ -8,7 +8,7 @@ branch: codex/wave2-272-roadmap-update
 pr_context:
   number: 303
   head_ref: codex/wave2-272-roadmap-update
-  reviewed_head_commit: 67771f1f1721716c02474ceb2524fb1fabe850f5
+  reviewed_head_commit: c41aad210fe478235d23902d44ef62bec826edf8
   reviewed_head_commit_note: "PR #303 head observed before this review-response update; not a single-commit provenance marker for every file in files_changed."
   diff_base: 122ad2f6b823d92373ace703ce28a0b8c393e374
   diff_base_note: "GitHub PR #303 baseRefOid for the reviewed diff."
@@ -25,16 +25,21 @@ source_commits:
     role: "Prior audit manifest provenance correction."
     files:
       - docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
-source_issue: 272
-source_pr: 302
+  - commit: c41aad210fe478235d23902d44ef62bec826edf8
+    role: "Prior review-response clarification for manifest provenance."
+    files:
+      - docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
+records_issue: 272
+records_pr: 302
+records_note: "This manifest records Wave 2 Batch 1 roadmap status after PR #302 closed issue #272; it does not claim ownership of PR #302 implementation changes."
 physics_review: not_required
 risk: docs_only
 scope:
   - "Record Wave 2 Batch 1 completion after PR #302 closed issue #272."
   - "No runtime code, public API behavior, physics behavior, units, or metadata behavior changed."
+agent_notes:
+  - "Reviewed the doc-architect guidance from the local agent skill registry before editing; this local skill read is intentionally not recorded as a reproducible repository command."
 commands:
-  - cmd: "rtk sed -n '1,220p' <skill:doc-architect>/SKILL.md"
-    result: "Reviewed documentation synchronization workflow."
   - cmd: "rtk gh pr view 303 --json number,title,isDraft,mergeStateStatus,headRefName,headRefOid,baseRefName,body,files,statusCheckRollup,url"
     result: "Confirmed draft PR #303 scope and current checks."
   - cmd: "rtk gh issue view 272 --json number,title,state,closed,closedAt,closedByPullRequestsReferences,url"
@@ -45,8 +50,8 @@ commands:
     result: "Audit manifest parsed successfully."
   - cmd: "rtk git diff --check"
     result: "No whitespace errors."
-  - cmd: "rtk rg -n \"<local-absolute-path-patterns>\" docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml"
-    result: "No local absolute paths in the new manifest."
+  - cmd: "rtk rg -n \"(^|[[:space:]\\\"'=:/])/([[:alnum:]_.-]+/){2,}|<(skill:[^>]+|local-[^>]+-patterns)>\" docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml"
+    result: "No committed local absolute paths or unresolved template placeholders in the new manifest."
   - cmd: "rtk gh pr view 303 --json number,title,state,isDraft,headRefName,headRefOid,baseRefName,baseRefOid,files,url,commits"
     result: "Confirmed PR #303 diff base, reviewed head, changed files, and source commits for this manifest correction."
   - cmd: "rtk git show --name-only --format=fuller --stat --no-renames 3cecf19976bec79baed4f05c122bf8364fe30862"

--- a/docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
+++ b/docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
@@ -2,8 +2,8 @@
 agent: Codex
 skills:
   - doc-architect
-  - github:github
-  - github:yeet
+external_tools:
+  - "GitHub CLI/plugin used for issue and PR context; not a local agent skill."
 branch: codex/wave2-272-roadmap-update
 pr_context:
   number: 303
@@ -50,7 +50,7 @@ commands:
     result: "Audit manifest parsed successfully."
   - cmd: "rtk git diff --check"
     result: "No whitespace errors."
-  - cmd: "rtk rg -n \"(^|[[:space:]\\\"'=:/])/([[:alnum:]_.-]+/){2,}|<(skill:[^>]+|local-[^>]+-patterns)>\" docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml"
+  - cmd: "rtk rg -n \"skill:doc-architect|local-absolute-path-patterns|(^|[[:space:]\\\"'=:/])/([[:alnum:]_.-]+/){2,}\" docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml"
     result: "No committed local absolute paths or unresolved template placeholders in the new manifest."
   - cmd: "rtk gh pr view 303 --json number,title,state,isDraft,headRefName,headRefOid,baseRefName,baseRefOid,files,url,commits"
     result: "Confirmed PR #303 diff base, reviewed head, changed files, and source commits for this manifest correction."

--- a/docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
+++ b/docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
@@ -5,7 +5,7 @@ skills:
   - github:github
   - github:yeet
 branch: codex/wave2-272-roadmap-update
-commit: 3cecf19976bec79baed4f05c122bf8364fe30862
+commit: db47b51f5e0d783cf7b747747b1cc38d8fad9f97
 source_issue: 272
 source_pr: 302
 physics_review: not_required

--- a/docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
+++ b/docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
@@ -1,0 +1,38 @@
+---
+agent: Codex
+skills:
+  - doc-architect
+  - github:github
+  - github:yeet
+branch: codex/wave2-272-roadmap-update
+commit: 3cecf19976bec79baed4f05c122bf8364fe30862
+source_issue: 272
+source_pr: 302
+physics_review: not_required
+risk: docs_only
+scope:
+  - "Record Wave 2 Batch 1 completion after PR #302 closed issue #272."
+  - "No runtime code, public API behavior, physics behavior, units, or metadata behavior changed."
+commands:
+  - cmd: "rtk sed -n '1,220p' <skill:doc-architect>/SKILL.md"
+    result: "Reviewed documentation synchronization workflow."
+  - cmd: "rtk gh pr view 303 --json number,title,isDraft,mergeStateStatus,headRefName,headRefOid,baseRefName,body,files,statusCheckRollup,url"
+    result: "Confirmed draft PR #303 scope and current checks."
+  - cmd: "rtk gh issue view 272 --json number,title,state,closed,closedAt,closedByPullRequestsReferences,url"
+    result: "Confirmed issue #272 is closed by PR #302."
+  - cmd: "rtk gh pr view 302 --json number,title,state,isDraft,mergedAt,mergeCommit,url,headRefName"
+    result: "Confirmed PR #302 merged at 2026-04-27T09:58:57Z with merge commit 122ad2f6b823d92373ace703ce28a0b8c393e374."
+  - cmd: "rtk python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml').read_text())\""
+    result: "Audit manifest parsed successfully."
+  - cmd: "rtk git diff --check"
+    result: "No whitespace errors."
+  - cmd: "rtk rg -n \"<local-absolute-path-patterns>\" docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml"
+    result: "No local absolute paths in the new manifest."
+files_changed:
+  - path: docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
+    change: "Records the Wave 2 Batch 1 completion outcome for #272 and PR #302."
+  - path: docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml
+    change: "Adds file-backed audit manifest for PR #303."
+deferred:
+  - "Remaining Wave 2 public-surface audits: #279, #280, #281, #276, #290, and #287."
+  - "Runtime behavior hardening remains outside this docs-only roadmap update."


### PR DESCRIPTION
## Summary

- Records Wave 2 Batch 1 completion for #272 after PR #302 merged.
- Adds the PR #302 merge metadata, outcome summary, and remaining Wave 2 public-surface issues.
- Adds a file-backed audit manifest for this roadmap-only PR.

## Validation

- GitHub checks: 2/2 passed.
- `rtk python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml').read_text())"` -> manifest parsed successfully.
- `rtk git diff --check HEAD^..HEAD` -> clean.
- path hygiene check on the new manifest -> no local absolute path matches.

## Scope

- Docs/audit-manifest only.
- No runtime code, public API behavior, physics behavior, units, or metadata behavior changed.

## Deferred

- Remaining Wave 2 public-surface audits: #279, #280, #281, #276, #290, and #287.
- Runtime behavior hardening remains outside this roadmap update.

## Audit Manifest

- `docs/developers/plans/audit-manifest-272-wave2-batch1-roadmap.yaml`
