### PR TITLE
[AGENT:docs] Record Wave 4 and 5 merge progress

### DIFF
--- a/docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
+++ b/docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
@@ -352,6 +352,26 @@ the data and metadata contracts are clear.
 - GUI payload metadata gaps are baselined before any metadata-rich behavior is
   introduced.
 
+#### Wave 4 Progress Report
+
+Status as of 2026-04-28: the public-doc and plot-helper baseline slices have
+landed. The remaining Wave 4 work is runtime/design-facing GUI and plot metadata
+behavior.
+
+| Issue | PR | Merged | Merge commit | Result |
+| --- | --- | --- | --- | --- |
+| #283 | #322 `[AGENT:validation] Add plot helper contract baseline` | 2026-04-28 18:53 JST | `6bcc887` | Added docs/test-only plot-helper contracts for field plots, dashboards, pair plots, labels, colorbars, and optional plotting surfaces. Runtime behavior unchanged. |
+| #275 | #323 `[AGENT:docs] Guard public tutorial colorbar mappables` | 2026-04-28 19:57 JST | `0147000` | Replaced brittle public tutorial colorbar mappable lookups with explicit mappables, restored the GPS-aware spectrogram x-axis in the GBD tutorial, and added notebook drift guards. Runtime package behavior unchanged. |
+
+Net outcome:
+
+- #275 remains open for residual tutorial/public-doc drift work, including
+  deferred source-policy cleanup and any remaining notebook guard follow-ups.
+- #283 remains open for runtime/design decisions around dynamic scientific
+  labels, `PairPlot` mismatch policy, and stable `FieldPlot` colorbar exposure.
+- #274 remains open for GUI payload metadata, renderer labels, and colorbar
+  behavior that affects GUI-facing contracts.
+
 ### Wave 5: Release Readiness
 
 **Issues:** #293 -> #294
@@ -374,6 +394,28 @@ limitations are accepted.
 - Public docs accurately distinguish source install, PyPI install, and conda
   install states.
 - PyPI release is verified in a fresh environment before conda-forge onboarding.
+
+#### Wave 5 Progress Report
+
+Status as of 2026-04-28: release-gate hardening and the conda-forge onboarding
+roadmap have landed. No PyPI or conda-forge publication has been performed.
+
+| Issue | PR | Merged | Merge commit | Result |
+| --- | --- | --- | --- | --- |
+| #293 | #326 `[AGENT:release] Harden release metadata version parsing` | 2026-04-28 20:00 JST | `f8cff53` | Hardened the release metadata checker so malformed or unparseable top-level `CITATION.cff` version metadata fails closed. Release tooling only; runtime package behavior unchanged. |
+| #294 | #327 `[AGENT:release] Record conda-forge onboarding roadmap` | 2026-04-28 19:57 JST | `4bf66c0` | Added the conda-forge staged-recipes roadmap, corrected the v1 recipe model to use `build.entry_points`, deferred the optional GUI entry point from the first core recipe, and added noarch recipe test guidance. Docs/test-only. |
+
+Net outcome:
+
+- #293 remains open for the actual PyPI release workflow: build artifacts,
+  Trusted Publishing verification, release metadata final checks, and fresh
+  install smoke tests.
+- #294 remains open for the external `conda-forge/staged-recipes` submission
+  after a stable source release exists or maintainers explicitly approve a
+  source-archive-first submission.
+- The accepted release-gate policy is fail-closed: if `CITATION.cff` exists but
+  its top-level `version` cannot be parsed by the supported subset, the release
+  metadata check must fail rather than warn and continue.
 
 ## Parallel Work Lanes
 

--- a/docs/developers/plans/audit-manifest-wave4-wave5-roadmap.yaml
+++ b/docs/developers/plans/audit-manifest-wave4-wave5-roadmap.yaml
@@ -1,0 +1,82 @@
+---
+agent: Codex
+skills:
+  - doc-architect
+  - github
+  - using-git-worktrees
+branch: codex/update-roadmap-postmerge
+records_scope: "Wave 4 and Wave 5 roadmap status after PR #323, #326, and #327 merges."
+physics_review: not_required
+risk: docs_only
+scope:
+  - "Record merged Wave 4 public-doc PR #323 and prior plot-helper PR #322."
+  - "Record merged Wave 5 release-readiness PRs #326 and #327."
+  - "Keep #275, #283, #274, #293, and #294 open as residual work owners."
+  - "Record the accepted fail-closed release-gate policy for unparseable top-level CITATION.cff version metadata."
+  - "No runtime package behavior, physics behavior, units, or public analysis semantics changed."
+merge_verification:
+  - issue: 283
+    pr: 322
+    merged_at: "2026-04-28T09:53:36Z"
+    merge_commit: 6bcc887200616b91ef60a70c671d31899a574606
+    status: open
+    note: "Issue remains open for plot-helper runtime/design decisions."
+  - issue: 275
+    pr: 323
+    merged_at: "2026-04-28T10:57:01Z"
+    merge_commit: 0147000da63eb5df0cb0ae9ffd26ee1908110b62
+    status: open
+    note: "Issue remains open for residual tutorial/public-doc drift work."
+  - issue: 293
+    pr: 326
+    merged_at: "2026-04-28T11:00:55Z"
+    merge_commit: f8cff53809550cc34d033f0452566829a40320b0
+    status: open
+    note: "Issue remains open for actual PyPI release workflow and final release verification."
+  - issue: 294
+    pr: 327
+    merged_at: "2026-04-28T10:57:13Z"
+    merge_commit: 4bf66c0021e6219db9d89a7e3042663b39052666
+    status: open
+    note: "Issue remains open for external conda-forge staged-recipes submission."
+residuals:
+  - issue: 274
+    classification: "Wave 4 GUI payload metadata residual"
+    reason: "GUI payload metadata, renderer labels, and colorbar behavior still require dedicated contract/runtime decisions."
+  - issue: 275
+    classification: "Wave 4 tutorial/public-doc drift residual"
+    reason: "PR #323 added colorbar and GPS-axis guards, but the issue still owns broader public-doc source-policy cleanup and follow-ups."
+  - issue: 283
+    classification: "Wave 4 plot-helper runtime/design residual"
+    reason: "PR #322 added baseline coverage, while dynamic labels, PairPlot mismatch policy, and FieldPlot colorbar exposure remain design decisions."
+  - issue: 293
+    classification: "Wave 5 PyPI release residual"
+    reason: "PR #326 hardened release metadata parsing but did not build, publish, or verify release artifacts."
+  - issue: 294
+    classification: "Wave 5 conda-forge onboarding residual"
+    reason: "PR #327 recorded the roadmap but did not open staged-recipes or create a feedstock."
+commands:
+  - cmd: "rtk git fetch origin main"
+    result: "Fetched latest main after PR #323, #326, and #327 merges."
+  - cmd: "rtk git worktree add <scratch-worktree> -b codex/update-roadmap-postmerge origin/main"
+    result: "Created isolated roadmap update worktree from latest main."
+  - cmd: "rtk gh issue view 275 --json number,state,title,url"
+    result: "Confirmed #275 is open."
+  - cmd: "rtk gh issue view 283 --json number,state,title,url"
+    result: "Confirmed #283 is open."
+  - cmd: "rtk gh issue view 274 --json number,state,title,url"
+    result: "Confirmed #274 is open."
+  - cmd: "rtk gh issue view 293 --json number,state,title,url"
+    result: "Confirmed #293 is open."
+  - cmd: "rtk gh issue view 294 --json number,state,title,url"
+    result: "Confirmed #294 is open."
+files_changed:
+  - path: docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
+    change: "Adds Wave 4 and Wave 5 progress reports with merge commits, issue states, residuals, and release-gate policy."
+  - path: docs/developers/plans/audit-manifest-wave4-wave5-roadmap.yaml
+    change: "Adds file-backed audit manifest for this roadmap-only status update."
+deferred:
+  - "Continue #275 for public-doc drift cleanup and tutorial source-policy work."
+  - "Continue #283 and #274 for plot-helper and GUI metadata runtime/design decisions."
+  - "Continue #293 for actual PyPI release build, publish, and smoke verification."
+  - "Continue #294 for external conda-forge staged-recipes and feedstock onboarding."


### PR DESCRIPTION
## Summary
- record Wave 4 progress for merged plot-helper and public tutorial drift guard PRs
- record Wave 5 progress for merged release metadata and conda-forge roadmap PRs
- keep #275, #283, #274, #293, and #294 open as residual work owners
- add a roadmap audit manifest for this docs-only status update

## Validation
- rtk python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('docs/developers/plans/audit-manifest-wave4-wave5-roadmap.yaml').read_text())"
- rtk git diff --check
- rtk git diff --cached --check
- rtk rg -n "(/home/washimi|/tmp/gwexpy-roadmap-postmerge|TODO|TBD|Pending)" docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md docs/developers/plans/audit-manifest-wave4-wave5-roadmap.yaml

Refs #275, #283, #274, #293, #294.