### PR TITLE
[AGENT:release] Exclude GUI and sample data from first PyPI artifacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Packaging & Optional Dependencies (issue #251)
 
 - **packaging**: Added `netcdf4` extra (`netCDF4`, `xarray`) and `zarr` extra (`zarr`) to `pyproject.toml`; both are now included in the `all` convenience extra.
-- **packaging**: Removed the experimental `gwexpy.gui` console script from the first PyPI supported surface; GUI dependencies remain source/development-only and outside `gwexpy[all]`.
+- **packaging**: Removed the experimental `gwexpy.gui` package, console script, and `gui` extra from the first PyPI distribution; GUI work remains source/development-only until the post-release stabilization track is complete.
+- **packaging**: Tightened first-release artifact hygiene by excluding top-level tests, docs sample data, and package-internal Sphinx helper shims from built distributions.
 - **packaging**: Removed hand-edited tail from `requirements-dev.txt`; `analysis` extras are now managed exclusively through `pyproject.toml`.
 - **interop**: Fixed `_optional.py` `_EXTRA_MAP` — phantom extras (`interop`, `bio`, `stats`, `eda`) replaced with `None` entries that fall back to bare `pip install <package>`; `netCDF4`/`xarray` now point to `netcdf4` extra; `zarr` points to `zarr` extra.
 - **io**: `ensure_dependency()` error hint corrected to `pip install 'gwexpy[<extra>]'` instead of `pip install <pkg>[<extra>]`.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,9 +1,12 @@
 include CHANGELOG.md
 include LICENSE.txt
 include README.md
-recursive-include docs/_static/samples *.csv *.h5 *.txt
 include pyproject.toml
+prune docs/_static/samples
+prune gwexpy/gui
+prune gwexpy/utils/sphinx
 prune gwexpy/*/tests
+prune tests
 recursive-exclude gwexpy *.md
 prune .agent
 prune .harness

--- a/docs/developers/plans/active/2026-04-27-issue-burn-down-roadmap.md
+++ b/docs/developers/plans/active/2026-04-27-issue-burn-down-roadmap.md
@@ -454,8 +454,9 @@ Net outcome:
   corrections are reviewed and accepted.
 - #274 is explicitly deferred as a post-release GUI stabilization track. The
   first PyPI package supports the Python library surface, not the experimental
-  GUI app; `gwexpy.gui` is not installed as a console script for the first PyPI
-  release.
+  GUI app; `gwexpy.gui` is not included in first-release artifacts, no
+  `gwexpy.gui` console script is installed, and no `gui` PyPI extra is
+  published for the first PyPI release.
 - #294 remains open for the external `conda-forge/staged-recipes` submission
   after a stable source release exists or maintainers explicitly approve a
   source-archive-first submission.
@@ -567,8 +568,8 @@ Before closing #293, decide for every remaining audit issue whether it is:
 Current classification:
 
 - #274 is a **post-release follow-up**. The first PyPI release excludes the
-  experimental GUI app from the supported public surface and does not expose a
-  `gwexpy.gui` console script.
+  experimental GUI app from the supported public surface, built artifacts, and
+  PyPI extras metadata.
 
 Conda-forge onboarding (#294) should start after a stable PyPI/source release
 unless maintainers intentionally choose a source-archive-first conda submission.

--- a/docs/developers/plans/active/2026-04-28-conda-forge-roadmap.md
+++ b/docs/developers/plans/active/2026-04-28-conda-forge-roadmap.md
@@ -128,8 +128,8 @@ feedstock will exercise. In the current roadmap draft, that means `3.11.*` and
 extension modules, revisit the platform model before submitting.
 
 The initial recipe should keep only the core `gwexpy` console script in
-`build.entry_points`. The first PyPI package does not expose `gwexpy.gui` as a
-console script because the GUI app is a post-release stabilization track. If the
+`build.entry_points`. The first PyPI package does not ship `gwexpy.gui` or a
+`gui` extra because the GUI app is a post-release stabilization track. If the
 GUI is added later, keep it in a separate output or add the GUI dependencies
 explicitly.
 

--- a/docs/developers/plans/manifests/audit-manifest-274-gui-pypi-deferral.yaml
+++ b/docs/developers/plans/manifests/audit-manifest-274-gui-pypi-deferral.yaml
@@ -24,6 +24,8 @@ decision:
     library release can proceed without treating #274 as release-blocking.
   policy:
     - "Do not install a gwexpy.gui console script in the first PyPI release."
+    - "Do not ship the gwexpy.gui Python package in first PyPI release artifacts."
+    - "Do not publish a gui extra in first PyPI release metadata."
     - "Keep GUI dependencies outside gwexpy[all]."
     - "Track GUI payload metadata and renderer work as post-release #274 stabilization."
 
@@ -63,13 +65,13 @@ commands_executed:
 
 files_changed:
   - path: pyproject.toml
-    change: "Removed the gwexpy.gui console script and documented GUI dependencies as source/development-only, outside the first PyPI supported surface."
+    change: "Removed the gwexpy.gui console script, excluded gwexpy.gui package discovery, and removed the gui extra from first-release metadata."
   - path: CHANGELOG.md
     change: "Recorded the user-visible packaging decision in Unreleased."
   - path: docs/web/en/user_guide/installation.md
-    change: "Marked the GUI extra as source/development-only and outside first PyPI support; clarified gwexpy[all] excludes GUI."
+    change: "Removed the GUI extra from first-release install guidance; clarified gwexpy[all] excludes GUI."
   - path: docs/web/ja/user_guide/installation.md
-    change: "Marked the GUI extra as source/development-only and outside first PyPI support; clarified gwexpy[all] excludes GUI."
+    change: "Removed the GUI extra from first-release install guidance; clarified gwexpy[all] excludes GUI."
   - path: docs/web/en/user_guide/gui.md
     change: "Removed console-script launch instructions and documented the GUI as post-release/source-development track."
   - path: docs/web/ja/user_guide/gui.md
@@ -100,5 +102,5 @@ test_results:
   docs_build: not_run_sphinx_unavailable
 
 risks:
-  - "The gwexpy.gui Python package is still present in built artifacts for source compatibility, but the GUI app is not exposed as a first-release console script or supported PyPI surface."
+  - "Source checkout GUI workflows now require manually installing PyQt5, pyqtgraph, qtpy, and sounddevice until GUI packaging is redesigned for a later release."
   - "Full docs build should be rerun in CI or a docs-enabled environment."

--- a/docs/web/en/reference/api/gui.rst
+++ b/docs/web/en/reference/api/gui.rst
@@ -4,17 +4,17 @@ Graphical User Interface
 **Stability:** Experimental
 
 .. warning::
-   The GWexpy GUI (``gwexpy.gui``) is **experimental** and not part of the first
-   PyPI supported surface. It requires the ``.[gui]`` optional dependency
-   (PyQt5, pyqtgraph) for source/development use. The API may change without
-   notice.
+   The GWexpy GUI (``gwexpy.gui``) is **experimental** and is not included in
+   the first PyPI distribution. For source/development use, install the GUI
+   dependencies (PyQt5, pyqtgraph, qtpy, sounddevice) explicitly. The API may
+   change without notice.
 
-To launch the GUI after installing the optional dependency from a source checkout
-or development install:
+To launch the GUI after installing the dependencies from a source checkout or
+development install:
 
 .. code-block:: bash
 
-   pip install "gwexpy[gui] @ git+https://github.com/tatsuki-washimi/gwexpy.git"
+   pip install PyQt5 pyqtgraph qtpy sounddevice
    python -m gwexpy.gui
 
 .. currentmodule:: gwexpy.gui

--- a/docs/web/en/user_guide/gui.md
+++ b/docs/web/en/user_guide/gui.md
@@ -2,18 +2,21 @@
 
 ## Overview
 
-**Status:** Experimental, source/development track
+**Status:** Experimental, source/development track only
 
-GWexpy includes a **PyQt5-based GUI** for interactive data exploration and visualization. However, the GUI should currently be treated as an **experimental, prototype-stage interface**, not as a finalized end-user product. For reproducible and fully supported workflows, the **Python API** remains the primary interface.
+The GWexpy source tree includes a **PyQt5-based GUI** for interactive data exploration and visualization. However, the GUI should currently be treated as an **experimental, prototype-stage interface**, not as a finalized end-user product. For reproducible and fully supported workflows, the **Python API** remains the primary interface.
 
-The GUI app is **not part of the first PyPI supported surface**. The first PyPI release focuses on the Python library API; GUI stabilization is tracked separately as post-release work.
+The GUI app and `gwexpy.gui` package are **not included in the first PyPI distribution**. The first PyPI release focuses on the Python library API; GUI stabilization is tracked separately as post-release work.
 
 ## Installation
 
-For source checkout or development use, install the GUI dependencies with the `gui` extra:
+For source checkout or development use, install GWexpy from a local clone and install the GUI dependencies explicitly:
 
 ```bash
-pip install "gwexpy[gui] @ git+https://github.com/tatsuki-washimi/gwexpy.git"
+git clone https://github.com/tatsuki-washimi/gwexpy.git
+cd gwexpy
+pip install -e .
+pip install PyQt5 pyqtgraph qtpy sounddevice
 ```
 
 This installs additional dependencies:
@@ -23,14 +26,13 @@ This installs additional dependencies:
 
 ## Launching the GUI
 
-After installing the GUI extra from a source checkout or development install, launch
-the module directly:
+After installing the GUI dependencies from a source checkout or development install, launch the module directly:
 
 ```bash
 python -m gwexpy.gui
 ```
 
-The first PyPI release does not install a `gwexpy.gui` console script.
+The first PyPI release does not install a `gwexpy.gui` console script or ship the `gwexpy.gui` package.
 
 ### Programmatically
 
@@ -88,10 +90,10 @@ Open files via:
 
 ### "ModuleNotFoundError: No module named 'PyQt5'"
 
-Ensure that the GUI extra was installed:
+Ensure that the GUI dependencies were installed in a source checkout or development environment:
 
 ```bash
-pip install "gwexpy[gui] @ git+https://github.com/tatsuki-washimi/gwexpy.git"
+pip install PyQt5 pyqtgraph qtpy sounddevice
 ```
 
 ### GUI does not launch

--- a/docs/web/en/user_guide/installation.md
+++ b/docs/web/en/user_guide/installation.md
@@ -119,7 +119,6 @@ pip install -e ".[dev,all]"
 | `audio` | `pydub`, `tinytag` | Audio export, processing, and optional metadata extraction. |
 | `seismic` | `obspy`, `mth5`, `mtpy` | Seismic and magnetotelluric data. |
 | `control` | `control` (python-control) | Control systems and transfer functions. |
-| `gui` | `PyQt5`, `pyqtgraph` | Experimental GUI dependencies for source/development use. The GUI app is not part of the first PyPI supported surface and is not included in `all`. |
 
 ---
 

--- a/docs/web/ja/reference/api/gui.rst
+++ b/docs/web/ja/reference/api/gui.rst
@@ -4,16 +4,16 @@
 **安定性:** Experimental
 
 .. warning::
-   GWexpy GUI（``gwexpy.gui``）は **試験実装段階** であり、初回 PyPI の
-   サポート対象には含めません。ソース / 開発環境で動作させる場合は
-   ``.[gui]`` オプション依存関係（PyQt5, pyqtgraph）が必要です。
-   API は予告なく変更される可能性があります。
+   GWexpy GUI（``gwexpy.gui``）は **試験実装段階** であり、初回 PyPI
+   配布物には含めません。ソース / 開発環境で動作させる場合は GUI
+   依存関係（PyQt5, pyqtgraph, qtpy, sounddevice）を明示的に
+   インストールしてください。API は予告なく変更される可能性があります。
 
 ソース checkout または開発インストールでオプション依存関係を入れた後の起動方法：
 
 .. code-block:: bash
 
-   pip install "gwexpy[gui] @ git+https://github.com/tatsuki-washimi/gwexpy.git"
+   pip install PyQt5 pyqtgraph qtpy sounddevice
    python -m gwexpy.gui
 
 .. currentmodule:: gwexpy.gui

--- a/docs/web/ja/user_guide/gui.md
+++ b/docs/web/ja/user_guide/gui.md
@@ -2,18 +2,21 @@
 
 ## 概要
 
-**ステータス:** 試作版（ソース / 開発環境向け）
+**ステータス:** 試作版（ソース / 開発環境専用）
 
-GWexpy には **PyQt5 ベースの GUI** が含まれており、対話的なデータ探索と可視化が可能です。ただし現時点では、GUI は **試作段階 / 実験的インターフェース**として扱ってください。再現性やサポートの観点では、**Python API** が引き続き主要インターフェースです。
+GWexpy のソースツリーには **PyQt5 ベースの GUI** が含まれており、対話的なデータ探索と可視化が可能です。ただし現時点では、GUI は **試作段階 / 実験的インターフェース**として扱ってください。再現性やサポートの観点では、**Python API** が引き続き主要インターフェースです。
 
-GUI アプリは **初回 PyPI のサポート対象には含めません**。初回 PyPI リリースは Python ライブラリ API を主対象とし、GUI の安定化は post-release 作業として別に扱います。
+GUI アプリと `gwexpy.gui` package は **初回 PyPI 配布物には含めません**。初回 PyPI リリースは Python ライブラリ API を主対象とし、GUI の安定化は post-release 作業として別に扱います。
 
 ## インストール
 
-ソース checkout または開発用途では、`gui` extras で GUI 依存関係をインストールできます：
+ソース checkout または開発用途では、ローカル clone から GWexpy を入れたうえで GUI 依存関係を明示的にインストールします：
 
 ```bash
-pip install "gwexpy[gui] @ git+https://github.com/tatsuki-washimi/gwexpy.git"
+git clone https://github.com/tatsuki-washimi/gwexpy.git
+cd gwexpy
+pip install -e .
+pip install PyQt5 pyqtgraph qtpy sounddevice
 ```
 
 これにより、以下の追加の依存パッケージがインストールされます：
@@ -23,14 +26,13 @@ pip install "gwexpy[gui] @ git+https://github.com/tatsuki-washimi/gwexpy.git"
 
 ## GUI を起動する
 
-ソース checkout または開発インストールで GUI extras を入れた後は、
-モジュールを直接起動します：
+ソース checkout または開発インストールで GUI 依存関係を入れた後は、モジュールを直接起動します：
 
 ```bash
 python -m gwexpy.gui
 ```
 
-初回 PyPI リリースでは `gwexpy.gui` console script はインストールしません。
+初回 PyPI リリースでは `gwexpy.gui` console script も `gwexpy.gui` package も配布しません。
 
 ### プログラム内での起動
 
@@ -88,10 +90,10 @@ GUI は以下の形式でのデータ読み込みに対応しています：
 
 ### "ModuleNotFoundError: No module named 'PyQt5'"
 
-GUI extras がインストールされていることを確認してください：
+ソース checkout または開発環境で GUI 依存関係がインストールされていることを確認してください：
 
 ```bash
-pip install "gwexpy[gui] @ git+https://github.com/tatsuki-washimi/gwexpy.git"
+pip install PyQt5 pyqtgraph qtpy sounddevice
 ```
 
 ### GUI が起動しない

--- a/docs/web/ja/user_guide/installation.md
+++ b/docs/web/ja/user_guide/installation.md
@@ -119,7 +119,6 @@ pip install -e ".[dev,all]"
 | `audio` | `pydub`, `tinytag` | 音声書き出し、オーディオ解析、任意のメタデータ抽出。 |
 | `seismic` | `obspy`, `mth5`, `mtpy` | 地震・地磁気データ解析。 |
 | `control` | `control` (python-control) | 制御系モデル・伝達関数解析。 |
-| `gui` | `PyQt5`, `pyqtgraph` | ソース / 開発環境向けの試作 GUI 依存関係。GUI アプリは初回 PyPI のサポート対象には含めず、`all` にも含めません。 |
 
 ---
 

--- a/gwexpy/interop/_optional.py
+++ b/gwexpy/interop/_optional.py
@@ -103,12 +103,12 @@ _EXTRA_MAP: dict[str, str | None] = {
     # audio: Audio processing
     "pydub": "audio",
     "tinytag": "audio",
-    # gui: GUI components
-    "PyQt5": "gui",
-    "pyqtgraph": "gui",
-    "qtpy": "gui",
-    "sounddevice": "gui",
     # No declared extra — install these packages directly
+    # GUI dependencies are source/development-only for the first PyPI release.
+    "PyQt5": None,
+    "pyqtgraph": None,
+    "qtpy": None,
+    "sounddevice": None,
     "PySpice": None,
     "skrf": None,
     "torch": None,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,15 +128,6 @@ audio = [
   "tinytag>=1.10",
 ]
 
-# GUI dependencies for source/development use. The GUI app is experimental,
-# not included in gwexpy[all], and not part of the first PyPI supported surface.
-gui = [
-  "PyQt5",
-  "pyqtgraph",
-  "qtpy",
-  "sounddevice",
-]
-
 # Development tools
 dev = [
   "build",
@@ -217,7 +208,15 @@ gwexpy = [
 
 [tool.setuptools.packages.find]
 include = ["gwexpy*"]
-exclude = ["gwexpy*.tests*", "typings*", "tests*", "docs*", "examples*"]
+exclude = [
+  "gwexpy*.tests*",
+  "gwexpy.gui*",
+  "gwexpy.utils.sphinx*",
+  "typings*",
+  "tests*",
+  "docs*",
+  "examples*",
+]
 
 [project.scripts]
 "gwexpy" = "gwexpy.cli:main"

--- a/scripts/check_release_artifacts.py
+++ b/scripts/check_release_artifacts.py
@@ -22,6 +22,7 @@ FORBIDDEN_PARTS = {
     "htmlcov",
     "scratch",
     "temp_logs",
+    "tests",
     "tmp",
 }
 
@@ -63,7 +64,11 @@ def _is_forbidden(member_name: str) -> bool:
         return True
     if member_name.endswith(FORBIDDEN_SUFFIXES):
         return True
-    return _is_package_internal_test(parts) or _is_package_internal_markdown(parts)
+    return (
+        _is_package_internal_test(parts)
+        or _is_package_internal_markdown(parts)
+        or _is_package_internal_sphinx_helper(parts)
+    )
 
 
 def _is_package_internal_test(parts: tuple[str, ...]) -> bool:
@@ -76,6 +81,15 @@ def _is_package_internal_markdown(parts: tuple[str, ...]) -> bool:
     # reference material and must not ship in release artifacts.
     package_parts = _package_parts(parts)
     return len(package_parts) >= 2 and package_parts[-1].endswith(".md")
+
+
+def _is_package_internal_sphinx_helper(parts: tuple[str, ...]) -> bool:
+    package_parts = _package_parts(parts)
+    return len(package_parts) >= 3 and package_parts[:3] == (
+        "gwexpy",
+        "utils",
+        "sphinx",
+    )
 
 
 def _package_parts(parts: tuple[str, ...]) -> tuple[str, ...]:

--- a/tests/interop/test_errors_and_optional.py
+++ b/tests/interop/test_errors_and_optional.py
@@ -113,14 +113,15 @@ class TestRequireOptional:
         assert "pip install 'gwexpy[netcdf4]'" in msg
         assert 'pip install "gwexpy[all]"' in msg
 
-    def test_gui_extra_does_not_suggest_all(self):
-        """The gui extra is intentionally excluded from gwexpy[all]."""
+    def test_gui_dependencies_use_bare_install_hint(self):
+        """GUI dependencies are not exposed as a first-release PyPI extra."""
         with patch.dict(sys.modules, {"PyQt5": None}):
             with pytest.raises(ImportError) as excinfo:
                 require_optional("PyQt5")
 
         msg = str(excinfo.value)
-        assert "pip install 'gwexpy[gui]'" in msg
+        assert "pip install PyQt5" in msg
+        assert "gwexpy[gui]" not in msg
         assert "gwexpy[all]" not in msg
 
     @pytest.mark.parametrize("name", ["librosa", "pyroomacoustics"])

--- a/tests/io/test_io_improvements.py
+++ b/tests/io/test_io_improvements.py
@@ -27,8 +27,8 @@ def test_ensure_dependency_failure():
 def test_ensure_dependency_extra():
     # nonexistent with extra
     with pytest.raises(ImportError) as excinfo:
-        ensure_dependency("nonexistent", extra="gui")
-    assert "pip install 'gwexpy[gui]'" in str(excinfo.value)
+        ensure_dependency("nonexistent", extra="plotting")
+    assert "pip install 'gwexpy[plotting]'" in str(excinfo.value)
 
 def test_register_timeseries_format_auto_adapt(tmp_path):
     # Mock reader that returns a TimeSeriesDict

--- a/tests/test_check_release_artifacts_script.py
+++ b/tests/test_check_release_artifacts_script.py
@@ -120,6 +120,47 @@ def test_release_artifact_hygiene_rejects_package_internal_tests(
     assert any("gwexpy/histogram/tests" in problem for problem in problems)
 
 
+def test_release_artifact_hygiene_rejects_top_level_tests(
+    tmp_path: Path,
+):
+    module = load_script_module()
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    _write_wheel(
+        dist / "gwexpy-0.1.1-py3-none-any.whl",
+        ["tests/test_bruco.py"],
+    )
+    _write_sdist(
+        dist / "gwexpy-0.1.1.tar.gz",
+        ["gwexpy-0.1.1/tests/test_bruco.py"],
+    )
+
+    problems = module.check_artifacts(dist)
+
+    assert any("tests/test_bruco.py" in problem for problem in problems)
+
+
+def test_release_artifact_hygiene_rejects_package_internal_sphinx_helpers(
+    tmp_path: Path,
+):
+    module = load_script_module()
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    _write_wheel(
+        dist / "gwexpy-0.1.1-py3-none-any.whl",
+        ["gwexpy/utils/sphinx/ex2rst.py"],
+    )
+    _write_sdist(
+        dist / "gwexpy-0.1.1.tar.gz",
+        ["gwexpy-0.1.1/gwexpy/utils/sphinx/zenodo.py"],
+    )
+
+    problems = module.check_artifacts(dist)
+
+    assert any("gwexpy/utils/sphinx/ex2rst.py" in problem for problem in problems)
+    assert any("gwexpy/utils/sphinx/zenodo.py" in problem for problem in problems)
+
+
 def test_release_artifact_hygiene_rejects_package_internal_agent_docs(
     tmp_path: Path,
 ):

--- a/tests/test_conda_forge_roadmap.py
+++ b/tests/test_conda_forge_roadmap.py
@@ -87,17 +87,14 @@ def test_pyproject_excludes_experimental_gui_console_script_from_first_pypi():
     pyproject = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
     scripts = pyproject["project"]["scripts"]
     optional_dependencies = pyproject["project"]["optional-dependencies"]
-    gui_requirements = {
-        _dependency_name(requirement) for requirement in optional_dependencies["gui"]
-    }
     all_requirements = {
         _dependency_name(requirement)
         for requirement in optional_dependencies.get("all", [])
     }
 
     assert scripts == {"gwexpy": "gwexpy.cli:main"}
-    assert gui_requirements
-    assert gui_requirements.isdisjoint(all_requirements)
+    assert "gui" not in optional_dependencies
+    assert {"pyqt5", "pyqtgraph", "qtpy", "sounddevice"}.isdisjoint(all_requirements)
 
 
 def test_conda_forge_roadmap_records_noarch_python_recipe_test_coverage():


### PR DESCRIPTION
## Summary
- remove docs/_static/samples/sample_segment_data.csv from sdist inputs
- exclude gwexpy.gui from wheel/sdist package discovery for the first PyPI release
- remove the gui extra from published metadata and update docs/tests/roadmaps accordingly

## Verification
- rtk pytest -q tests/interop/test_errors_and_optional.py::TestRequireOptional::test_gui_dependencies_use_bare_install_hint tests/io/test_io_improvements.py::test_ensure_dependency_extra tests/test_conda_forge_roadmap.py -p no:cacheprovider
- rtk python scripts/check_release_metadata.py
- rtk git diff --check
- rtk python -m build --outdir /tmp/gwexpy-dist-gui-exclude-351
- rtk python scripts/check_release_artifacts.py /tmp/gwexpy-dist-gui-exclude-351
- rtk /tmp/gwexpy-twine-venv/bin/python -m twine check /tmp/gwexpy-dist-gui-exclude-351/*
- inspected artifacts: no gwexpy/gui, no docs/_static/samples/sample_segment_data.csv, no Provides-Extra: gui, only gwexpy console script
- fresh venv wheel smoke: version 0.1.1, gwexpy.gui spec None, gui extra absent

Refs #293
Refs #274