### PR TITLE
[AGENT:validation] Add field algebra contract baseline

### DIFF
--- a/docs/developers/plans/2026-04-28-field-algebra-contract-audit.md
+++ b/docs/developers/plans/2026-04-28-field-algebra-contract-audit.md
@@ -1,0 +1,77 @@
+# Field Algebra Contract Audit
+
+Date: 2026-04-28
+Issue: #287, "Audit field algebra contracts"
+Mode: audit-first; docs and regression tests only.
+
+## Scope For This Slice
+
+This slice records a narrow baseline for `gwexpy.fields.ScalarField` binary
+arithmetic. It does not change runtime behavior.
+
+Reviewed inputs:
+
+- `gwexpy/fields/base.py` domain metadata handling and unit validation.
+- `gwexpy/fields/scalar.py` `ScalarField` construction and metadata
+  propagation paths.
+- Existing field-domain, unit, and space-transform contract tests under
+  `tests/fields/`.
+- Prior field-space audit notes in `docs/developers/plans/`.
+
+## Current Observed Behavior
+
+- Aligned same-shape `ScalarField` addition with compatible value units returns
+  a `ScalarField`, converts compatible units through the inherited array
+  arithmetic path, and preserves the left-hand field's `axis0_domain`,
+  `space_domains`, axes, and unit.
+- Same-shape fields with different `x` coordinate grids currently add without
+  a field-level coordinate check. The result inherits the left-hand field's
+  public axis metadata.
+- Same-shape fields with different axis0 domains, for example `time` versus
+  `frequency`, currently add when the data units permit arithmetic. The result
+  inherits the left-hand field's axis0 domain and axis names.
+
+The two mismatch cases are recorded with explicit `pytest.xfail()` calls only
+for the current unsafe behavior where arithmetic succeeds. If runtime code later
+raises a matching `ValueError`, those tests will pass normally and force the
+temporary xfail branch to be removed or updated. Unexpected exception types or
+non-contract error messages remain ordinary test failures.
+
+## Why Runtime Change Is Deferred
+
+Field algebra touches physics-sensitive metadata contracts: coordinate grid
+alignment, time/frequency-domain separation, unit conversion, and compatibility
+with NumPy/GWpy array arithmetic. A runtime guard should be reviewed by a human
+before deciding:
+
+- which binary operations require identical field axes;
+- whether equivalent but differently represented axes may be accepted;
+- how error messages should distinguish value-unit failures from metadata
+  alignment failures;
+- how much behavior may diverge from inherited GWpy/NumPy semantics.
+
+This slice therefore adds only tests and audit documentation.
+
+## Follow-Up Candidates
+
+1. Define the public binary-operation alignment contract for `ScalarField`,
+   including axis names, axis coordinates, `axis0_domain`, and `space_domains`.
+2. Decide whether coordinate comparison should require exact equality or
+   quantity-aware tolerances.
+3. Extend the same contract review to `VectorField`, `TensorField`,
+   `FieldList`, and `FieldDict` arithmetic paths.
+4. Add runtime guards after physics review and replace the strict xfail tests
+   with passing regression tests.
+
+## Verification
+
+Required focused commands for this slice:
+
+```bash
+rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp pytest -q tests/fields/test_field_algebra_contracts.py -p no:cacheprovider
+rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp pytest -q tests/fields/test_field_algebra_contracts.py tests/fields/test_scalarfield_domain.py tests/fields/test_space_transform_contracts.py -p no:cacheprovider
+rtk ruff check tests/fields/test_field_algebra_contracts.py
+rtk ruff format --check tests/fields/test_field_algebra_contracts.py
+rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp python -c "import yaml; yaml.safe_load(open('docs/developers/plans/audit-manifest-287-field-algebra.yaml'))"
+rtk git diff --check
+```

--- a/docs/developers/plans/audit-manifest-287-field-algebra.yaml
+++ b/docs/developers/plans/audit-manifest-287-field-algebra.yaml
@@ -1,0 +1,102 @@
+---
+# Audit manifest for issue #287 field-algebra contract slice
+# Date: 2026-04-28
+
+skill:
+  - superpowers:using-superpowers
+  - superpowers:test-driven-development
+  - superpowers:verification-before-completion
+issue: 287
+branch: codex/wave4-287-field-contracts
+agent_model: Codex session default
+
+scope:
+  mode: docs_and_tests_only
+  runtime_modules_changed: false
+  contract_surface:
+    - ScalarField binary addition with aligned field metadata
+    - ScalarField same-shape spatial coordinate mismatch guard gap
+    - ScalarField same-shape axis0 domain mismatch guard gap
+
+physics_review: deferred_required_before_runtime_change
+physics_review_reason: >
+  This slice documents current behavior and desired future guards only. It does
+  not change coordinate-grid alignment, time/frequency-domain separation, unit
+  conversion, or NumPy/GWpy arithmetic inheritance semantics.
+
+commands_executed:
+  - cmd: "rtk sed -n '1,220p' AGENTS.md"
+    result: "Read repository entrypoint instructions."
+  - cmd: "rtk sed -n '1,260p' .agent/AGENTS.md"
+    result: "Read project agent guidelines."
+  - cmd: "rtk sed -n '1,220p' .agent/workflow/SKILL.md"
+    result: "No such file in this worktree; project-local SKILL.md files were not present at the documented paths."
+  - cmd: "rtk sed -n '1,220p' .agent/validation/SKILL.md"
+    result: "No such file in this worktree; project-local SKILL.md files were not present at the documented paths."
+  - cmd: "rtk sed -n '1,220p' .agent/docs/SKILL.md"
+    result: "No such file in this worktree; project-local SKILL.md files were not present at the documented paths."
+  - cmd: "rtk find .agent -maxdepth 3 -type f -name 'SKILL.md' | rtk sort"
+    result: "No project-local SKILL.md files found."
+  - cmd: "rtk find docs/developers/plans -maxdepth 1 -type f | rtk sort | rtk sed -n '1,160p'"
+    result: "Reviewed available developer plan and audit context."
+  - cmd: "rtk sed -n '1,240p' docs/developers/plans/2026-04-27-wave3-field-space-transform-contract-audit.md"
+    result: "Reviewed prior field contract audit style and deferred-change pattern."
+  - cmd: "rtk sed -n '1,220p' docs/developers/plans/audit-manifest-285-field-space-transforms.yaml"
+    result: "Reviewed existing audit manifest format."
+  - cmd: "rtk sed -n '1,260p' tests/fields/test_scalarfield_domain.py"
+    result: "Reviewed domain and unit propagation test patterns."
+  - cmd: "rtk sed -n '1,260p' tests/fields/test_space_transform_contracts.py"
+    result: "Reviewed field contract helper and assertion style."
+  - cmd: "rtk rg -n \"class ScalarField|axis0_domain|space_domains|def axis\\(\" gwexpy/fields tests/fields -S"
+    result: "Located ScalarField metadata properties and existing field tests."
+  - cmd: "rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp python -c \"... ScalarField binary arithmetic probe ...\""
+    result: "Confirmed aligned addition preserves left metadata, while same-shape x-grid and axis0-domain mismatches currently do not raise."
+  - cmd: "rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp pytest -q tests/fields/test_field_algebra_contracts.py -p no:cacheprovider"
+    result: "1 passed, 2 xfailed in 1.67s"
+  - cmd: "rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp pytest -q tests/fields/test_field_algebra_contracts.py tests/fields/test_scalarfield_domain.py tests/fields/test_space_transform_contracts.py -p no:cacheprovider"
+    result: "24 passed, 2 xfailed in 1.72s"
+  - cmd: "rtk ruff check tests/fields/test_field_algebra_contracts.py"
+    result: "Ruff: No issues found"
+  - cmd: "rtk ruff format --check tests/fields/test_field_algebra_contracts.py"
+    result: "1 file already formatted"
+  - cmd: "rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp python -c \"import yaml; yaml.safe_load(open('docs/developers/plans/audit-manifest-287-field-algebra.yaml'))\""
+    result: "Parsed successfully"
+  - cmd: "rtk git diff --check"
+    result: "Clean"
+  - cmd: "quality review"
+    result: >
+      Requested narrowing mismatch xfails so only the current unsafe success
+      path is xfailed; unexpected exceptions or non-contract ValueErrors now
+      fail normally.
+
+test_results:
+  new_test_file: "1 passed, 2 xfailed"
+  focused_field_regression: "24 passed, 2 xfailed"
+  ruff_changed_tests: clean
+  ruff_format_changed_tests: clean
+  yaml_parse_manifest: clean
+  diff_check: clean
+  full_pytest: not_run
+  mypy: not_run
+  docs_build: not_run
+
+files_changed:
+  - path: tests/fields/test_field_algebra_contracts.py
+    change: >
+      Adds an aligned ScalarField binary-addition baseline plus strict xfail
+      tests for desired future same-shape x-coordinate and axis0-domain
+      mismatch guards.
+  - path: docs/developers/plans/2026-04-28-field-algebra-contract-audit.md
+    change: >
+      Documents scope, reviewed inputs, observed inherited arithmetic behavior,
+      deferred runtime decisions, and follow-up candidates.
+  - path: docs/developers/plans/audit-manifest-287-field-algebra.yaml
+    change: >
+      Records issue scope, physics-review status, command log, test results,
+      and changed files for this docs/test-only slice.
+
+deferred_follow_ups:
+  - "Define public ScalarField binary-operation alignment requirements."
+  - "Decide exact versus tolerance-based coordinate comparisons."
+  - "Audit VectorField, TensorField, FieldList, and FieldDict algebra paths."
+  - "Add runtime guards after physics review and replace strict xfail tests."

--- a/tests/fields/test_field_algebra_contracts.py
+++ b/tests/fields/test_field_algebra_contracts.py
@@ -1,0 +1,97 @@
+"""Contract baseline for ScalarField binary algebra metadata alignment."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from astropy import units as u
+from numpy.testing import assert_allclose
+
+from gwexpy.fields import ScalarField
+
+
+def _make_scalar_field(
+    *,
+    value: float = 1.0,
+    unit=u.V,
+    axis0=None,
+    axis1=None,
+    axis2=None,
+    axis3=None,
+    axis_names=("t", "x", "y", "z"),
+    axis0_domain: str = "time",
+) -> ScalarField:
+    shape = (2, 2, 2, 2)
+    axis0 = np.arange(shape[0]) * u.s if axis0 is None else axis0
+    axis1 = np.arange(shape[1]) * u.m if axis1 is None else axis1
+    axis2 = np.arange(shape[2]) * u.m if axis2 is None else axis2
+    axis3 = np.arange(shape[3]) * u.m if axis3 is None else axis3
+    return ScalarField(
+        np.full(shape, value, dtype=float),
+        unit=unit,
+        axis0=axis0,
+        axis1=axis1,
+        axis2=axis2,
+        axis3=axis3,
+        axis_names=axis_names,
+        axis0_domain=axis0_domain,
+        space_domain="real",
+    )
+
+
+def _assert_axis_matches(result: ScalarField, expected: ScalarField, name: str) -> None:
+    result_axis = result.axis(name).index
+    expected_axis = expected.axis(name).index
+    assert result_axis.unit == expected_axis.unit
+    assert_allclose(result_axis.value, expected_axis.value)
+
+
+def test_scalarfield_add_aligned_grid_preserves_metadata_and_values():
+    left = _make_scalar_field(value=1.0, unit=u.V)
+    right = _make_scalar_field(value=2.0, unit=u.mV)
+
+    result = left + right
+
+    assert isinstance(result, ScalarField)
+    assert result.axis0_domain == "time"
+    assert result.space_domains == {"x": "real", "y": "real", "z": "real"}
+    assert result.unit == u.V
+    for axis_name in ("t", "x", "y", "z"):
+        _assert_axis_matches(result, left, axis_name)
+    assert_allclose(result.value, np.full(left.shape, 1.002))
+
+
+def test_scalarfield_add_rejects_same_shape_x_coordinate_mismatch():
+    left = _make_scalar_field(value=1.0)
+    right = _make_scalar_field(value=2.0, axis1=np.array([10.0, 11.0]) * u.m)
+
+    try:
+        left + right
+    except ValueError as exc:
+        assert "axis" in str(exc).lower() or "coordinate" in str(exc).lower()
+    else:
+        pytest.xfail(
+            "Issue #287: ScalarField binary arithmetic should reject same-shape "
+            "spatial coordinate grid mismatches before inheriting array arithmetic."
+        )
+
+
+def test_scalarfield_add_rejects_same_shape_axis0_domain_mismatch():
+    time_field = _make_scalar_field(value=1.0, unit=u.V)
+    frequency_field = _make_scalar_field(
+        value=2.0,
+        unit=u.V,
+        axis0=np.arange(2) * u.Hz,
+        axis_names=("f", "x", "y", "z"),
+        axis0_domain="frequency",
+    )
+
+    try:
+        time_field + frequency_field
+    except ValueError as exc:
+        assert "axis" in str(exc).lower() or "domain" in str(exc).lower()
+    else:
+        pytest.xfail(
+            "Issue #287: ScalarField binary arithmetic should reject same-shape "
+            "axis0 domain mismatches even when data units permit arithmetic."
+        )


### PR DESCRIPTION
## Summary

Adds a docs/test-only contract baseline for issue #287 field algebra risks:

- records aligned `ScalarField` binary addition as the current stable baseline;
- adds xfail-guarded desired behavior for same-shape spatial coordinate mismatches;
- adds xfail-guarded desired behavior for same-shape `axis0_domain` mismatches;
- documents why runtime guards are deferred for human/physics review.

## Scope

- Tests only: `tests/fields/test_field_algebra_contracts.py`
- Developer audit doc and manifest only.
- No production/runtime code changes.
- No Fourier, unit, metadata propagation, or field algebra behavior changes.

## Validation

- `rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp pytest -q tests/fields/test_field_algebra_contracts.py -p no:cacheprovider -rxX` -> 1 passed, 2 xfailed
- `rtk env MPLCONFIGDIR=/tmp/matplotlib XDG_CACHE_HOME=/tmp pytest -q tests/fields/test_field_algebra_contracts.py tests/fields/test_scalarfield_domain.py tests/fields/test_space_transform_contracts.py -p no:cacheprovider` -> 24 passed, 2 xfailed
- `rtk ruff check tests/fields/test_field_algebra_contracts.py` -> clean
- `rtk ruff format --check tests/fields/test_field_algebra_contracts.py` -> already formatted
- YAML manifest parse -> clean
- `rtk git diff --check HEAD^..HEAD` -> clean

## Review

- Spec compliance: approved.
- Code quality: approved after narrowing xfail behavior so only the current unsafe success path is xfailed.

## Notes

This PR intentionally does not close all #287 work. Follow-up runtime guards for coordinate and domain mismatch behavior should be reviewed explicitly because they affect physics-facing field algebra semantics.

Closes none.
