### PR TITLE
[AGENT:validation] Record GUI payload metadata contracts

### DIFF
--- a/docs/developers/plans/2026-04-28-gui-payload-contract-audit.md
+++ b/docs/developers/plans/2026-04-28-gui-payload-contract-audit.md
@@ -1,0 +1,75 @@
+# GUI Payload Contract Audit
+
+Date: 2026-04-28
+Issue: #274
+Scope: docs/test-only baseline for current GUI payload shape and metadata absence.
+
+## Summary
+
+This slice records the current GUI result payload contracts before any
+metadata-rich behavior is introduced. It does not change runtime GUI,
+plotting, spectral, or physics code.
+
+The covered paths are:
+
+- `gwexpy.gui.engine.Engine.compute()`
+- `gwexpy.gui.streaming.SpectralAccumulator.get_results()`
+
+Both paths currently emit value-oriented payloads for GUI rendering. They do
+not carry value units, display units, source names, channel identifiers, or a
+metadata object in the result payload.
+
+## Current Contracts
+
+### Time Series
+
+`Engine.compute(..., graph_type="Time Series", ...)` currently returns one
+payload per active trace as:
+
+```python
+(times, values)
+```
+
+`SpectralAccumulator.get_results()` returns the same tuple shape for streaming
+time-series display history.
+
+The tuple shape means there are no metadata keys in the payload. The tests
+assert the payload is not a dict, which explicitly records the current absence
+of `unit`, `name`, `channel`, and `metadata` fields.
+
+### Spectrogram
+
+`Engine.compute(..., graph_type="Spectrogram", ...)` currently returns one
+payload per active trace as a dict with exactly these keys:
+
+```python
+{"type", "times", "freqs", "value"}
+```
+
+`SpectralAccumulator.get_results()` returns the same dict shape from
+spectrogram history.
+
+The new tests assert the exact current key set and explicitly assert that the
+dict does not expose `unit`, `name`, `channel`, or `metadata`.
+
+## Test Strategy
+
+The tests use local lightweight fakes and direct accumulator state setup. This
+keeps the coverage headless and independent of Qt, a live display, NDS,
+network, and expensive spectral computation. The tests are contract baselines,
+not gwpy spectral-math tests.
+
+## Deferred Behavior
+
+Metadata-rich GUI payloads remain follow-up work. A future behavior-changing PR
+can add structured fields such as x/y/value units, display units, names,
+channels, and metadata after the broader plot/helper contracts settle.
+
+That future PR should update these tests intentionally rather than treating
+their failures as incidental breakage.
+
+## Physics Review
+
+Physics review is not required for this slice. No runtime algorithms, unit
+conversions, spectral math, plotting semantics, or GUI rendering behavior were
+changed.

--- a/docs/developers/plans/audit-manifest-274-gui-payload.yaml
+++ b/docs/developers/plans/audit-manifest-274-gui-payload.yaml
@@ -196,3 +196,33 @@ strict_gui_skip_review_response:
     yaml_parse_manifest: clean
     diff_check: clean
     mypy: clean
+
+top_level_gui_dependency_review_response:
+  date: 2026-04-28
+  pr: 324
+  item: "Replace pytest.importorskip preflight with explicit top-level package discovery."
+  files_changed:
+    - path: tests/gui/test_gui_payload_contracts.py
+      change: "Replaced pytest.importorskip() preflight with importlib.util.find_spec() based top-level dependency discovery, so installed-but-broken GUI packages fail instead of being skipped before gwexpy.gui imports run."
+    - path: docs/developers/plans/audit-manifest-274-gui-payload.yaml
+      change: "Recorded the top-level dependency preflight review response and validation."
+  commands_executed:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal pytest -q tests/gui/test_gui_payload_contracts.py -p no:cacheprovider"
+      result: "8 passed."
+    - cmd: "rtk ruff check tests/gui/test_gui_payload_contracts.py"
+      result: "No issues found."
+    - cmd: "rtk ruff format --check tests/gui/test_gui_payload_contracts.py"
+      result: "1 file already formatted."
+    - cmd: "rtk mypy gwexpy tests/gui/test_gui_payload_contracts.py --ignore-missing-imports"
+      result: "No issues found."
+    - cmd: "rtk python -c \"import yaml; yaml.safe_load(open('docs/developers/plans/audit-manifest-274-gui-payload.yaml'))\""
+      result: "Manifest parsed successfully."
+    - cmd: "rtk git diff --check"
+      result: "Clean."
+  test_results:
+    focused_pytest: "8 passed"
+    ruff_check_changed_test: clean
+    ruff_format_changed_test: clean
+    mypy: clean
+    yaml_parse_manifest: clean
+    diff_check: clean

--- a/docs/developers/plans/audit-manifest-274-gui-payload.yaml
+++ b/docs/developers/plans/audit-manifest-274-gui-payload.yaml
@@ -87,3 +87,36 @@ review_response:
     ruff_check_changed_test: clean
     ruff_format_changed_test: clean
     diff_check: clean
+
+additional_review_response:
+  date: 2026-04-28
+  pr: 324
+  item: "Guard gwexpy.gui import chain for partial GUI environments such as PyQt5 present but pyqtgraph or qtpy missing."
+  files_changed:
+    - path: tests/gui/test_gui_payload_contracts.py
+      change: "Broadened the GUI payload fixture guard to cover PyQt5, pyqtgraph, and qtpy before importing gwexpy.gui modules, and to skip only known GUI dependency ImportError cases during those imports."
+    - path: docs/developers/plans/audit-manifest-274-gui-payload.yaml
+      change: "Recorded the additional review response and partial-GUI skip verification."
+  commands_executed:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal python -c '<block pyqtgraph import; run pytest for tests/gui/test_gui_payload_contracts.py>'"
+      result: "Before the guard update, reproduced the partial-GUI failure: 3 passed, 1 setup error from missing pyqtgraph."
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal python -c '<block pyqtgraph import; run pytest for tests/gui/test_gui_payload_contracts.py>'"
+      result: "After the guard update, confirmed clean partial-GUI behavior: 4 skipped."
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal pytest -q tests/gui/test_gui_payload_contracts.py -p no:cacheprovider"
+      result: "4 passed."
+    - cmd: "rtk ruff check tests/gui/test_gui_payload_contracts.py"
+      result: "No issues found."
+    - cmd: "rtk ruff format --check tests/gui/test_gui_payload_contracts.py"
+      result: "1 file already formatted."
+    - cmd: "rtk python -c '<parse docs/developers/plans/audit-manifest-274-gui-payload.yaml with yaml.safe_load>'"
+      result: "Manifest parsed successfully."
+    - cmd: "rtk git diff --check"
+      result: "Clean."
+  test_results:
+    focused_pytest: "4 passed"
+    synthetic_no_pyqtgraph_before_fix: "3 passed, 1 setup error"
+    synthetic_no_pyqtgraph_after_fix: "4 skipped"
+    ruff_check_changed_test: clean
+    ruff_format_changed_test: clean
+    yaml_parse_manifest: clean
+    diff_check: clean

--- a/docs/developers/plans/audit-manifest-274-gui-payload.yaml
+++ b/docs/developers/plans/audit-manifest-274-gui-payload.yaml
@@ -40,7 +40,7 @@ test_results:
   diff_check: clean
   full_pytest: "failed locally: `rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal pytest -q tests/ -p no:cacheprovider` exited 139 at 20% of the suite after a pyqtgraph Qt teardown RuntimeError: `wrapped C/C++ object of type ViewBox has been deleted`."
   mypy: "passed (`mypy: No issues found`)"
-  ci_coverage: "PR #324 head 226d0865a567a3b6468b75b2dcdc682d40783313 had 7 passing GitHub checks on 2026-04-28, including `Ruff, mypy, pytest, and smoke build`."
+  ci_coverage: "PR #324 pre-cleanup head 226d0865a567a3b6468b75b2dcdc682d40783313 had 7 passing GitHub checks on 2026-04-28, including `Ruff, mypy, pytest, and smoke build`; final-head CI is reported in the PR comment after checks complete."
   docs_build: not_run
 
 files_changed:
@@ -63,6 +63,7 @@ notes:
 agent_internal_notes:
   - "Reviewed local superpowers using-superpowers guidance."
   - "Reviewed local superpowers test-driven-development guidance; no production code was changed in this docs/test-only pass."
+  - "Reviewed local receiving-code-review guidance before handling the follow-up; this local skill read is intentionally not recorded as a reproducible repository command."
 
 review_response:
   date: 2026-04-28
@@ -132,8 +133,6 @@ final_review_response:
     - path: docs/developers/plans/audit-manifest-274-gui-payload.yaml
       change: "Removed non-reproducible local skill placeholders from commands_executed, moved them to agent_internal_notes, and recorded local mypy/full-pytest status plus CI coverage for the previous PR head."
   commands_executed:
-    - cmd: "rtk sed -n '1,220p' /home/washimi/.codex/superpowers/skills/receiving-code-review/SKILL.md"
-      result: "Reviewed code-review response workflow."
     - cmd: "rtk sed -n '1,260p' tests/gui/test_gui_payload_contracts.py"
       result: "Reviewed current GUI payload contract tests."
     - cmd: "rtk sed -n '1,260p' docs/developers/plans/audit-manifest-274-gui-payload.yaml"

--- a/docs/developers/plans/audit-manifest-274-gui-payload.yaml
+++ b/docs/developers/plans/audit-manifest-274-gui-payload.yaml
@@ -10,10 +10,6 @@ agent_model: Codex session default
 physics_review_required: false
 
 commands_executed:
-  - cmd: "rtk sed -n '1,220p' <local superpowers using-superpowers skill>"
-    result: "Reviewed session skill-selection guidance."
-  - cmd: "rtk sed -n '1,260p' <local superpowers test-driven-development skill>"
-    result: "Reviewed TDD guidance; no production code was changed in this docs/test-only pass."
   - cmd: "rtk sed -n '1,240p' .agent/AGENTS.md"
     result: "Reviewed project agent instructions."
   - cmd: "rtk sed -n '1,220p' docs/developers/plans/2026-04-26-gui-plot-metadata-unit-audit.md"
@@ -42,8 +38,9 @@ test_results:
   ruff_format_changed_test: clean
   yaml_parse_manifest: clean
   diff_check: clean
-  full_pytest: not_run
-  mypy: not_run
+  full_pytest: "failed locally: `rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal pytest -q tests/ -p no:cacheprovider` exited 139 at 20% of the suite after a pyqtgraph Qt teardown RuntimeError: `wrapped C/C++ object of type ViewBox has been deleted`."
+  mypy: "passed (`mypy: No issues found`)"
+  ci_coverage: "PR #324 head 226d0865a567a3b6468b75b2dcdc682d40783313 had 7 passing GitHub checks on 2026-04-28, including `Ruff, mypy, pytest, and smoke build`."
   docs_build: not_run
 
 files_changed:
@@ -62,6 +59,10 @@ review_sensitive_follow_ups:
 notes:
   - "Runtime gwexpy code was intentionally not changed."
   - "Tests avoid Qt, live GUI display, NDS, network access, and expensive spectral computation."
+
+agent_internal_notes:
+  - "Reviewed local superpowers using-superpowers guidance."
+  - "Reviewed local superpowers test-driven-development guidance; no production code was changed in this docs/test-only pass."
 
 review_response:
   date: 2026-04-28
@@ -120,3 +121,49 @@ additional_review_response:
     ruff_format_changed_test: clean
     yaml_parse_manifest: clean
     diff_check: clean
+
+final_review_response:
+  date: 2026-04-28
+  pr: 324
+  item: "Address outstanding review cleanup on GUI payload contract tests and audit manifest."
+  files_changed:
+    - path: tests/gui/test_gui_payload_contracts.py
+      change: "Kept the PyQt5, pyqtgraph, and qtpy dependency guard so only known GUI dependency ImportError cases skip; renamed the gwpy-style value helper to _AttrWrapper; documented the accumulator expected time derivation."
+    - path: docs/developers/plans/audit-manifest-274-gui-payload.yaml
+      change: "Removed non-reproducible local skill placeholders from commands_executed, moved them to agent_internal_notes, and recorded local mypy/full-pytest status plus CI coverage for the previous PR head."
+  commands_executed:
+    - cmd: "rtk sed -n '1,220p' /home/washimi/.codex/superpowers/skills/receiving-code-review/SKILL.md"
+      result: "Reviewed code-review response workflow."
+    - cmd: "rtk sed -n '1,260p' tests/gui/test_gui_payload_contracts.py"
+      result: "Reviewed current GUI payload contract tests."
+    - cmd: "rtk sed -n '1,260p' docs/developers/plans/audit-manifest-274-gui-payload.yaml"
+      result: "Reviewed current audit manifest."
+    - cmd: "rtk rg -n \"^(import|from) (PyQt5|pyqtgraph|qtpy|gwexpy\\.gui)\" gwexpy/gui -g '*.py'"
+      result: "Verified the gwexpy.gui import chain uses PyQt5, pyqtgraph, and qtpy as the relevant optional GUI dependencies."
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal pytest -q tests/gui/test_gui_payload_contracts.py -p no:cacheprovider"
+      result: "4 passed."
+    - cmd: "rtk ruff check tests/gui/test_gui_payload_contracts.py"
+      result: "No issues found."
+    - cmd: "rtk ruff format --check tests/gui/test_gui_payload_contracts.py"
+      result: "1 file already formatted."
+    - cmd: "rtk python -c \"import yaml; yaml.safe_load(open('docs/developers/plans/audit-manifest-274-gui-payload.yaml'))\""
+      result: "Manifest parsed successfully."
+    - cmd: "rtk git diff --check"
+      result: "Clean."
+    - cmd: "rtk mypy gwexpy/"
+      result: "mypy: No issues found."
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal pytest -q tests/ -p no:cacheprovider"
+      result: "Failed locally: exited 139 at 20% of the suite after a pyqtgraph Qt teardown RuntimeError: `wrapped C/C++ object of type ViewBox has been deleted`."
+    - cmd: "rtk gh pr checks 324"
+      result: "CI Checks Summary: Passed 7, Failed 0 for PR #324 pre-edit head."
+    - cmd: "rtk gh pr view 324 --json headRefOid,statusCheckRollup,url"
+      result: "Confirmed PR #324 pre-edit head 226d0865a567a3b6468b75b2dcdc682d40783313 and passing GitHub checks including `Ruff, mypy, pytest, and smoke build`."
+  test_results:
+    focused_pytest: "4 passed"
+    ruff_check_changed_test: clean
+    ruff_format_changed_test: clean
+    yaml_parse_manifest: clean
+    diff_check: clean
+    mypy: "passed (`mypy: No issues found`)"
+    full_pytest: "failed locally with signal 11 at 20% due to known Qt teardown failure in pyqtgraph AxisItem/ViewBox"
+    ci_coverage: "PR #324 pre-edit head 226d0865a567a3b6468b75b2dcdc682d40783313 had 7 passing checks, including `Ruff, mypy, pytest, and smoke build`."

--- a/docs/developers/plans/audit-manifest-274-gui-payload.yaml
+++ b/docs/developers/plans/audit-manifest-274-gui-payload.yaml
@@ -38,7 +38,7 @@ test_results:
   ruff_format_changed_test: clean
   yaml_parse_manifest: clean
   diff_check: clean
-  full_pytest: "failed locally: `rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal pytest -q tests/ -p no:cacheprovider` exited 139 at 20% of the suite after a pyqtgraph Qt teardown RuntimeError: `wrapped C/C++ object of type ViewBox has been deleted`."
+  full_pytest: "failed locally: `rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal pytest -q tests/ -p no:cacheprovider` exited 139 at 20% of the suite after a pyqtgraph Qt teardown RuntimeError: `wrapped C/C++ object of type ViewBox has been deleted`; this local full-suite limitation was not reproduced by GitHub CI on the reviewed PR head."
   mypy: "passed (`mypy: No issues found`)"
   ci_coverage: "PR #324 pre-cleanup head 226d0865a567a3b6468b75b2dcdc682d40783313 had 7 passing GitHub checks on 2026-04-28, including `Ruff, mypy, pytest, and smoke build`; final-head CI is reported in the PR comment after checks complete."
   docs_build: not_run
@@ -166,3 +166,33 @@ final_review_response:
     mypy: "passed (`mypy: No issues found`)"
     full_pytest: "failed locally with signal 11 at 20% due to known Qt teardown failure in pyqtgraph AxisItem/ViewBox"
     ci_coverage: "PR #324 pre-edit head 226d0865a567a3b6468b75b2dcdc682d40783313 had 7 passing checks, including `Ruff, mypy, pytest, and smoke build`."
+
+strict_gui_skip_review_response:
+  date: 2026-04-28
+  pr: 324
+  item: "Restrict GUI import skip handling to truly missing top-level GUI dependency packages."
+  files_changed:
+    - path: tests/gui/test_gui_payload_contracts.py
+      change: "Changed the ImportError skip classifier to return a dependency only when the missing name belongs to the GUI dependency set and importlib.util.find_spec() confirms the top-level package is absent; installed but incompatible GUI APIs now re-raise."
+    - path: docs/developers/plans/audit-manifest-274-gui-payload.yaml
+      change: "Recorded the stricter skip classifier review response and clarified that the local full-pytest Qt teardown failure was not reproduced by GitHub CI on the reviewed PR head."
+  commands_executed:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal pytest -q tests/gui/test_gui_payload_contracts.py -p no:cacheprovider"
+      result: "6 passed."
+    - cmd: "rtk ruff check tests/gui/test_gui_payload_contracts.py"
+      result: "No issues found."
+    - cmd: "rtk ruff format --check tests/gui/test_gui_payload_contracts.py"
+      result: "1 file already formatted."
+    - cmd: "rtk python -c \"import yaml; yaml.safe_load(open('docs/developers/plans/audit-manifest-274-gui-payload.yaml'))\""
+      result: "Manifest parsed successfully."
+    - cmd: "rtk git diff --check"
+      result: "Clean."
+    - cmd: "rtk mypy gwexpy tests/gui/test_gui_payload_contracts.py --ignore-missing-imports"
+      result: "No issues found."
+  test_results:
+    focused_pytest: "6 passed"
+    ruff_check_changed_test: clean
+    ruff_format_changed_test: clean
+    yaml_parse_manifest: clean
+    diff_check: clean
+    mypy: clean

--- a/docs/developers/plans/audit-manifest-274-gui-payload.yaml
+++ b/docs/developers/plans/audit-manifest-274-gui-payload.yaml
@@ -1,0 +1,64 @@
+---
+# Audit manifest for Issue #274 GUI payload contract baseline
+# Date: 2026-04-28
+
+skill:
+  - test-driven-development
+issue: 274
+branch: codex/wave4-274-gui-payload-contracts
+agent_model: Codex session default
+physics_review_required: false
+
+commands_executed:
+  - cmd: "rtk sed -n '1,220p' <local superpowers using-superpowers skill>"
+    result: "Reviewed session skill-selection guidance."
+  - cmd: "rtk sed -n '1,260p' <local superpowers test-driven-development skill>"
+    result: "Reviewed TDD guidance; no production code was changed in this docs/test-only pass."
+  - cmd: "rtk sed -n '1,240p' .agent/AGENTS.md"
+    result: "Reviewed project agent instructions."
+  - cmd: "rtk sed -n '1,220p' docs/developers/plans/2026-04-26-gui-plot-metadata-unit-audit.md"
+    result: "Reviewed prior GUI/plot metadata audit and identified GUI payload contract gap."
+  - cmd: "rtk sed -n '1,220p' docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md"
+    result: "Reviewed issue-wave guidance for docs/test-only contract baselines."
+  - cmd: "rtk env MPLCONFIGDIR=<tmp>/matplotlib XDG_CACHE_HOME=<tmp> QT_QPA_PLATFORM=minimal pytest -q tests/gui/test_gui_payload_contracts.py -p no:cacheprovider"
+    result: "4 passed."
+  - cmd: "rtk env MPLCONFIGDIR=<tmp>/matplotlib XDG_CACHE_HOME=<tmp> QT_QPA_PLATFORM=minimal pytest -q tests/gui/test_plot_renderer.py tests/gui/test_accumulator_delay.py tests/gui/test_gui_payload_contracts.py -p no:cacheprovider"
+    result: "8 passed."
+  - cmd: "rtk ruff check tests/gui/test_gui_payload_contracts.py"
+    result: "Initially reported I001 import ordering; clean after mechanical fix."
+  - cmd: "rtk ruff check --fix tests/gui/test_gui_payload_contracts.py"
+    result: "Fixed import ordering."
+  - cmd: "rtk ruff format --check tests/gui/test_gui_payload_contracts.py"
+    result: "1 file already formatted."
+  - cmd: "rtk python -c \"import yaml; yaml.safe_load(open('docs/developers/plans/audit-manifest-274-gui-payload.yaml'))\""
+    result: "Manifest parsed successfully."
+  - cmd: "rtk git diff --check"
+    result: "Clean."
+
+test_results:
+  focused_pytest: "4 passed"
+  gui_regression_pytest: "8 passed"
+  ruff_check_changed_test: clean
+  ruff_format_changed_test: clean
+  yaml_parse_manifest: clean
+  diff_check: clean
+  full_pytest: not_run
+  mypy: not_run
+  docs_build: not_run
+
+files_changed:
+  - path: tests/gui/test_gui_payload_contracts.py
+    change: "Added headless current-contract tests for Engine.compute() and SpectralAccumulator.get_results() time-series and spectrogram payload shapes."
+  - path: docs/developers/plans/2026-04-28-gui-payload-contract-audit.md
+    change: "Documented current GUI payload limitations and deferred metadata-rich behavior."
+  - path: docs/developers/plans/audit-manifest-274-gui-payload.yaml
+    change: "Recorded issue scope, commands, verification results, files changed, and physics review status."
+
+review_sensitive_follow_ups:
+  - "Introduce structured GUI payload metadata such as units, name, channel, and metadata."
+  - "Update GUI renderer labels and colorbar behavior based on metadata-rich payloads."
+  - "Review display-unit and phase/dB labeling semantics with domain owners before behavior changes."
+
+notes:
+  - "Runtime gwexpy code was intentionally not changed."
+  - "Tests avoid Qt, live GUI display, NDS, network access, and expensive spectral computation."

--- a/docs/developers/plans/audit-manifest-274-gui-payload.yaml
+++ b/docs/developers/plans/audit-manifest-274-gui-payload.yaml
@@ -62,3 +62,28 @@ review_sensitive_follow_ups:
 notes:
   - "Runtime gwexpy code was intentionally not changed."
   - "Tests avoid Qt, live GUI display, NDS, network access, and expensive spectral computation."
+
+review_response:
+  date: 2026-04-28
+  pr: 324
+  item: "Guard module-level GUI imports so missing PyQt5 produces an explicit skip instead of collection failure."
+  files_changed:
+    - path: tests/gui/test_gui_payload_contracts.py
+      change: "Moved gwexpy.gui Engine and SpectralAccumulator imports into a pytest fixture guarded by pytest.importorskip('PyQt5')."
+  commands_executed:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal pytest -q tests/gui/test_gui_payload_contracts.py -p no:cacheprovider"
+      result: "4 passed."
+    - cmd: "rtk ruff check tests/gui/test_gui_payload_contracts.py"
+      result: "Clean after targeted import-order fix."
+    - cmd: "rtk ruff format --check tests/gui/test_gui_payload_contracts.py"
+      result: "1 file already formatted."
+    - cmd: "rtk git diff --check"
+      result: "Clean."
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal python /tmp/check_gui_payload_pyqt5_skip.py"
+      result: "Synthetic no-PyQt5 harness confirmed 4 skipped with pytest-qt disabled; the first harness attempt without disabling pytest-qt exited before collection because pytest-qt itself requires a Qt binding."
+  test_results:
+    focused_pytest: "4 passed"
+    synthetic_no_pyqt5: "4 skipped"
+    ruff_check_changed_test: clean
+    ruff_format_changed_test: clean
+    diff_check: clean

--- a/tests/gui/test_gui_payload_contracts.py
+++ b/tests/gui/test_gui_payload_contracts.py
@@ -22,12 +22,24 @@ def _missing_gui_dependency_name(exc: ImportError) -> str | None:
     return None
 
 
+def _missing_top_level_gui_dependency_name() -> str | None:
+    return next(
+        (
+            dependency
+            for dependency in _GUI_IMPORT_DEPENDENCIES
+            if importlib.util.find_spec(dependency) is None
+        ),
+        None,
+    )
+
+
 @pytest.fixture
 def gui_payload_classes():
-    for dependency in _GUI_IMPORT_DEPENDENCIES:
-        pytest.importorskip(
-            dependency,
-            reason="gwexpy.gui payload contracts require the GUI dependency chain",
+    missing_dependency = _missing_top_level_gui_dependency_name()
+    if missing_dependency is not None:
+        pytest.skip(
+            "gwexpy.gui payload contracts require "
+            f"{missing_dependency} from the GUI dependency chain",
         )
     try:
         from gwexpy.gui.engine import Engine
@@ -115,6 +127,29 @@ def test_missing_gui_dependency_name_does_not_hide_installed_api_breakage(
         _missing_gui_dependency_name(ImportError("unrelated", name="not_gui_dep"))
         is None
     )
+
+
+def test_missing_top_level_gui_dependency_name_uses_spec_without_importing(
+    monkeypatch,
+):
+    checked: list[str] = []
+
+    def find_spec(name):
+        checked.append(name)
+        return None if name == "pyqtgraph" else object()
+
+    monkeypatch.setattr(importlib.util, "find_spec", find_spec)
+
+    assert _missing_top_level_gui_dependency_name() == "pyqtgraph"
+    assert checked == ["PyQt5", "pyqtgraph"]
+
+
+def test_missing_top_level_gui_dependency_name_keeps_installed_packages_strict(
+    monkeypatch,
+):
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+
+    assert _missing_top_level_gui_dependency_name() is None
 
 
 def test_engine_time_series_payload_is_tuple_without_metadata_keys(gui_payload_classes):

--- a/tests/gui/test_gui_payload_contracts.py
+++ b/tests/gui/test_gui_payload_contracts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 from collections import deque
 
 import numpy as np
@@ -13,14 +14,12 @@ def _missing_gui_dependency_name(exc: ImportError) -> str | None:
     missing = getattr(exc, "name", None)
     if missing is None:
         return None
-    return next(
-        (
-            dependency
-            for dependency in _GUI_IMPORT_DEPENDENCIES
-            if missing == dependency or missing.startswith(f"{dependency}.")
-        ),
-        None,
-    )
+    dependency = missing.split(".", maxsplit=1)[0]
+    if dependency not in _GUI_IMPORT_DEPENDENCIES:
+        return None
+    if importlib.util.find_spec(dependency) is None:
+        return dependency
+    return None
 
 
 @pytest.fixture
@@ -34,11 +33,10 @@ def gui_payload_classes():
         from gwexpy.gui.engine import Engine
         from gwexpy.gui.streaming import SpectralAccumulator
     except (ImportError, ModuleNotFoundError) as exc:
-        dependency = _missing_gui_dependency_name(exc)
-        if dependency is not None:
+        missing_dependency = _missing_gui_dependency_name(exc)
+        if missing_dependency is not None:
             pytest.skip(
-                f"gwexpy.gui payload contracts require {dependency}: {exc}",
-                allow_module_level=False,
+                f"gwexpy.gui payload contracts require {missing_dependency}: {exc}",
             )
         raise
 
@@ -80,6 +78,43 @@ def _active_trace(graph_type: str) -> dict[str, object]:
         "ch_b": None,
         "graph_type": graph_type,
     }
+
+
+def test_missing_gui_dependency_name_requires_absent_top_level_package(monkeypatch):
+    def find_spec(name):
+        return None if name == "pyqtgraph" else object()
+
+    monkeypatch.setattr(importlib.util, "find_spec", find_spec)
+
+    assert (
+        _missing_gui_dependency_name(
+            ModuleNotFoundError("missing pyqtgraph", name="pyqtgraph")
+        )
+        == "pyqtgraph"
+    )
+    assert (
+        _missing_gui_dependency_name(
+            ModuleNotFoundError("missing pyqtgraph.Qt", name="pyqtgraph.Qt")
+        )
+        == "pyqtgraph"
+    )
+
+
+def test_missing_gui_dependency_name_does_not_hide_installed_api_breakage(
+    monkeypatch,
+):
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+
+    assert (
+        _missing_gui_dependency_name(
+            ImportError("cannot import name", name="pyqtgraph.some_submodule")
+        )
+        is None
+    )
+    assert (
+        _missing_gui_dependency_name(ImportError("unrelated", name="not_gui_dep"))
+        is None
+    )
 
 
 def test_engine_time_series_payload_is_tuple_without_metadata_keys(gui_payload_classes):

--- a/tests/gui/test_gui_payload_contracts.py
+++ b/tests/gui/test_gui_payload_contracts.py
@@ -3,11 +3,21 @@ from __future__ import annotations
 from collections import deque
 
 import numpy as np
-
-from gwexpy.gui.engine import Engine
-from gwexpy.gui.streaming import SpectralAccumulator
+import pytest
 
 _METADATA_KEYS = {"unit", "name", "channel", "metadata"}
+
+
+@pytest.fixture
+def gui_payload_classes():
+    pytest.importorskip(
+        "PyQt5",
+        reason="gwexpy.gui package imports PyQt5 while loading GUI submodules",
+    )
+    from gwexpy.gui.engine import Engine
+    from gwexpy.gui.streaming import SpectralAccumulator
+
+    return Engine, SpectralAccumulator
 
 
 class _Value:
@@ -47,7 +57,8 @@ def _active_trace(graph_type: str) -> dict[str, object]:
     }
 
 
-def test_engine_time_series_payload_is_tuple_without_metadata_keys():
+def test_engine_time_series_payload_is_tuple_without_metadata_keys(gui_payload_classes):
+    Engine, _ = gui_payload_classes
     engine = Engine()
     payload = engine.compute(
         {"H1:TEST": _FakeTimeSeries()},
@@ -63,7 +74,10 @@ def test_engine_time_series_payload_is_tuple_without_metadata_keys():
     assert not isinstance(payload, dict)
 
 
-def test_engine_spectrogram_payload_has_current_four_key_shape_only():
+def test_engine_spectrogram_payload_has_current_four_key_shape_only(
+    gui_payload_classes,
+):
+    Engine, _ = gui_payload_classes
     engine = Engine()
     engine.configure(
         {
@@ -90,7 +104,10 @@ def test_engine_spectrogram_payload_has_current_four_key_shape_only():
     assert np.allclose(payload["value"], [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
 
 
-def test_spectral_accumulator_time_series_payload_is_tuple_without_metadata_keys():
+def test_spectral_accumulator_time_series_payload_is_tuple_without_metadata_keys(
+    gui_payload_classes,
+):
+    _, SpectralAccumulator = gui_payload_classes
     accumulator = SpectralAccumulator()
     accumulator.active_traces = [_active_trace("Time Series")]
     accumulator.display_history = {"H1:TEST": deque([1.0, 2.0, 3.0])}
@@ -106,7 +123,10 @@ def test_spectral_accumulator_time_series_payload_is_tuple_without_metadata_keys
     assert not isinstance(payload, dict)
 
 
-def test_spectral_accumulator_spectrogram_payload_has_current_four_key_shape_only():
+def test_spectral_accumulator_spectrogram_payload_has_current_four_key_shape_only(
+    gui_payload_classes,
+):
+    _, SpectralAccumulator = gui_payload_classes
     accumulator = SpectralAccumulator()
     accumulator.active_traces = [_active_trace("Spectrogram")]
     accumulator.spectrogram_history = {

--- a/tests/gui/test_gui_payload_contracts.py
+++ b/tests/gui/test_gui_payload_contracts.py
@@ -45,15 +45,15 @@ def gui_payload_classes():
     return Engine, SpectralAccumulator
 
 
-class _Value:
+class _AttrWrapper:
     def __init__(self, value):
         self.value = value
 
 
 class _FakeTimeSeries:
     def __init__(self):
-        self.sample_rate = _Value(8.0)
-        self.times = _Value(np.array([100.0, 100.125, 100.25, 100.375]))
+        self.sample_rate = _AttrWrapper(8.0)
+        self.times = _AttrWrapper(np.array([100.0, 100.125, 100.25, 100.375]))
         self.value = np.array([1.0, 2.0, 3.0, 4.0])
 
     def __len__(self) -> int:
@@ -65,8 +65,8 @@ class _FakeTimeSeries:
 
 class _FakeSpectrogram:
     def __init__(self):
-        self.times = _Value(np.array([100.0, 101.0]))
-        self.frequencies = _Value(np.array([1.0, 2.0, 3.0]))
+        self.times = _AttrWrapper(np.array([100.0, 101.0]))
+        self.frequencies = _AttrWrapper(np.array([1.0, 2.0, 3.0]))
         self.value = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
 
     def crop_frequencies(self, start, stop):
@@ -143,6 +143,8 @@ def test_spectral_accumulator_time_series_payload_is_tuple_without_metadata_keys
     assert isinstance(payload, tuple)
     assert len(payload) == 2
     times, values = payload
+    # With no current samples, history is anchored before t0:
+    # t0 - (history_len - current_len) * dt = 98.5, then advance by dt.
     assert np.allclose(times, [98.5, 99.0, 99.5])
     assert np.allclose(values, [1.0, 2.0, 3.0])
     assert not isinstance(payload, dict)

--- a/tests/gui/test_gui_payload_contracts.py
+++ b/tests/gui/test_gui_payload_contracts.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from collections import deque
+
+import numpy as np
+
+from gwexpy.gui.engine import Engine
+from gwexpy.gui.streaming import SpectralAccumulator
+
+_METADATA_KEYS = {"unit", "name", "channel", "metadata"}
+
+
+class _Value:
+    def __init__(self, value):
+        self.value = value
+
+
+class _FakeTimeSeries:
+    def __init__(self):
+        self.sample_rate = _Value(8.0)
+        self.times = _Value(np.array([100.0, 100.125, 100.25, 100.375]))
+        self.value = np.array([1.0, 2.0, 3.0, 4.0])
+
+    def __len__(self) -> int:
+        return len(self.value)
+
+    def spectrogram2(self, fftlength, *, overlap=0, window="hann"):
+        return _FakeSpectrogram()
+
+
+class _FakeSpectrogram:
+    def __init__(self):
+        self.times = _Value(np.array([100.0, 101.0]))
+        self.frequencies = _Value(np.array([1.0, 2.0, 3.0]))
+        self.value = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+    def crop_frequencies(self, start, stop):
+        return self
+
+
+def _active_trace(graph_type: str) -> dict[str, object]:
+    return {
+        "active": True,
+        "ch_a": "H1:TEST",
+        "ch_b": None,
+        "graph_type": graph_type,
+    }
+
+
+def test_engine_time_series_payload_is_tuple_without_metadata_keys():
+    engine = Engine()
+    payload = engine.compute(
+        {"H1:TEST": _FakeTimeSeries()},
+        "Time Series",
+        [_active_trace("Time Series")],
+    )[0]
+
+    assert isinstance(payload, tuple)
+    assert len(payload) == 2
+    times, values = payload
+    assert np.allclose(times, [100.0, 100.125, 100.25, 100.375])
+    assert np.allclose(values, [1.0, 2.0, 3.0, 4.0])
+    assert not isinstance(payload, dict)
+
+
+def test_engine_spectrogram_payload_has_current_four_key_shape_only():
+    engine = Engine()
+    engine.configure(
+        {
+            "bw": 2.0,
+            "overlap": 0.0,
+            "window": "hann",
+            "start_freq": 0.0,
+            "stop_freq": 10.0,
+        }
+    )
+
+    payload = engine.compute(
+        {"H1:TEST": _FakeTimeSeries()},
+        "Spectrogram",
+        [_active_trace("Spectrogram")],
+    )[0]
+
+    assert isinstance(payload, dict)
+    assert set(payload) == {"type", "times", "freqs", "value"}
+    assert _METADATA_KEYS.isdisjoint(payload)
+    assert payload["type"] == "spectrogram"
+    assert np.allclose(payload["times"], [100.0, 101.0])
+    assert np.allclose(payload["freqs"], [1.0, 2.0, 3.0])
+    assert np.allclose(payload["value"], [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+
+
+def test_spectral_accumulator_time_series_payload_is_tuple_without_metadata_keys():
+    accumulator = SpectralAccumulator()
+    accumulator.active_traces = [_active_trace("Time Series")]
+    accumulator.display_history = {"H1:TEST": deque([1.0, 2.0, 3.0])}
+    accumulator.buffers = {"H1:TEST": {"t0": 100.0, "current_len": 0, "dt": 0.5}}
+
+    payload = accumulator.get_results()[0]
+
+    assert isinstance(payload, tuple)
+    assert len(payload) == 2
+    times, values = payload
+    assert np.allclose(times, [98.5, 99.0, 99.5])
+    assert np.allclose(values, [1.0, 2.0, 3.0])
+    assert not isinstance(payload, dict)
+
+
+def test_spectral_accumulator_spectrogram_payload_has_current_four_key_shape_only():
+    accumulator = SpectralAccumulator()
+    accumulator.active_traces = [_active_trace("Spectrogram")]
+    accumulator.spectrogram_history = {
+        "H1:TEST": deque(
+            [
+                {"t": 100.0, "f": np.array([1.0, 2.0]), "v": np.array([3.0, 4.0])},
+                {"t": 101.0, "f": np.array([1.0, 2.0]), "v": np.array([5.0, 6.0])},
+            ]
+        )
+    }
+
+    payload = accumulator.get_results()[0]
+
+    assert isinstance(payload, dict)
+    assert set(payload) == {"type", "times", "freqs", "value"}
+    assert _METADATA_KEYS.isdisjoint(payload)
+    assert payload["type"] == "spectrogram"
+    assert np.allclose(payload["times"], [100.0, 101.0])
+    assert np.allclose(payload["freqs"], [1.0, 2.0])
+    assert np.allclose(payload["value"], [[3.0, 4.0], [5.0, 6.0]])

--- a/tests/gui/test_gui_payload_contracts.py
+++ b/tests/gui/test_gui_payload_contracts.py
@@ -6,16 +6,41 @@ import numpy as np
 import pytest
 
 _METADATA_KEYS = {"unit", "name", "channel", "metadata"}
+_GUI_IMPORT_DEPENDENCIES = ("PyQt5", "pyqtgraph", "qtpy")
+
+
+def _missing_gui_dependency_name(exc: ImportError) -> str | None:
+    missing = getattr(exc, "name", None)
+    if missing is None:
+        return None
+    return next(
+        (
+            dependency
+            for dependency in _GUI_IMPORT_DEPENDENCIES
+            if missing == dependency or missing.startswith(f"{dependency}.")
+        ),
+        None,
+    )
 
 
 @pytest.fixture
 def gui_payload_classes():
-    pytest.importorskip(
-        "PyQt5",
-        reason="gwexpy.gui package imports PyQt5 while loading GUI submodules",
-    )
-    from gwexpy.gui.engine import Engine
-    from gwexpy.gui.streaming import SpectralAccumulator
+    for dependency in _GUI_IMPORT_DEPENDENCIES:
+        pytest.importorskip(
+            dependency,
+            reason="gwexpy.gui payload contracts require the GUI dependency chain",
+        )
+    try:
+        from gwexpy.gui.engine import Engine
+        from gwexpy.gui.streaming import SpectralAccumulator
+    except (ImportError, ModuleNotFoundError) as exc:
+        dependency = _missing_gui_dependency_name(exc)
+        if dependency is not None:
+            pytest.skip(
+                f"gwexpy.gui payload contracts require {dependency}: {exc}",
+                allow_module_level=False,
+            )
+        raise
 
     return Engine, SpectralAccumulator
 


### PR DESCRIPTION
## Summary

Addresses #274 with a focused GUI payload current-contract baseline.

- Adds headless tests for `Engine.compute()` time-series and spectrogram payload shapes.
- Adds headless tests for `SpectralAccumulator.get_results()` time-series and spectrogram payload shapes.
- Records the current absence of `unit`, `name`, `channel`, and `metadata` in GUI result payloads.
- Adds an audit note and manifest for this docs/test-only slice.

## Scope

Docs/test only. No `gwexpy` runtime package files changed. No GUI behavior, plotting behavior, spectral math, physics, metadata propagation, or unit conversion behavior changed.

## Verification

- `rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal pytest -q tests/gui/test_gui_payload_contracts.py -p no:cacheprovider` -> 4 passed
- `rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp QT_QPA_PLATFORM=minimal pytest -q tests/gui/test_plot_renderer.py tests/gui/test_accumulator_delay.py tests/gui/test_gui_payload_contracts.py -p no:cacheprovider` -> 8 passed
- `rtk ruff check tests/gui/test_gui_payload_contracts.py` -> clean
- `rtk ruff format --check tests/gui/test_gui_payload_contracts.py` -> 1 file already formatted
- YAML parse for `docs/developers/plans/audit-manifest-274-gui-payload.yaml` -> clean
- `rtk git diff --check HEAD^..HEAD` -> clean

## Reviews

- Spec compliance review: APPROVED.
- Code quality review: APPROVED after manifest path-hygiene cleanup.

## Deferred

- Structured GUI payload metadata such as units, names, channels, and metadata.
- Renderer label/colorbar behavior based on metadata-rich payloads.
- Domain review for display-unit and phase/dB labeling semantics before behavior changes.
