### PR TITLE
[AGENT:docs] Guard public tutorial drift before release

### DIFF
--- a/docs/developers/plans/archive/contract-audits/2026-04-28-wave3-preprocessing-pipeline-contract-audit.md
+++ b/docs/developers/plans/archive/contract-audits/2026-04-28-wave3-preprocessing-pipeline-contract-audit.md
@@ -3,6 +3,7 @@
 Date: 2026-04-28
 Issue: #288, "Audit preprocessing pipeline decomposition and forecasting contracts"
 Mode: audit-first; docs and regression tests only.
+First-release follow-up owner: #346 (preprocessing runtime/statistical policy decisions).
 
 ## Scope For This Slice
 

--- a/docs/developers/plans/manifests/audit-manifest-275-public-doc-drift.yaml
+++ b/docs/developers/plans/manifests/audit-manifest-275-public-doc-drift.yaml
@@ -179,3 +179,36 @@ deferred_follow_ups:
 human_review:
   physics_review_required: false
   rationale: "Docs/notebook/test-only changes; no runtime or physics behavior changes."
+
+follow_up_2026_04_29:
+  branch: codex/release-preflight-293-testpypi
+  scope:
+    classification: docs_test_only
+    runtime_code_changed: false
+    notebook_execution: false
+    physics_behavior_changed: false
+    summary: >
+      Added pre-release drift guards for public tutorial internal links and
+      known stale HHT/colorbar code snippets. The guards cover public tutorial
+      notebooks and Markdown tutorial pages without editing notebook outputs.
+  commands_executed:
+    - cmd: "rtk pytest tests/docs/test_tutorial_notebook_quality.py -q"
+      result: "49 passed after adding the scoped drift guards."
+    - cmd: "rtk pytest tests/plot/test_plot_helper_contracts.py tests/timeseries/test_preprocessing_pipeline_contracts.py tests/docs/test_tutorial_notebook_quality.py -q"
+      result: "74 passed in the combined pre-release focused suite after narrowing PR #350 to the latest main branch."
+    - cmd: "rtk ruff check tests/docs/test_tutorial_notebook_quality.py tests/timeseries/test_preprocessing_pipeline_contracts.py"
+      result: "No issues found."
+    - cmd: "rtk git diff --check"
+      result: "Clean."
+  files_changed:
+    - path: tests/docs/test_tutorial_notebook_quality.py
+      change: >
+        Added public tutorial guards for internal docs links and stale
+        HHT/colorbar snippets across tutorial notebooks and Markdown tutorial
+        pages.
+  contracts_covered:
+    - "Public tutorial markdown must not link to docs/developers/, docs_internal/, or API_MAPPING.md."
+    - "Public tutorial notebooks and Markdown pages must not use known stale HHT/colorbar snippets such as plt.gca().get_images(), plt.gca().collections[-1], plt.gca().get_children(), hasattr(c, 'get_clim'), or spec = data.hht(...)."
+  deferred_follow_ups:
+    - "Do not enforce a repo-wide positional plt.colorbar ban in this slice; broader cleanup would require separate content churn."
+    - "Clarify the public EN/JA tutorial notebook source policy before closing #275, or record it as a known limitation."

--- a/tests/docs/test_tutorial_notebook_quality.py
+++ b/tests/docs/test_tutorial_notebook_quality.py
@@ -17,6 +17,18 @@ FORBIDDEN_OUTPUT_PATTERNS = [
     re.compile(r"\bDeprecationWarning\b"),
     re.compile(r"\bConvergenceWarning\b"),
 ]
+FORBIDDEN_PUBLIC_DOC_LINK_PATTERNS = [
+    re.compile(r"docs/developers/"),
+    re.compile(r"docs_internal/"),
+    re.compile(r"API_MAPPING\.md"),
+]
+STALE_TUTORIAL_CODE_SNIPPETS = [
+    "plt.gca().get_images()",
+    "plt.gca().collections[-1]",
+    "plt.gca().get_children()",
+    "hasattr(c, 'get_clim')",
+    "spec = data.hht(",
+]
 
 
 def _read_notebook(path: Path) -> dict:
@@ -35,6 +47,14 @@ def _localized_tutorial_path(relative_path: Path) -> Path:
 
 def _read_tutorial_notebook(relative_path: Path) -> dict:
     return _read_notebook(_localized_tutorial_path(relative_path))
+
+
+def _public_tutorial_notebooks() -> list[Path]:
+    return sorted(TUTORIAL_ROOT.glob("*/user_guide/tutorials/*.ipynb"))
+
+
+def _public_tutorial_markdown_files() -> list[Path]:
+    return sorted(TUTORIAL_ROOT.glob("*/user_guide/tutorials/*.md"))
 
 
 def _notebook_locale(relative_path: Path) -> str:
@@ -332,6 +352,68 @@ def test_tutorial_outputs_do_not_expose_local_paths_or_raw_warnings():
                 break
 
     assert not offenders, "Forbidden notebook output found:\n" + "\n".join(offenders)
+
+
+def test_public_tutorial_markdown_does_not_link_internal_docs_surfaces():
+    offenders: list[str] = []
+
+    for path in _public_tutorial_notebooks():
+        nb = _read_notebook(path)
+        for markdown in _markdown_texts(nb):
+            hit = next(
+                (
+                    pattern.pattern
+                    for pattern in FORBIDDEN_PUBLIC_DOC_LINK_PATTERNS
+                    if pattern.search(markdown)
+                ),
+                None,
+            )
+            if hit:
+                offenders.append(f"{path.relative_to(ROOT)} -> {hit}")
+                break
+
+    for path in _public_tutorial_markdown_files():
+        markdown = path.read_text()
+        hit = next(
+            (
+                pattern.pattern
+                for pattern in FORBIDDEN_PUBLIC_DOC_LINK_PATTERNS
+                if pattern.search(markdown)
+            ),
+            None,
+        )
+        if hit:
+            offenders.append(f"{path.relative_to(ROOT)} -> {hit}")
+
+    assert not offenders, "Forbidden internal-doc link found:\n" + "\n".join(offenders)
+
+
+def test_public_tutorial_code_does_not_use_known_stale_hht_or_colorbar_patterns():
+    offenders: list[str] = []
+
+    for path in _public_tutorial_notebooks():
+        joined = _code_text(_read_notebook(path))
+        hit = next(
+            (snippet for snippet in STALE_TUTORIAL_CODE_SNIPPETS if snippet in joined),
+            None,
+        )
+        if hit:
+            offenders.append(f"{path.relative_to(ROOT)} -> {hit}")
+
+    for path in _public_tutorial_markdown_files():
+        markdown = path.read_text()
+        hit = next(
+            (
+                snippet
+                for snippet in STALE_TUTORIAL_CODE_SNIPPETS
+                if snippet in markdown
+            ),
+            None,
+        )
+        if hit:
+            offenders.append(f"{path.relative_to(ROOT)} -> {hit}")
+
+    assert not offenders, "Stale tutorial pattern found:\n" + "\n".join(offenders)
 
 
 @pytest.mark.parametrize(

--- a/tests/timeseries/test_preprocessing_pipeline_contracts.py
+++ b/tests/timeseries/test_preprocessing_pipeline_contracts.py
@@ -1,3 +1,5 @@
+"""First-release preprocessing pipeline contract baselines (#346)."""
+
 from __future__ import annotations
 
 import numpy as np


### PR DESCRIPTION
## Summary
- narrow PR #350 onto the latest main branch so it no longer includes prior release-hygiene commits
- add scoped public tutorial guards for internal docs links and stale HHT/colorbar snippets
- record the #275 follow-up verification in the public-doc drift audit manifest
- add a small #346 follow-up-owner note/docstring for the already-merged preprocessing contract baseline

## Scope
This PR is docs/tests only. Plot-helper and preprocessing runtime hardening already exist on main through earlier merged work; this PR keeps only the remaining #275 drift guard and small #346 documentation linkage. It does not add GUI app support or expand the GUI runtime surface.

## Files Changed
- tests/docs/test_tutorial_notebook_quality.py
- docs/developers/plans/manifests/audit-manifest-275-public-doc-drift.yaml
- tests/timeseries/test_preprocessing_pipeline_contracts.py
- docs/developers/plans/archive/contract-audits/2026-04-28-wave3-preprocessing-pipeline-contract-audit.md

## Verification
- rtk pytest tests/docs/test_tutorial_notebook_quality.py -q -> 49 passed
- rtk pytest tests/timeseries/test_preprocessing_pipeline_contracts.py -q -> 10 passed
- rtk pytest tests/plot/test_plot_helper_contracts.py -q -> 15 passed
- rtk pytest tests/plot/test_plot_helper_contracts.py tests/timeseries/test_preprocessing_pipeline_contracts.py tests/docs/test_tutorial_notebook_quality.py -q -> 74 passed
- rtk ruff check tests/docs/test_tutorial_notebook_quality.py tests/timeseries/test_preprocessing_pipeline_contracts.py -> clean
- YAML parse for audit-manifest-275-public-doc-drift.yaml -> clean
- rtk git diff --check -> clean

Part of #275. Cross-links the already-merged #346 preprocessing baseline.