### PR TITLE
[AGENT:validation] Harden field algebra contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 
 - **fields**: `VectorField` and `TensorField` now support initialization directly from NumPy ndarrays (5D for VectorField, 6D for TensorField), automatically creating the component `ScalarField`s without breaking backward-compatible dictionary initialization.
 
+### Changed
+
+- **fields**: `ScalarField` binary arithmetic now fails fast with `ValueError` when operands have mismatched time/frequency domains, spatial domains, or coordinate grids. Align fields explicitly before arithmetic; future regridding/interpolation APIs will track explicit grid-alignment workflows.
+
 ### Documentation
 
 - **docs**: Unified the Class Index into five major categories (Core, Field, Signal, Analysis, Utilities) with standardized Japanese translations (e.g., "時系列行列" for `TimeSeriesMatrix`).

--- a/docs/developers/plans/audit-manifest-287-field-algebra-hardening.yaml
+++ b/docs/developers/plans/audit-manifest-287-field-algebra-hardening.yaml
@@ -1,0 +1,88 @@
+---
+# Audit manifest for #287 Field algebra hardening
+# Date: 2026-04-28
+
+skill:
+  - validation
+issue:
+  - 287
+scope: runtime field algebra hardening
+agent_model: Codex session default
+
+commands_executed:
+  - cmd: "rtk gh issue view 287 --repo tatsuki-washimi/gwexpy --comments --json number,title,state,updatedAt,comments,url"
+    result: "Confirmed #287 remains open and reviewed the silent field algebra failure reports."
+  - cmd: "rtk python reproduce_287.py"
+    result: "Confirmed local draft rejects time/frequency domain mismatch and spatial grid mismatch."
+  - cmd: "rtk pytest tests/fields/test_field_algebra_contracts.py -q"
+    result: "RED observed before implementation refinement: GPS-axis jitter was accepted and equivalent coordinate units were rejected."
+  - cmd: "rtk pytest tests/fields/test_field_algebra_contracts.py -q"
+    result: "Passed after axis comparison hardening."
+  - cmd: "rtk pytest tests/fields/test_scalarfield_collections.py tests/fields/test_vectorfield.py tests/fields/test_tensorfield.py tests/fields/test_scalarfield_domain.py tests/fields/test_field_algebra_contracts.py -q"
+    result: "86 passed."
+  - cmd: "rtk pytest tests/fields -q"
+    result: "288 passed."
+  - cmd: "rtk ruff check gwexpy/ tests/"
+    result: "No issues found."
+  - cmd: "rtk ruff check gwexpy/fields/base.py gwexpy/fields/collections.py tests/fields/test_field_algebra_contracts.py"
+    result: "No issues found."
+  - cmd: "rtk ruff format --check gwexpy/fields/base.py gwexpy/fields/collections.py tests/fields/test_field_algebra_contracts.py"
+    result: "Passed after formatting."
+  - cmd: "rtk mypy gwexpy/"
+    result: "No issues found."
+  - cmd: "rtk mypy gwexpy/fields/base.py gwexpy/fields/collections.py"
+    result: "No issues found."
+  - cmd: "rtk pytest tests/ -q"
+    result: "Attempted full one-process test suite; exited 139 around 21% with no actionable Python traceback."
+  - cmd: "rtk pytest tests/analysis tests/astro tests/cli tests/compatibility tests/data tests/detector tests/docs -q"
+    result: "523 passed."
+  - cmd: "rtk pytest tests/e2e tests/fields tests/fitting tests/frequencyseries tests/general -q"
+    result: "770 passed."
+  - cmd: "rtk pytest tests/gui tests/histogram tests/interop tests/io tests/nds tests/noise -q"
+    result: "1435 passed."
+  - cmd: "rtk proxy pytest tests/numerics tests/plot tests/scripts tests/segments tests/signal tests/spectral -q -x"
+    result: "912 passed, 5 skipped, 1 xfailed."
+  - cmd: "rtk proxy pytest tests/spectrogram tests/statistics tests/table tests/time tests/timeseries tests/types tests/utils -q"
+    result: "2439 passed, 183 skipped, 5 xfailed."
+  - cmd: "rtk python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('docs/developers/plans/audit-manifest-287-field-algebra-hardening.yaml').read_text())\""
+    result: "Audit manifest YAML parsed successfully."
+  - cmd: "rtk git diff --check"
+    result: "Clean."
+
+verify_physics: required_before_merge
+
+test_results:
+  field_algebra_contracts: passed
+  focused_field_related_tests: passed
+  all_field_tests: passed
+  split_test_suite:
+    passed: 6079
+    skipped: 188
+    xfailed: 6
+  ruff_check_changed_files: passed
+  ruff_format_changed_files: passed
+  mypy_changed_modules: passed
+  full_ruff_check: passed
+  full_mypy: passed
+  full_pytest: attempted_exit_139_without_traceback
+
+files_changed:
+  - path: gwexpy/fields/base.py
+    change: "Adds FieldBase binary ufunc validation for axis0 domain, spatial domain, and all coordinate axes; compares equivalent axis units in a common unit with absolute-only tolerance."
+  - path: gwexpy/fields/collections.py
+    change: "Reuses the shared field-axis coordinate comparison helper for FieldList and FieldDict validation."
+  - path: tests/fields/test_field_algebra_contracts.py
+    change: "Adds regression coverage for aligned field arithmetic, domain mismatch, spatial domain mismatch, coordinate mismatch, large GPS-axis jitter, and equivalent coordinate-unit acceptance."
+  - path: docs/developers/plans/2026-04-27-issue-burn-down-roadmap.md
+    change: "Records the local #287 field algebra hardening draft and keeps #287 release-blocking until reviewed and merged."
+  - path: docs/developers/plans/audit-manifest-287-field-algebra-hardening.yaml
+    change: "Records scope, validation commands, and review requirements for #287 hardening."
+
+release_gate_classification:
+  issue: 287
+  classification: release-blocking_until_reviewed_pr_merge
+  rationale: "The silent algebra failure is runtime physics-facing behavior. The local draft mitigates it, but release gating should only clear after maintainer physics/data-model review and PR merge."
+
+known_residuals:
+  - "ScalarField slicing / Array4D integer slicing policy remains a separate data-model decision in #287."
+  - "Explicit regridding/interpolation APIs are not implemented by this hardening pass; mismatched grids now fail fast and require a future explicit alignment API."

--- a/gwexpy/fields/base.py
+++ b/gwexpy/fields/base.py
@@ -1,4 +1,5 @@
 """Base class for field objects with domain-aware axis metadata."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -9,6 +10,36 @@ from astropy import units as u
 from ..types.array4d import Array4D
 
 __all__ = ["FieldBase"]
+
+# Tolerance for axis coordinate comparison.  Keep relative tolerance disabled:
+# large absolute coordinates such as GPS seconds must not allow order-second
+# jitter through relative scaling.
+_AXIS_RTOL = 0.0
+_AXIS_ATOL = 1e-12
+
+
+def _axis_coordinates_close(left, right) -> bool:
+    """Return True when two coordinate axes describe the same physical grid."""
+    if left.shape != right.shape:
+        return False
+
+    left_unit = getattr(left, "unit", u.dimensionless_unscaled)
+    right_unit = getattr(right, "unit", u.dimensionless_unscaled)
+    if not right_unit.is_equivalent(left_unit):
+        return False
+
+    left_values = (
+        left.to_value(left_unit) if hasattr(left, "to_value") else np.asarray(left)
+    )
+    right_values = (
+        right.to_value(left_unit) if hasattr(right, "to_value") else np.asarray(right)
+    )
+    return np.allclose(
+        np.asarray(left_values),
+        np.asarray(right_values),
+        rtol=_AXIS_RTOL,
+        atol=_AXIS_ATOL,
+    )
 
 
 class FieldBase(Array4D):
@@ -137,6 +168,43 @@ class FieldBase(Array4D):
             self._axis0_offset = getattr(obj, "_axis0_offset", None)
 
         self._validate_domain_units()
+
+    def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        """Validate domain and coordinate consistency before arithmetic."""
+        # Identify FieldBase objects among inputs
+        fields = [x for x in inputs if isinstance(x, FieldBase)]
+
+        if len(fields) > 1:
+            first = fields[0]
+            for other in fields[1:]:
+                # 1. Check axis0 domain (Time vs Frequency)
+                if first._axis0_domain != other._axis0_domain:
+                    raise ValueError(
+                        f"Field domain mismatch: {first._axis0_domain} vs "
+                        f"{other._axis0_domain}. Perform domain transform "
+                        "(e.g., fft_time) before operation."
+                    )
+
+                # 2. Check spatial domains (Real vs K-space)
+                if first._space_domains != other._space_domains:
+                    raise ValueError(
+                        "Field spatial domain mismatch: "
+                        f"{first._space_domains} vs {other._space_domains}."
+                    )
+
+                # 3. Check coordinates (All 4 axes must align)
+                for i in range(4):
+                    idx1 = getattr(first, f"_axis{i}_index")
+                    idx2 = getattr(other, f"_axis{i}_index")
+                    if not _axis_coordinates_close(idx1, idx2):
+                        name = first.axis_names[i]
+                        raise ValueError(
+                            f"Field coordinate mismatch on axis {i} ('{name}'). "
+                            "Regrid operands to a common grid before operation."
+                        )
+
+        # Defer to superclass (Array4D -> Array -> GwpyArray)
+        return super().__array_ufunc__(ufunc, method, *inputs, **kwargs)
 
     @property
     def axis0_domain(self):

--- a/gwexpy/fields/collections.py
+++ b/gwexpy/fields/collections.py
@@ -1,16 +1,14 @@
 """Collections for ScalarField objects in the `gwexpy.fields` namespace."""
+
 from __future__ import annotations
 
 import numpy as np
 from astropy import units as u
 
+from .base import _axis_coordinates_close
 from .scalar import ScalarField
 
 __all__ = ["FieldList", "FieldDict"]
-
-# Tolerance for axis coordinate comparison
-_AXIS_RTOL = 1e-9
-_AXIS_ATOL = 1e-12
 
 
 class FieldList(list):
@@ -103,21 +101,7 @@ class FieldList(list):
                         f"Item {i}: Axis {ax_idx} shape mismatch. "
                         f"Expected {ref_ax.shape}, got {item_ax.shape}"
                     )
-                ref_axis_unit = getattr(ref_ax, "unit", u.dimensionless_unscaled)
-                item_axis_unit = getattr(item_ax, "unit", u.dimensionless_unscaled)
-                if ref_axis_unit != item_axis_unit:
-                    raise ValueError(
-                        f"Item {i}: Axis {ax_idx} unit mismatch. "
-                        f"Expected {ref_axis_unit}, got {item_axis_unit}"
-                    )
-                ref_val = getattr(ref_ax, "value", ref_ax)
-                item_val = getattr(item_ax, "value", item_ax)
-                if not np.allclose(
-                    np.asarray(ref_val),
-                    np.asarray(item_val),
-                    rtol=_AXIS_RTOL,
-                    atol=_AXIS_ATOL,
-                ):
+                if not _axis_coordinates_close(ref_ax, item_ax):
                     raise ValueError(
                         f"Item {i}: Axis {ax_idx} coordinate mismatch. "
                         f"Axis values differ beyond tolerance."
@@ -280,21 +264,7 @@ class FieldDict(dict):
                         f"Key '{key}': Axis {ax_idx} shape mismatch. "
                         f"Expected {ref_ax.shape}, got {item_ax.shape}"
                     )
-                ref_axis_unit = getattr(ref_ax, "unit", u.dimensionless_unscaled)
-                item_axis_unit = getattr(item_ax, "unit", u.dimensionless_unscaled)
-                if ref_axis_unit != item_axis_unit:
-                    raise ValueError(
-                        f"Key '{key}': Axis {ax_idx} unit mismatch. "
-                        f"Expected {ref_axis_unit}, got {item_axis_unit}"
-                    )
-                ref_val = getattr(ref_ax, "value", ref_ax)
-                item_val = getattr(item_ax, "value", item_ax)
-                if not np.allclose(
-                    np.asarray(ref_val),
-                    np.asarray(item_val),
-                    rtol=_AXIS_RTOL,
-                    atol=_AXIS_ATOL,
-                ):
+                if not _axis_coordinates_close(ref_ax, item_ax):
                     raise ValueError(
                         f"Key '{key}': Axis {ax_idx} coordinate mismatch. "
                         f"Axis values differ beyond tolerance."

--- a/tests/fields/test_field_algebra_contracts.py
+++ b/tests/fields/test_field_algebra_contracts.py
@@ -1,97 +1,95 @@
-"""Contract baseline for ScalarField binary algebra metadata alignment."""
+"""Contract tests for physics-facing ScalarField algebra."""
 
 from __future__ import annotations
 
 import numpy as np
 import pytest
 from astropy import units as u
-from numpy.testing import assert_allclose
 
 from gwexpy.fields import ScalarField
 
 
-def _make_scalar_field(
+def _field(
     *,
-    value: float = 1.0,
-    unit=u.V,
+    data_value: float = 1.0,
     axis0=None,
     axis1=None,
-    axis2=None,
-    axis3=None,
-    axis_names=("t", "x", "y", "z"),
     axis0_domain: str = "time",
+    space_domain: str | dict[str, str] = "real",
+    unit=u.V,
 ) -> ScalarField:
-    shape = (2, 2, 2, 2)
-    axis0 = np.arange(shape[0]) * u.s if axis0 is None else axis0
-    axis1 = np.arange(shape[1]) * u.m if axis1 is None else axis1
-    axis2 = np.arange(shape[2]) * u.m if axis2 is None else axis2
-    axis3 = np.arange(shape[3]) * u.m if axis3 is None else axis3
+    shape = (4, 3, 2, 2)
+    if axis0 is None:
+        axis0 = np.arange(shape[0]) * u.s
+    if axis1 is None:
+        axis1 = np.arange(shape[1]) * u.m
     return ScalarField(
-        np.full(shape, value, dtype=float),
+        np.full(shape, data_value),
         unit=unit,
         axis0=axis0,
         axis1=axis1,
-        axis2=axis2,
-        axis3=axis3,
-        axis_names=axis_names,
+        axis2=np.arange(shape[2]) * u.m,
+        axis3=np.arange(shape[3]) * u.m,
+        axis_names=["t", "x", "y", "z"],
         axis0_domain=axis0_domain,
-        space_domain="real",
+        space_domain=space_domain,
     )
 
 
-def _assert_axis_matches(result: ScalarField, expected: ScalarField, name: str) -> None:
-    result_axis = result.axis(name).index
-    expected_axis = expected.axis(name).index
-    assert result_axis.unit == expected_axis.unit
-    assert_allclose(result_axis.value, expected_axis.value)
-
-
-def test_scalarfield_add_aligned_grid_preserves_metadata_and_values():
-    left = _make_scalar_field(value=1.0, unit=u.V)
-    right = _make_scalar_field(value=2.0, unit=u.mV)
+def test_scalarfield_addition_preserves_left_grid_for_aligned_fields():
+    left = _field(data_value=1.0)
+    right = _field(data_value=2.0)
 
     result = left + right
 
     assert isinstance(result, ScalarField)
-    assert result.axis0_domain == "time"
-    assert result.space_domains == {"x": "real", "y": "real", "z": "real"}
     assert result.unit == u.V
-    for axis_name in ("t", "x", "y", "z"):
-        _assert_axis_matches(result, left, axis_name)
-    assert_allclose(result.value, np.full(left.shape, 1.002))
+    assert result.axis0_domain == "time"
+    np.testing.assert_allclose(result.value, 3.0)
+    np.testing.assert_allclose(result._axis1_index.to_value(u.m), [0.0, 1.0, 2.0])
 
 
-def test_scalarfield_add_rejects_same_shape_x_coordinate_mismatch():
-    left = _make_scalar_field(value=1.0)
-    right = _make_scalar_field(value=2.0, axis1=np.array([10.0, 11.0]) * u.m)
+def test_scalarfield_addition_rejects_axis0_domain_mismatch():
+    left = _field(axis0_domain="time", axis0=np.arange(4) * u.s)
+    right = _field(axis0_domain="frequency", axis0=np.arange(4) * u.Hz)
 
-    try:
+    with pytest.raises(ValueError, match="Field domain mismatch"):
         left + right
-    except ValueError as exc:
-        assert "axis" in str(exc).lower() or "coordinate" in str(exc).lower()
-    else:
-        pytest.xfail(
-            "Issue #287: ScalarField binary arithmetic should reject same-shape "
-            "spatial coordinate grid mismatches before inheriting array arithmetic."
-        )
 
 
-def test_scalarfield_add_rejects_same_shape_axis0_domain_mismatch():
-    time_field = _make_scalar_field(value=1.0, unit=u.V)
-    frequency_field = _make_scalar_field(
-        value=2.0,
-        unit=u.V,
-        axis0=np.arange(2) * u.Hz,
-        axis_names=("f", "x", "y", "z"),
-        axis0_domain="frequency",
+def test_scalarfield_addition_rejects_spatial_domain_mismatch():
+    left = _field(space_domain={"x": "real", "y": "real", "z": "real"})
+    right = _field(
+        axis1=np.arange(3) / u.m,
+        space_domain={"x": "k", "y": "real", "z": "real"},
     )
 
-    try:
-        time_field + frequency_field
-    except ValueError as exc:
-        assert "axis" in str(exc).lower() or "domain" in str(exc).lower()
-    else:
-        pytest.xfail(
-            "Issue #287: ScalarField binary arithmetic should reject same-shape "
-            "axis0 domain mismatches even when data units permit arithmetic."
-        )
+    with pytest.raises(ValueError, match="Field spatial domain mismatch"):
+        left + right
+
+
+def test_scalarfield_addition_rejects_misaligned_spatial_coordinates():
+    left = _field(axis1=np.arange(3) * u.m)
+    right = _field(axis1=np.array([0.0, 1.5, 3.0]) * u.m)
+
+    with pytest.raises(ValueError, match="Field coordinate mismatch on axis 1"):
+        left + right
+
+
+def test_scalarfield_addition_rejects_large_gps_axis_jitter():
+    gps_start = 1_000_000_000.0
+    left = _field(axis0=(gps_start + np.arange(4)) * u.s)
+    right = _field(axis0=(gps_start + np.arange(4) + 0.5) * u.s)
+
+    with pytest.raises(ValueError, match="Field coordinate mismatch on axis 0"):
+        left + right
+
+
+def test_scalarfield_addition_accepts_equivalent_coordinate_units():
+    left = _field(axis1=np.array([0.0, 1.0, 2.0]) * u.m)
+    right = _field(axis1=np.array([0.0, 100.0, 200.0]) * u.cm)
+
+    result = left + right
+
+    assert isinstance(result, ScalarField)
+    np.testing.assert_allclose(result.value, 2.0)


### PR DESCRIPTION
## Summary

- Add `FieldBase.__array_ufunc__` validation so binary field arithmetic fails fast when field operands have mismatched `axis0_domain`, spatial domains, or coordinate grids.
- Compare axis coordinates after converting equivalent units into the left operand unit, with `rtol=0.0` and `atol=1e-12` to avoid GPS-scale relative tolerance masking order-second jitter.
- Reuse the same coordinate comparison helper in `FieldList` and `FieldDict` validation.
- Extend #287 regression coverage for aligned arithmetic, domain mismatch, spatial domain mismatch, grid mismatch, GPS-axis jitter, and equivalent coordinate units.
- Add an audit manifest recording validation and the required physics/data-model review.

## Release Gate Impact

This is the focused hardening PR for #287. The change is runtime and physics-facing, so #287 should remain release-blocking until this PR receives human physics/data-model review and is merged.

Known residuals remain outside this PR: explicit regridding/interpolation APIs and the broader ScalarField/Array4D slicing policy decision.

## Validation

- `rtk pytest tests/fields/test_field_algebra_contracts.py tests/fields/test_scalarfield_collections.py tests/fields/test_vectorfield.py tests/fields/test_tensorfield.py tests/fields/test_scalarfield_domain.py -q` -> 86 passed
- `rtk pytest tests/fields -q` -> 288 passed
- `rtk ruff check gwexpy/fields/base.py gwexpy/fields/collections.py tests/fields/test_field_algebra_contracts.py` -> passed
- `rtk ruff format --check gwexpy/fields/base.py gwexpy/fields/collections.py tests/fields/test_field_algebra_contracts.py` -> passed
- `rtk mypy gwexpy/fields/base.py gwexpy/fields/collections.py` -> passed
- Earlier broader local validation also passed `rtk ruff check gwexpy/ tests/` and `rtk mypy gwexpy/`.
- Full one-process `rtk pytest tests/ -q` was attempted earlier and exited 139 without an actionable Python traceback; split test-suite runs passed and are recorded in the audit manifest.

Refs #287
