### PR TITLE
[AGENT:validation] Close preprocessing contract residuals

### DIFF
--- a/docs/developers/plans/archive/contract-audits/2026-04-28-wave3-preprocessing-pipeline-contract-audit.md
+++ b/docs/developers/plans/archive/contract-audits/2026-04-28-wave3-preprocessing-pipeline-contract-audit.md
@@ -34,6 +34,12 @@ PCA/ICA runtime paths.
 - `Pipeline([("standardize", StandardizeTransform())])` round-trips values and
   preserves `t0`, `dt`, `unit`, and `name` for the covered regular
   `TimeSeries` case.
+- `Pipeline.inverse_transform()` defaults to strict mode. If a step such as
+  `ImputeTransform` does not advertise inverse support, strict inverse raises
+  `ValueError` with a "does not support inverse_transform" message.
+- `StandardizeTransform.inverse_transform()` raises `TypeError` for an
+  incompatible plain ndarray after fitting on a `TimeSeries`; this slice records
+  the current unsupported-input error surface without changing accepted inputs.
 
 ### Imputation
 
@@ -52,6 +58,12 @@ PCA/ICA runtime paths.
   in row-major order into a `TimeSeriesList`.
 - Flattened elements preserve per-element value arrays, names, `t0`, `dt`, and
   units for the covered `(2, 2, 4)` matrix.
+- In the covered multivariate `StandardizeTransform` path, fitting and
+  transforming a `TimeSeriesList` currently returns a `TimeSeriesMatrix`, while
+  inverse-transforming that matrix restores a flat `TimeSeriesList` through
+  `to_list()` semantics. Values, names, `t0`, and `dt` round-trip in this path,
+  but restored list elements are currently dimensionless rather than preserving
+  the original physical unit.
 - This test is intentionally separate from collection-restoration runtime
   changes. Follow-up work should decide whether row/column structure should be
   preserved or whether flat list semantics are the intended public contract.
@@ -68,6 +80,13 @@ PCA/ICA runtime paths.
 - `channel_labels`, `preprocessing`, and `input_meta` are currently passive
   stored metadata; this slice does not assert mutation, validation, or metadata
   propagation through transform/inverse-transform paths.
+- `pca_inverse_transform()` and `ica_inverse_transform()` use
+  `input_meta["original_shape"]` to restore the reconstructed matrix shape when
+  the reconstructed feature count matches that shape. The returned matrix takes
+  `t0` and `dt` from the scores/sources input object, not from `input_meta`.
+- PCA/ICA inverse reconstruction applies stored `channel_labels` to the returned
+  matrix when labels are present. The covered ICA inverse case records passive
+  result metadata and the non-prewhitened reconstruction path only.
 
 ## Stable Versus Experimental Surfaces
 
@@ -101,6 +120,8 @@ These are intentionally not included in this docs/test-only slice:
   Hurst helpers.
 - Change `TimeSeriesMatrix.to_list()` flattening, collection restoration, or
   row/column metadata preservation.
+- Change multivariate pipeline collection restoration to preserve original list
+  units on inverse output.
 - Change whitening epsilon validation or numerical regularization thresholds.
 - Change PCA/ICA inverse shape fallback behavior, optional dependency errors,
   reproducibility knobs, or metadata propagation.
@@ -158,7 +179,7 @@ rtk ruff format --check tests/timeseries/test_preprocessing_pipeline_contracts.p
 rtk python - <<'PY'
 import yaml
 from pathlib import Path
-yaml.safe_load(Path("docs/developers/plans/audit-manifest-288-preprocessing-contracts.yaml").read_text())
+yaml.safe_load(Path("docs/developers/plans/manifests/audit-manifest-288-preprocessing-contracts.yaml").read_text())
 PY
 rtk git diff --check
 ```

--- a/docs/developers/plans/manifests/audit-manifest-288-preprocessing-contracts.yaml
+++ b/docs/developers/plans/manifests/audit-manifest-288-preprocessing-contracts.yaml
@@ -8,7 +8,7 @@ skill:
   - test-driven-development
   - verification-before-completion
 issue: 288
-branch: codex/wave3-288-preprocessing-contracts
+branch: codex/288-preprocessing-contract-closure
 agent_role: Implementation worker
 agent_model: Codex session default
 
@@ -20,7 +20,7 @@ commands_executed:
   - cmd: "rtk cat .agent/skills_index.md"
     result: "Confirmed this checkout has a skills index rather than individual .agent skill directories."
   - cmd: "rtk git status --short --branch"
-    result: "Confirmed worktree branch codex/wave3-288-preprocessing-contracts."
+    result: "Confirmed worktree branch codex/288-preprocessing-contract-closure."
   - cmd: "rtk rg --files docs/developers/plans"
     result: "Reviewed available Wave 3 audit plan and manifest examples."
   - cmd: "rtk sed -n '1,260p' gwexpy/timeseries/preprocess.py"
@@ -43,12 +43,26 @@ commands_executed:
     result: "Reviewed existing standardization and whitening metadata/unit tests."
   - cmd: "rtk sed -n '1,560p' tests/signal/test_imputation.py"
     result: "Reviewed low-level signal imputation policy and optional pandas fallback tests."
+  - cmd: "rtk pytest -q tests/timeseries/test_preprocessing_pipeline_contracts.py"
+    result: "Pre-change local baseline: 6 passed."
+  - cmd: "rtk pytest -q tests/timeseries/test_preprocessing_pipeline_contracts.py"
+    result: "After adding second-slice characterization tests: 9 passed, 1 failed; adjusted multivariate TimeSeriesList restoration assertions to match current Matrix-forward/List-inverse behavior."
+  - cmd: "rtk python -c \"...\""
+    result: "Probed multivariate StandardizeTransform TimeSeriesList fit_transform and inverse_transform return types: forward returned TimeSeriesMatrix, inverse returned TimeSeriesList."
+  - cmd: "rtk pytest -q tests/timeseries/test_preprocessing_pipeline_contracts.py"
+    result: "After updating forward-return assertion: 9 passed, 1 failed; unit assertion showed inverse-restored TimeSeriesList elements are dimensionless in current behavior."
+  - cmd: "rtk pytest -q tests/timeseries/test_preprocessing_pipeline_contracts.py"
+    result: "10 passed after baselining dimensionless inverse-restored list units."
   - cmd: "rtk env XDG_CACHE_HOME=/tmp MPLCONFIGDIR=/tmp/matplotlib pytest -q tests/timeseries/test_preprocessing_pipeline_contracts.py"
     result: "Initial run: 1 failed, 5 passed; adjusted matrix unit assertion to per-element unit contract."
   - cmd: "rtk env XDG_CACHE_HOME=/tmp MPLCONFIGDIR=/tmp/matplotlib pytest -q tests/timeseries/test_preprocessing_pipeline_contracts.py"
     result: "6 passed, 1 warning from GWpy TimeSeries xindex/x0 construction."
   - cmd: "rtk env XDG_CACHE_HOME=/tmp MPLCONFIGDIR=/tmp/matplotlib pytest -q tests/timeseries/test_preprocessing_pipeline_contracts.py tests/timeseries/test_preprocess_impute.py tests/timeseries/test_preprocess_standardize_whiten.py tests/timeseries/test_pipeline.py tests/timeseries/test_decomposition.py tests/signal/test_imputation.py tests/signal/test_preprocessing.py"
     result: "313 passed, 1 skipped, 10 warnings from current GWpy xindex/x0 construction and all-NaN mean imputation behavior."
+  - cmd: "rtk env XDG_CACHE_HOME=/tmp MPLCONFIGDIR=/tmp/matplotlib pytest -q tests/timeseries/test_preprocessing_pipeline_contracts.py"
+    result: "10 passed, 2 warnings from current GWpy xindex/x0 construction."
+  - cmd: "rtk env XDG_CACHE_HOME=/tmp MPLCONFIGDIR=/tmp/matplotlib pytest -q tests/timeseries/test_preprocessing_pipeline_contracts.py tests/timeseries/test_preprocess_impute.py tests/timeseries/test_preprocess_standardize_whiten.py tests/timeseries/test_pipeline.py tests/timeseries/test_decomposition.py tests/signal/test_imputation.py tests/signal/test_preprocessing.py"
+    result: "317 passed, 1 skipped, 11 warnings from current GWpy xindex/x0 construction and all-NaN mean imputation behavior."
   - cmd: "rtk ruff check tests/timeseries/test_preprocessing_pipeline_contracts.py"
     result: "No issues found."
   - cmd: "rtk ruff format --check tests/timeseries/test_preprocessing_pipeline_contracts.py"
@@ -64,8 +78,8 @@ verify_physics: not_required_for_this_pr
   # decomposition, forecasting, or Hurst behavior.
 
 test_results:
-  new_test_file: "6 passed, 1 warning"
-  focused_existing_pytest: "313 passed, 1 skipped, 10 warnings"
+  new_test_file: "10 passed, 2 warnings"
+  focused_existing_pytest: "317 passed, 1 skipped, 11 warnings"
   ruff_changed_tests: clean
   ruff_format_changed_tests: clean
   yaml_parse: clean
@@ -76,10 +90,10 @@ test_results:
 
 files_changed:
   - path: tests/timeseries/test_preprocessing_pipeline_contracts.py
-    change: "Added deterministic preprocessing, pipeline, matrix to_list, and PCAResult metadata contract tests."
-  - path: docs/developers/plans/2026-04-28-wave3-preprocessing-pipeline-contract-audit.md
-    change: "Documented #288 first-slice contracts, stable versus experimental surfaces, deferred behavior changes, and verification plan."
-  - path: docs/developers/plans/audit-manifest-288-preprocessing-contracts.yaml
+    change: "Added deterministic preprocessing, pipeline, unsupported input, matrix to_list/list-restoration, PCAResult, ICAResult, and inverse reconstruction metadata contract tests."
+  - path: docs/developers/plans/archive/contract-audits/2026-04-28-wave3-preprocessing-pipeline-contract-audit.md
+    change: "Documented #288 first and second-slice contracts, stable versus experimental surfaces, deferred behavior changes, and verification plan."
+  - path: docs/developers/plans/manifests/audit-manifest-288-preprocessing-contracts.yaml
     change: "Recorded audit commands, verification status, files changed, and deferred follow-ups."
 
 contracts_covered:
@@ -88,14 +102,20 @@ contracts_covered:
   - "impute_timeseries treats NaN as missing but leaves Inf as observed data in the covered forward-fill path."
   - "Quantity max_gap values are converted to the TimeSeries time-axis unit before gap filtering."
   - "Pipeline plus StandardizeTransform restores values, t0, dt, unit, and name in the covered regular TimeSeries path."
+  - "Pipeline.inverse_transform defaults to strict mode and raises ValueError for non-invertible steps such as ImputeTransform."
+  - "StandardizeTransform.inverse_transform raises TypeError for incompatible ndarray input after fitting on TimeSeries."
   - "TimeSeriesMatrix.to_list flattens a multi-row, multi-column matrix in row-major order with per-element metadata."
+  - "Multivariate StandardizeTransform over TimeSeriesList currently returns TimeSeriesMatrix on forward transform and restores a flat TimeSeriesList on inverse; values, names, t0, and dt round-trip, while restored list units are dimensionless."
   - "PCAResult aliases and summary_dict expose passive wrapped-model and metadata contracts without requiring sklearn."
+  - "PCA inverse reconstruction uses input_meta original_shape when feature counts match, applies channel_labels, and takes t0/dt from the scores object."
+  - "ICAResult stores passive metadata; non-prewhitened ICA inverse reconstruction uses input_meta original_shape when feature counts match, applies channel_labels, and takes t0/dt from the sources object."
 
 deferred_follow_ups:
   - "Decide whether standardization inverse helpers should return metadata-bearing TimeSeries objects or plain arrays."
   - "Clarify StandardizeTransform transformed-unit semantics and whether dimensionless output is required."
   - "Define non-finite input policy across imputation, standardization, whitening, PCA, ICA, ARIMA, and Hurst helpers."
   - "Audit Pipeline unsupported input errors, fit/transform ordering, inverse ordering, and collection restoration semantics."
+  - "Decide whether multivariate TimeSeriesList pipeline inverse output should restore original physical units."
   - "Audit whitening epsilon validation, PCA/ZCA shapes, covariance finite-ness, and metadata propagation."
   - "Audit PCA/ICA optional dependency behavior, reproducibility knobs, inverse shape fallback, and channel metadata."
   - "Audit ARIMA/SARIMAX optional dependencies, forecast intervals, GPS/TAI time assumptions, and output metadata."

--- a/tests/timeseries/test_preprocessing_pipeline_contracts.py
+++ b/tests/timeseries/test_preprocessing_pipeline_contracts.py
@@ -6,8 +6,13 @@ from astropy import units as u
 
 from gwexpy.timeseries import TimeSeries, TimeSeriesMatrix
 from gwexpy.timeseries.collections import TimeSeriesList
-from gwexpy.timeseries.decomposition import PCAResult
-from gwexpy.timeseries.pipeline import Pipeline, StandardizeTransform
+from gwexpy.timeseries.decomposition import (
+    ICAResult,
+    PCAResult,
+    ica_inverse_transform,
+    pca_inverse_transform,
+)
+from gwexpy.timeseries.pipeline import ImputeTransform, Pipeline, StandardizeTransform
 from gwexpy.timeseries.preprocess import impute_timeseries, standardize_timeseries
 
 
@@ -86,6 +91,20 @@ def test_pipeline_standardize_inverse_restores_values_and_time_metadata():
     assert restored.name == ts.name
 
 
+def test_pipeline_inverse_strict_error_and_standardize_unsupported_input_contract():
+    ts = TimeSeries([1.0, np.nan, 3.0], t0=0.0 * u.s, dt=1.0 * u.s)
+
+    unsupported_inverse = Pipeline([("impute", ImputeTransform(method="ffill"))])
+    transformed = unsupported_inverse.fit_transform(ts)
+
+    with pytest.raises(ValueError, match="does not support inverse_transform"):
+        unsupported_inverse.inverse_transform(transformed)
+
+    standardize = StandardizeTransform().fit(ts)
+    with pytest.raises(TypeError, match="Incompatible input"):
+        standardize.inverse_transform(np.asarray(transformed.value))
+
+
 def test_multicolumn_matrix_to_list_flattens_in_row_major_order():
     names = ["r0c0", "r0c1", "r1c0", "r1c1"]
     data = np.arange(16.0).reshape(2, 2, 4)
@@ -108,6 +127,35 @@ def test_multicolumn_matrix_to_list_flattens_in_row_major_order():
         assert series.t0 == matrix.t0
         assert series.dt == matrix.dt
         assert series.unit == u.m
+
+
+def test_multivariate_standardize_list_inverse_uses_flat_to_list_restoration():
+    series_list = TimeSeriesList()
+    for index, values in enumerate(([1.0, 2.0, 3.0], [2.0, 4.0, 6.0])):
+        series_list.append(
+            TimeSeries(
+                values,
+                t0=5.0 * u.s,
+                dt=0.5 * u.s,
+                unit=u.m,
+                name=f"witness-{index}",
+            )
+        )
+
+    transform = StandardizeTransform(multivariate=True)
+    transformed = transform.fit_transform(series_list)
+    restored = transform.inverse_transform(transformed)
+
+    assert isinstance(transformed, TimeSeriesMatrix)
+    assert transformed.shape == (2, 1, 3)
+    assert transformed.channel_names == ["witness-0", "witness-1"]
+    assert isinstance(restored, TimeSeriesList)
+    assert [series.name for series in restored] == ["witness-0", "witness-1"]
+    for restored_series, original_series in zip(restored, series_list, strict=True):
+        np.testing.assert_allclose(restored_series.value, original_series.value)
+        assert restored_series.t0 == original_series.t0
+        assert restored_series.dt == original_series.dt
+        assert restored_series.unit == u.dimensionless_unscaled
 
 
 def test_pca_result_summary_and_metadata_are_passive_contracts():
@@ -137,3 +185,73 @@ def test_pca_result_summary_and_metadata_are_passive_contracts():
     assert result.channel_labels == ["a", "b"]
     assert result.preprocessing is preprocessing
     assert result.input_meta is input_meta
+
+
+def test_pca_inverse_reconstructs_shape_from_input_meta_but_time_from_scores(
+    monkeypatch,
+):
+    class FakePCA:
+        def inverse_transform(self, scores):
+            return np.arange(scores.shape[0] * 4.0).reshape(scores.shape[0], 4)
+
+    import gwexpy.timeseries.decomposition as decomposition
+
+    monkeypatch.setattr(decomposition, "_check_sklearn", lambda name="sklearn": None)
+    scores = TimeSeriesMatrix(
+        np.ones((2, 1, 3)),
+        t0=20.0 * u.s,
+        dt=0.25 * u.s,
+    )
+    result = PCAResult(
+        sklearn_model=FakePCA(),
+        channel_labels=["r0c0", "r0c1", "r1c0", "r1c1"],
+        preprocessing={"center": False, "scale": None},
+        input_meta={
+            "t0": 5.0 * u.s,
+            "dt": 1.0 * u.s,
+            "original_shape": (2, 2, 3),
+        },
+    )
+
+    reconstructed = pca_inverse_transform(result, scores)
+
+    assert isinstance(reconstructed, TimeSeriesMatrix)
+    assert reconstructed.shape == (2, 2, 3)
+    assert reconstructed.t0 == scores.t0
+    assert reconstructed.dt == scores.dt
+    assert reconstructed.channel_names == result.channel_labels
+
+
+def test_ica_result_metadata_and_inverse_reconstruction_contract(monkeypatch):
+    class FakeICA:
+        def inverse_transform(self, sources):
+            return np.arange(sources.shape[0] * 2.0).reshape(sources.shape[0], 2)
+
+    import gwexpy.timeseries.decomposition as decomposition
+
+    monkeypatch.setattr(decomposition, "_check_sklearn", lambda name="sklearn": None)
+    sources = TimeSeriesMatrix(
+        np.ones((2, 1, 3)),
+        t0=30.0 * u.s,
+        dt=0.5 * u.s,
+    )
+    result = ICAResult(
+        sklearn_model=FakeICA(),
+        channel_labels=["mix-a", "mix-b"],
+        preprocessing={"center": False, "scale": None, "prewhiten": False},
+        input_meta={
+            "t0": 7.0 * u.s,
+            "dt": 2.0 * u.s,
+            "original_shape": (2, 1, 3),
+        },
+    )
+
+    reconstructed = ica_inverse_transform(result, sources)
+
+    assert result.channel_labels == ["mix-a", "mix-b"]
+    assert result.preprocessing["prewhiten"] is False
+    assert isinstance(reconstructed, TimeSeriesMatrix)
+    assert reconstructed.shape == (2, 1, 3)
+    assert reconstructed.t0 == sources.t0
+    assert reconstructed.dt == sources.dt
+    assert reconstructed.channel_names == result.channel_labels


### PR DESCRIPTION
## Summary
- Add #288 contract coverage for strict pipeline inverse errors and unsupported `StandardizeTransform.inverse_transform()` inputs.
- Baseline current non-finite and matrix/list behavior: `Inf` remains observed data, `TimeSeriesMatrix.to_list()` flattens row-major, and multivariate list standardization restores a flat `TimeSeriesList` with dimensionless units.
- Add PCA/ICA inverse reconstruction contract coverage and update the #288 audit note and manifest.

## Validation
- `rtk env XDG_CACHE_HOME=/tmp MPLCONFIGDIR=/tmp/matplotlib pytest -q tests/timeseries/test_preprocessing_pipeline_contracts.py tests/timeseries/test_preprocess_impute.py tests/timeseries/test_preprocess_standardize_whiten.py tests/timeseries/test_pipeline.py tests/timeseries/test_decomposition.py tests/signal/test_imputation.py tests/signal/test_preprocessing.py -p no:cacheprovider` -> 317 passed, 1 skipped, 11 warnings.
- `rtk ruff check tests/timeseries/test_preprocessing_pipeline_contracts.py` -> no issues.
- `rtk ruff format --check tests/timeseries/test_preprocessing_pipeline_contracts.py` -> already formatted.
- YAML manifest parse -> passed.
- `rtk git diff --check` -> clean.

## Review notes
- Runtime behavior unchanged.
- Statistical/API follow-ups remain for global non-finite policy, multivariate inverse unit restoration, and PCA/ICA fallback semantics.

Refs #288
