### PR TITLE
[AGENT:docs] Record Wave 2 Batch 2 completion

### DIFF
--- a/docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
+++ b/docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
@@ -211,8 +211,35 @@ Net outcome:
   implementation-only.
 - The WAV metadata contract now matches the existing warning-and-skip behavior
   when `tinytag` is missing.
-- Wave 2 still needs the remaining public-surface audits: #279, #280, #281,
-  #276, #290, and #287.
+- Wave 2 Batch 1 left #279, #280, #281, #276, #290, and #287 for the next
+  public-surface batch.
+
+#### Wave 2 Batch 2 Completion Report
+
+Status as of 2026-04-28: the second Wave 2 public-surface batch has been
+merged. All PR heads were clean and green in GitHub checks before merge.
+
+| Issue | PR | Merged | Merge commit | Result |
+| --- | --- | --- | --- | --- |
+| #281 | #317 `[AGENT:validation] Add detector proxy contract baseline` | 2026-04-28 15:14 JST | `b0443db` | Added docs/test-only detector package, channel proxy, and unit alias contract coverage. Runtime behavior unchanged. |
+| #279 | #318 `[AGENT:validation] Add time conversion contract baseline` | 2026-04-28 15:14 JST | `4572590` | Added docs/test-only GPS/UTC conversion, scalar/vector return-type, timezone-policy, and interop helper contract coverage. Runtime behavior unchanged. |
+| #280 | #319 `[AGENT:validation] Add CLI command contract baseline` | 2026-04-28 15:14 JST | `e10172b` | Added docs/test-only CLI placeholder, stdout/stderr, exit-code, version/help, and GWpy re-export boundary contract coverage. Runtime behavior unchanged. |
+| #290 | #320 `[AGENT:validation] Add histogram and segments contract baseline` | 2026-04-28 15:14 JST | `c5aa144` | Added docs/test-only `Histogram` and `gwexpy.segments` public contract coverage for units, bin geometry, metadata, statistics, rebinning, collections, and proxy boundaries. Runtime behavior unchanged. |
+| #276 | #321 `[AGENT:validation] Add SegmentTable contract baseline` | 2026-04-28 15:15 JST | `88dd783` | Added docs/test-only `SegmentTable`, `RowProxy`, `SegmentCell`, lazy payload/cache, copy/materialize, and structural plotting contract coverage. Runtime behavior unchanged. |
+| #287 | #325 `[AGENT:validation] Add field algebra contract baseline` | 2026-04-28 15:15 JST | `e3ac1e9` | Added a docs/test-only field-algebra baseline plus xfail-guarded coordinate/domain mismatch behavior. This intentionally did not close #287 because broader field data-model audit and physics-facing runtime guard decisions remain. |
+
+Net outcome:
+
+- #276, #279, #280, #281, and #290 are closed through merged PRs.
+- #287 remains open as an explicit field data-model residual. The merged
+  baseline records the current aligned-arithmetic behavior and defers runtime
+  coordinate/domain guards for human physics review.
+- #278 is not a Wave 2 blocker. PR #313 already merged a docs/test-only noise
+  baseline, but #278 remains a Wave 3 numerical/analysis residual because that
+  PR used `Refs #278` and the remaining PSD/ASD behavior decisions are
+  numerical/physics-facing.
+- Wave 2 public-surface work is complete for the issue set that can be closed
+  through docs/test-only audits without changing runtime field algebra.
 
 ### Wave 3: Numerical And Analysis Contracts
 

--- a/docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
+++ b/docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
@@ -241,6 +241,29 @@ Net outcome:
 - Wave 2 public-surface work is complete for the issue set that can be closed
   through docs/test-only audits without changing runtime field algebra.
 
+#### Behavior Decision Queue
+
+Status as of 2026-04-28: human review comments on PRs #314, #315, #316,
+#322, and #328 identify design decisions that should not block docs/test-only
+contract PRs. Resolve these before runtime behavior PRs, or before release if
+they become public-contract commitments.
+
+| Priority | Source PR | Owning Issue | Decision Area | Where To Decide | When To Decide | Review Required |
+| --- | --- | --- | --- | --- | --- | --- |
+| 1 | #328 | #291 / #287 | `Array4D` dimension-dropping return classes, `AxisApiMixin.sel(method=...)`, downstream smoke-test ordering | #291 follow-up design note cross-linked to #287 | Before low-level axis or `ScalarField` runtime hardening PRs | Human review; physics/data-model review if `ScalarField` semantics change |
+| 2 | #315 | #288 | `inverse_transform()` return type, `Inf` missing-data policy, `TimeSeriesMatrix.to_list()` flattening | #288 follow-up design note | Before preprocessing return-type or metadata behavior PRs | Human API/metadata review; statistical review for missing-data policy |
+| 3 | #314 | #284 | Bruco Welch DC/Nyquist scaling, `GWEXPY_BRUCO_BLOCK_BYTES` deterministic CI policy, correction priority | #284 follow-up design note | Before changing Bruco numerical behavior | Human physics/statistics review |
+| 4 | #322 | #283 / #274 | Dynamic unit labels, `FieldPlot` colorbar access, `PairPlot` mismatch policy | #283 follow-up for plot helpers, cross-link #274 for GUI/metadata | Before plot/runtime behavior PRs or GUI metadata work | Human UX/API review; physics review if labels imply unit semantics |
+| 5 | #316 | #282 | Astro pure re-export vs thin wrapper, optional `inspiral_range` CI, physical type/unit assertions | #282 follow-up design note | Before wrapper implementation or optional-deps CI expansion | Human physics/API review for wrapper behavior; CI review for optional deps |
+
+Operating rule:
+
+- Merge docs/test-only PRs when CI is green and review comments only identify
+  follow-up design decisions.
+- Do not mix the decisions above into the audit PRs.
+- Each runtime PR should cite the corresponding decision record and mark human
+  physics, statistics, API, or CI review where required.
+
 ### Wave 3: Numerical And Analysis Contracts
 
 **Issues:** #273 -> #285 / #286 -> #277 / #278 / #284 / #288 / #282

--- a/docs/developers/plans/audit-manifest-wave2-batch2-roadmap.yaml
+++ b/docs/developers/plans/audit-manifest-wave2-batch2-roadmap.yaml
@@ -14,6 +14,7 @@ scope:
   - "Record closed issue status for #276, #279, #280, #281, and #290."
   - "Classify #287 as an explicit field data-model residual after partial baseline PR #325."
   - "Classify #278 as a Wave 3 numerical/analysis residual after merged baseline PR #313."
+  - "Record the behavior decision queue from human review comments on PRs #314, #315, #316, #322, and #328."
   - "No runtime code, public API behavior, physics behavior, units, or metadata behavior changed."
 merge_verification:
   - issue: 281
@@ -54,6 +55,42 @@ residuals:
   - issue: 278
     classification: "Wave 3 numerical/analysis residual"
     reason: "PR #313 merged a noise baseline, but remaining PSD/ASD conventions and stochastic/optional-backend decisions belong to Wave 3."
+decision_queue:
+  - priority: 1
+    source_pr: 328
+    owning_issues: [291, 287]
+    decision_area: "Array4D dimension-dropping return classes, AxisApiMixin.sel(method=...), and downstream smoke-test ordering."
+    where_to_decide: "#291 follow-up design note cross-linked to #287."
+    when_to_decide: "Before low-level axis or ScalarField runtime hardening PRs."
+    review_required: "Human review; physics/data-model review if ScalarField semantics change."
+  - priority: 2
+    source_pr: 315
+    owning_issues: [288]
+    decision_area: "inverse_transform() return type, Inf missing-data policy, and TimeSeriesMatrix.to_list() flattening."
+    where_to_decide: "#288 follow-up design note."
+    when_to_decide: "Before preprocessing return-type or metadata behavior PRs."
+    review_required: "Human API/metadata review; statistical review for missing-data policy."
+  - priority: 3
+    source_pr: 314
+    owning_issues: [284]
+    decision_area: "Bruco Welch DC/Nyquist scaling, GWEXPY_BRUCO_BLOCK_BYTES deterministic CI policy, and correction priority."
+    where_to_decide: "#284 follow-up design note."
+    when_to_decide: "Before changing Bruco numerical behavior."
+    review_required: "Human physics/statistics review."
+  - priority: 4
+    source_pr: 322
+    owning_issues: [283, 274]
+    decision_area: "Dynamic unit labels, FieldPlot colorbar access, and PairPlot mismatch policy."
+    where_to_decide: "#283 follow-up for plot helpers, cross-link #274 for GUI/metadata."
+    when_to_decide: "Before plot/runtime behavior PRs or GUI metadata work."
+    review_required: "Human UX/API review; physics review if labels imply unit semantics."
+  - priority: 5
+    source_pr: 316
+    owning_issues: [282]
+    decision_area: "Astro pure re-export vs thin wrapper, optional inspiral_range CI, and physical type/unit assertions."
+    where_to_decide: "#282 follow-up design note."
+    when_to_decide: "Before wrapper implementation or optional-deps CI expansion."
+    review_required: "Human physics/API review for wrapper behavior; CI review for optional deps."
 commands:
   - cmd: "rtk gh pr view 317 --json number,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,headRefOid,baseRefName,headRefName,url"
     result: "Confirmed PR #317 was open, non-draft, CLEAN, and all check runs succeeded before merge."
@@ -81,11 +118,22 @@ commands:
     result: "Merged PR #325 without closing #287."
   - cmd: "GitHub connector get_issue for #276, #279, #280, #281, #287, #290, and #278"
     result: "Confirmed #276, #279, #280, #281, and #290 are closed; #287 and #278 remain open."
+  - cmd: "rtk gh pr view 314 --json number,reviews,comments,url"
+    result: "Confirmed human review comments identify follow-up decisions for Bruco scaling and deterministic CI policy."
+  - cmd: "rtk gh pr view 315 --json number,reviews,comments,url"
+    result: "Confirmed human review comments identify follow-up decisions for preprocessing return types, Inf policy, and matrix flattening."
+  - cmd: "rtk gh pr view 316 --json number,reviews,comments,url"
+    result: "Confirmed human review comments identify follow-up decisions for astro wrapper boundaries and optional-deps CI."
+  - cmd: "rtk gh pr view 322 --json number,reviews,comments,url"
+    result: "Confirmed human review comments identify follow-up decisions for plot labels, colorbar access, and mismatch policy."
+  - cmd: "rtk gh pr view 328 --json number,reviews,comments,url"
+    result: "Confirmed human review comments identify follow-up decisions for Array4D slicing and AxisApiMixin.sel behavior."
 files_changed:
   - path: docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
-    change: "Records Wave 2 Batch 2 completion, merged PRs, closed issues, and residual classification for #287 and #278."
+    change: "Records Wave 2 Batch 2 completion, merged PRs, closed issues, residual classification for #287 and #278, and the behavior decision queue from review comments."
   - path: docs/developers/plans/audit-manifest-wave2-batch2-roadmap.yaml
-    change: "Adds file-backed audit manifest for this roadmap-only status update."
+    change: "Adds file-backed audit manifest for this roadmap-only status update and the review-derived behavior decision queue."
 deferred:
   - "Close or split #287 after deciding the field data-model residual scope and human physics-review requirements."
   - "Continue #278 as a Wave 3 numerical/analysis residual or close it separately if maintainers accept PR #313 as sufficient."
+  - "Open or update follow-up design notes for the decision queue before runtime behavior PRs."

--- a/docs/developers/plans/audit-manifest-wave2-batch2-roadmap.yaml
+++ b/docs/developers/plans/audit-manifest-wave2-batch2-roadmap.yaml
@@ -1,0 +1,91 @@
+---
+agent: Codex
+skills:
+  - github
+  - using-git-worktrees
+  - doc-architect
+branch: codex/wave2-completion-roadmap
+records_wave: 2
+records_scope: "Wave 2 Batch 2 public-surface completion status."
+physics_review: not_required
+risk: docs_only
+scope:
+  - "Record merged Wave 2 Batch 2 public-surface PRs #317, #318, #319, #320, #321, and #325."
+  - "Record closed issue status for #276, #279, #280, #281, and #290."
+  - "Classify #287 as an explicit field data-model residual after partial baseline PR #325."
+  - "Classify #278 as a Wave 3 numerical/analysis residual after merged baseline PR #313."
+  - "No runtime code, public API behavior, physics behavior, units, or metadata behavior changed."
+merge_verification:
+  - issue: 281
+    pr: 317
+    merged_at: "2026-04-28T06:14:25Z"
+    merge_commit: b0443db17c038381d73e0c225792de9009d22bd8
+    status: closed
+  - issue: 279
+    pr: 318
+    merged_at: "2026-04-28T06:14:41Z"
+    merge_commit: 45725904e747724943ea7c1aedd1d4086750b1d9
+    status: closed
+  - issue: 280
+    pr: 319
+    merged_at: "2026-04-28T06:14:49Z"
+    merge_commit: e10172b5174e9090cb187f4e41b7a62c8dfdcd24
+    status: closed
+  - issue: 290
+    pr: 320
+    merged_at: "2026-04-28T06:14:56Z"
+    merge_commit: c5aa144c71332e7933ec8233a89518fbf15e8f53
+    status: closed
+  - issue: 276
+    pr: 321
+    merged_at: "2026-04-28T06:15:03Z"
+    merge_commit: 88dd7831fc2f9c792460ed03226dcda307d2569a
+    status: closed
+  - issue: 287
+    pr: 325
+    merged_at: "2026-04-28T06:15:19Z"
+    merge_commit: e3ac1e9e1fbcb5e411bc53fb852fa59126e99505
+    status: open
+    note: "PR #325 intentionally used Refs #287 and did not close the broader field data-model audit."
+residuals:
+  - issue: 287
+    classification: "Wave 2 field data-model residual"
+    reason: "Runtime coordinate/domain guard behavior affects physics-facing field algebra and needs human review before hardening."
+  - issue: 278
+    classification: "Wave 3 numerical/analysis residual"
+    reason: "PR #313 merged a noise baseline, but remaining PSD/ASD conventions and stochastic/optional-backend decisions belong to Wave 3."
+commands:
+  - cmd: "rtk gh pr view 317 --json number,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,headRefOid,baseRefName,headRefName,url"
+    result: "Confirmed PR #317 was open, non-draft, CLEAN, and all check runs succeeded before merge."
+  - cmd: "rtk gh pr view 318 --json number,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,headRefOid,baseRefName,headRefName,url"
+    result: "Confirmed PR #318 was open, non-draft, CLEAN, and all check runs succeeded before merge."
+  - cmd: "rtk gh pr view 319 --json number,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,headRefOid,baseRefName,headRefName,url"
+    result: "Confirmed PR #319 was open, non-draft, CLEAN, and all check runs succeeded before merge."
+  - cmd: "rtk gh pr view 320 --json number,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,headRefOid,baseRefName,headRefName,url"
+    result: "Confirmed PR #320 was open, non-draft, CLEAN, and all check runs succeeded before merge."
+  - cmd: "rtk gh pr view 321 --json number,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,headRefOid,baseRefName,headRefName,url"
+    result: "Confirmed PR #321 was open, non-draft, CLEAN, and all check runs succeeded before merge."
+  - cmd: "rtk gh pr view 325 --json number,state,isDraft,mergeStateStatus,reviewDecision,statusCheckRollup,headRefOid,baseRefName,headRefName,url"
+    result: "Confirmed PR #325 was open, non-draft, CLEAN, and all check runs succeeded before merge."
+  - cmd: "rtk gh pr merge 317 --squash --delete-branch --subject '[AGENT:validation] Add detector proxy contract baseline' --body 'Closes #281.'"
+    result: "Merged PR #317; remote merge succeeded, but local branch deletion failed because another worktree still used the branch."
+  - cmd: "rtk gh pr merge 318 --squash --subject '[AGENT:validation] Add time conversion contract baseline' --body 'Closes #279.'"
+    result: "Merged PR #318."
+  - cmd: "rtk gh pr merge 319 --squash --subject '[AGENT:validation] Add CLI command contract baseline' --body 'Closes #280.'"
+    result: "Merged PR #319."
+  - cmd: "rtk gh pr merge 320 --squash --subject '[AGENT:validation] Add histogram and segments contract baseline' --body 'Closes #290.'"
+    result: "Merged PR #320."
+  - cmd: "rtk gh pr merge 321 --squash --subject '[AGENT:validation] Add SegmentTable contract baseline' --body 'Closes #276.'"
+    result: "Merged PR #321."
+  - cmd: "rtk gh pr merge 325 --squash --subject '[AGENT:validation] Add field algebra contract baseline' --body 'Refs #287.'"
+    result: "Merged PR #325 without closing #287."
+  - cmd: "GitHub connector get_issue for #276, #279, #280, #281, #287, #290, and #278"
+    result: "Confirmed #276, #279, #280, #281, and #290 are closed; #287 and #278 remain open."
+files_changed:
+  - path: docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
+    change: "Records Wave 2 Batch 2 completion, merged PRs, closed issues, and residual classification for #287 and #278."
+  - path: docs/developers/plans/audit-manifest-wave2-batch2-roadmap.yaml
+    change: "Adds file-backed audit manifest for this roadmap-only status update."
+deferred:
+  - "Close or split #287 after deciding the field data-model residual scope and human physics-review requirements."
+  - "Continue #278 as a Wave 3 numerical/analysis residual or close it separately if maintainers accept PR #313 as sufficient."


### PR DESCRIPTION
## Summary

Records the Wave 2 Batch 2 public-surface completion after PRs #317, #318, #319, #320, #321, and #325 were merged.

- Adds a Wave 2 Batch 2 completion report to the burn-down roadmap.
- Records closure of #276, #279, #280, #281, and #290.
- Classifies #287 as the remaining field data-model residual after partial baseline PR #325.
- Classifies #278 as a Wave 3 numerical/analysis residual after merged baseline PR #313.
- Adds a file-backed audit manifest for this roadmap-only update.

## Validation

- `rtk python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('docs/developers/plans/audit-manifest-wave2-batch2-roadmap.yaml').read_text())"` -> passed
- `rtk git diff --check` -> clean
- `rtk git diff --cached --check` -> clean
- path/template hygiene check over changed docs -> no matches

## Scope

- Docs/audit-manifest only.
- No runtime code, public API behavior, physics behavior, units, metadata behavior, package metadata, or release artifacts changed.

## Deferred

- #287 remains open for field data-model residual decisions that affect physics-facing field algebra.
- #278 remains open as a Wave 3 numerical/analysis residual unless maintainers decide PR #313 is sufficient to close it.
