### PR TITLE
[AGENT:docs] Classify SeriesMatrix xindex tolerance residual

### DIFF
--- a/docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
+++ b/docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
@@ -117,7 +117,7 @@ and merged. All PR heads were green in GitHub CI before merge.
 | --- | --- | --- | --- | --- |
 | #291 | #295 `[AGENT:validation] Add types foundation contract audit coverage` | 2026-04-27 11:32 JST | `ae31d88` | Added low-level types, axis, metadata-container, and `as_series` contract coverage. Runtime behavior unchanged. Known `MetaDataMatrix` CSV blank channel/unit xfail remains documented. |
 | #270 | #296 `[AGENT:docs] Define to_matrix family contracts` | 2026-04-27 11:32 JST | `1f59c6e` | Documented and tested family-specific `to_matrix()` contracts for `TimeSeries`, `FrequencySeries`, and `Spectrogram`. Also classified the GWOSC segment fetch test as network-only so non-network CI gates stay deterministic. Runtime behavior unchanged. |
-| #269 | #298 `[AGENT:validation] Enforce SeriesMatrix matmul xindex equality` | 2026-04-27 11:33 JST | `acf87e7` | Hardened `SeriesMatrix.__matmul__` so same sample length is no longer enough when sample-axis coordinates differ. Near-equal numeric axes use `rtol=1e-9, atol=0.0`; one-sided missing axes still raise. Physics-sensitive behavior was reviewed before merge. |
+| #269 | #298 `[AGENT:validation] Enforce SeriesMatrix matmul xindex equality` | 2026-04-27 11:33 JST | `acf87e7` | Hardened `SeriesMatrix.__matmul__` so same sample length is no longer enough when sample-axis coordinates differ. Near-equal numeric axes use `rtol=1e-9, atol=0.0`; one-sided missing axes still raise. Physics-sensitive behavior was reviewed before merge. This closed the matrix-multiplication slice, not every #269 follow-up. |
 | #271 | #297 `[AGENT:validation] Preserve SeriesMatrix round-trip metadata` | 2026-04-27 12:19 JST | `5eab91a` | Preserved `SeriesMatrix` metadata through pickle, added metadata round-trip tests, filtered non-picklable `attrs` entries per active pickle protocol, and preserved subclass pickle reducers such as `SpectrogramMatrix.__reduce__`. |
 
 Net outcome:
@@ -133,6 +133,16 @@ Net outcome:
 - Wave 1 Batch 1 left #289 and #292 as the remaining Lane A targets; those
   were closed by the Batch 2 follow-up below.
 
+##### SeriesMatrix xindex tolerance residual
+
+#269 remains open for the post-#298 tolerance decision: the merged matmul slice
+prevents silent multiplication on mismatched sample axes, while a later deep
+dive identified that exact `xindex` equality can reject physically acceptable
+sub-sample timestamp jitter. No runtime tolerance policy changes in this
+roadmap update. Any move from exact equality to a tolerance such as a
+sample-period-relative `np.allclose` policy needs physics review before code or
+contract tests make that behavior normative.
+
 #### Wave 1 Batch 2 Completion Report
 
 Status as of 2026-04-27: the second autonomous Wave 1 batch has been completed
@@ -145,8 +155,9 @@ and merged. All PR heads were green in GitHub CI before merge.
 
 Net outcome:
 
-- Wave 1 foundation issues #291, #269, #270, #271, #289, and #292 are now
-  closed through merged PRs.
+- Wave 1 foundation issues #291, #270, #271, #289, and #292 are now closed
+  through merged PRs. #269 has a merged matmul invariant slice and remains open
+  for the xindex tolerance policy decision above.
 - Foundation contracts now cover low-level types, SeriesMatrix invariants,
   family-specific `to_matrix()` behavior, metadata persistence, collection API
   behavior, and standalone frequency/spectrogram class behavior.

--- a/docs/developers/plans/audit-manifest-269-xindex-tolerance-roadmap.yaml
+++ b/docs/developers/plans/audit-manifest-269-xindex-tolerance-roadmap.yaml
@@ -3,7 +3,8 @@ agent: Codex
 skills:
   - doc-architect
   - pytest-tdd
-  - github:github
+external_tools:
+  - "GitHub CLI/plugin used for issue and PR context; not a local agent skill."
 branch: codex/wave4-269-xindex-tolerance-roadmap
 issue: 269
 physics_review: not_required
@@ -31,13 +32,23 @@ commands:
     result: "Audit manifest parsed successfully."
   - cmd: "rtk rg -n \"<local-absolute-path-patterns>\" <changed-files>"
     result: "No local absolute paths in changed files."
+  - cmd: "rtk pytest -q tests/test_issue_burn_down_roadmap.py -p no:cacheprovider"
+    result: "Review follow-up validation: 1 passed."
+  - cmd: "rtk ruff check tests/test_issue_burn_down_roadmap.py"
+    result: "Review follow-up validation: no issues found."
+  - cmd: "rtk ruff format --check tests/test_issue_burn_down_roadmap.py"
+    result: "Review follow-up validation: 1 file already formatted."
+  - cmd: "rtk python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('docs/developers/plans/audit-manifest-269-xindex-tolerance-roadmap.yaml').read_text())\""
+    result: "Review follow-up validation: audit manifest parsed successfully."
+  - cmd: "rtk git diff --check"
+    result: "Review follow-up validation: no whitespace errors."
 files_changed:
   - path: docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
     change: "Separates the merged #298 matmul invariant slice from the remaining #269 xindex tolerance policy decision."
   - path: docs/developers/plans/audit-manifest-269-xindex-tolerance-roadmap.yaml
-    change: "Adds audit manifest for this docs/test-only roadmap correction."
+    change: "Adds audit manifest for this docs/test-only roadmap correction and keeps external tool references separate from local skills."
   - path: tests/test_issue_burn_down_roadmap.py
-    change: "Adds a lightweight guard that the #269 xindex tolerance residual remains explicitly classified."
+    change: "Adds a lightweight drift guard that the #269 xindex tolerance residual remains explicitly classified."
 deferred:
   - "Any exact-equality to fuzzy-tolerance runtime change."
   - "Tolerance value, warning policy, and resampling/interpolation guidance for physics-facing xindex alignment."

--- a/docs/developers/plans/audit-manifest-269-xindex-tolerance-roadmap.yaml
+++ b/docs/developers/plans/audit-manifest-269-xindex-tolerance-roadmap.yaml
@@ -1,0 +1,44 @@
+---
+agent: Codex
+skills:
+  - doc-architect
+  - pytest-tdd
+  - github:github
+branch: codex/wave4-269-xindex-tolerance-roadmap
+issue: 269
+physics_review: not_required
+risk: docs_test_only
+scope:
+  - "Classify the remaining SeriesMatrix xindex jitter tolerance work after PR #298."
+  - "Correct the burn-down roadmap so #269 is not described as fully closed."
+  - "Add a docs drift guard for the residual classification."
+commands:
+  - cmd: "rtk gh issue view 269 --json number,title,state,body,comments,labels,url"
+    result: "Confirmed #269 is open and contains the post-#298 xindex jitter tolerance deep-dive note."
+  - cmd: "rtk gh pr view 298 --json number,title,state,mergedAt,mergeCommit,url,body"
+    result: "Confirmed PR #298 merged the focused SeriesMatrix matmul xindex equality slice and explicitly did not close all #269 work."
+  - cmd: "rtk pytest -q tests/test_issue_burn_down_roadmap.py -p no:cacheprovider"
+    result: "Red before roadmap update: 0 passed, 1 failed."
+  - cmd: "rtk ruff check --fix tests/test_issue_burn_down_roadmap.py"
+    result: "Import/layout issue fixed; no issues remain."
+  - cmd: "rtk pytest -q tests/test_issue_burn_down_roadmap.py -p no:cacheprovider"
+    result: "Green after roadmap update: 1 passed."
+  - cmd: "rtk ruff format --check tests/test_issue_burn_down_roadmap.py"
+    result: "Already formatted."
+  - cmd: "rtk git diff --check"
+    result: "No whitespace errors."
+  - cmd: "rtk python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('docs/developers/plans/audit-manifest-269-xindex-tolerance-roadmap.yaml').read_text())\""
+    result: "Audit manifest parsed successfully."
+  - cmd: "rtk rg -n \"<local-absolute-path-patterns>\" <changed-files>"
+    result: "No local absolute paths in changed files."
+files_changed:
+  - path: docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
+    change: "Separates the merged #298 matmul invariant slice from the remaining #269 xindex tolerance policy decision."
+  - path: docs/developers/plans/audit-manifest-269-xindex-tolerance-roadmap.yaml
+    change: "Adds audit manifest for this docs/test-only roadmap correction."
+  - path: tests/test_issue_burn_down_roadmap.py
+    change: "Adds a lightweight guard that the #269 xindex tolerance residual remains explicitly classified."
+deferred:
+  - "Any exact-equality to fuzzy-tolerance runtime change."
+  - "Tolerance value, warning policy, and resampling/interpolation guidance for physics-facing xindex alignment."
+  - "Normative contract tests for tolerant xindex acceptance until physics review approves the policy."

--- a/tests/test_issue_burn_down_roadmap.py
+++ b/tests/test_issue_burn_down_roadmap.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
-ROADMAP = Path("docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md")
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ROADMAP = REPO_ROOT / "docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md"
 
 
 def test_seriesmatrix_xindex_tolerance_residual_is_classified() -> None:

--- a/tests/test_issue_burn_down_roadmap.py
+++ b/tests/test_issue_burn_down_roadmap.py
@@ -8,7 +8,9 @@ def test_seriesmatrix_xindex_tolerance_residual_is_classified() -> None:
     text = ROADMAP.read_text(encoding="utf-8")
     collapsed = " ".join(text.split())
 
-    assert "SeriesMatrix xindex tolerance residual" in text
-    assert "#269 remains open" in text
+    # These exact phrases are intentional roadmap drift guards: they preserve
+    # the residual #269 classification even if Markdown line wrapping changes.
+    assert "SeriesMatrix xindex tolerance residual" in collapsed
+    assert "#269 remains open" in collapsed
     assert "No runtime tolerance policy changes in this roadmap update" in collapsed
-    assert "physics review" in text
+    assert "physics review" in collapsed

--- a/tests/test_issue_burn_down_roadmap.py
+++ b/tests/test_issue_burn_down_roadmap.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+ROADMAP = Path("docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md")
+
+
+def test_seriesmatrix_xindex_tolerance_residual_is_classified() -> None:
+    text = ROADMAP.read_text(encoding="utf-8")
+    collapsed = " ".join(text.split())
+
+    assert "SeriesMatrix xindex tolerance residual" in text
+    assert "#269 remains open" in text
+    assert "No runtime tolerance policy changes in this roadmap update" in collapsed
+    assert "physics review" in text


### PR DESCRIPTION
Refs #269

## Summary

- Clarifies that PR #298 closed only the `SeriesMatrix.__matmul__` xindex invariant slice.
- Records the remaining #269 xindex jitter tolerance decision as an open, physics-review-boundary item.
- Adds a lightweight docs guard and audit manifest so the roadmap does not drift back to treating #269 as fully closed.

## Validation

- GitHub checks: 7/7 passed.
- Red first: `rtk pytest -q tests/test_issue_burn_down_roadmap.py -p no:cacheprovider` -> 0 passed, 1 failed before the roadmap update.
- Final: `rtk pytest -q tests/test_issue_burn_down_roadmap.py -p no:cacheprovider` -> 1 passed.
- `rtk ruff check tests/test_issue_burn_down_roadmap.py` -> clean.
- `rtk ruff format --check tests/test_issue_burn_down_roadmap.py` -> already formatted.
- Audit manifest YAML parsed successfully.
- `rtk git diff --check` and `rtk git diff --cached --check` -> clean.
- Path hygiene check over changed files -> no local absolute path matches.

## Scope

- Docs/test-only.
- No runtime tolerance policy, physics behavior, metadata behavior, units, or SeriesMatrix implementation changed.

## Deferred

- Exact-equality to fuzzy-tolerance runtime behavior.
- Tolerance value, warning policy, and resampling/interpolation guidance for physics-facing xindex alignment.
- Normative tolerant-xindex contract tests until physics review approves the policy.
