### PR TITLE
[AGENT:validation] Fix GWF TimeSeriesDict compatibility under GWpy 4

### DIFF
--- a/docs/developers/plans/manifests/audit-manifest-356-gwf-gwpy4-compat.yaml
+++ b/docs/developers/plans/manifests/audit-manifest-356-gwf-gwpy4-compat.yaml
@@ -1,0 +1,67 @@
+issue: 356
+title: "TimeSeriesDict.read GWF compatibility under GWpy 4"
+branch: codex/issue-356-gwf-gwpy4-compat
+date: 2026-05-07
+agent: Codex
+target_release: v0.1.2
+release_order: "03/10"
+tracker: 372
+depends_on:
+  issues:
+    - 357
+    - 371
+  pull_requests:
+    - 373
+    - 374
+skills:
+  - github:github
+  - task-planner
+  - code-reviewer-pro
+  - release-coordinator
+  - superpowers:test-driven-development
+  - superpowers:using-git-worktrees
+  - superpowers:executing-plans
+scope:
+  summary: "Handle GWpy 4 GWF reader dispatch drift for list sources and parallel reader kwargs."
+  included:
+    - "Detect non-empty list/tuple sources of .gwf paths as GWF inputs when format is omitted."
+    - "Normalize nproc/parallel compatibility kwargs against the selected GWpy GWF reader signature."
+    - "Apply the compatibility filter in both TimeSeriesDict.read and TimeSeries.read GWF paths."
+    - "Add regression coverage for list-source dispatch and unsupported nproc kwargs."
+  excluded:
+    - "No GWF data normalization, unit conversion, calibration, or physics behavior changes."
+    - "No release publication, tagging, PyPI/TestPyPI upload, or build artifacts."
+changed_files:
+  - path: gwexpy/timeseries/_gwf_io.py
+    change: "Added list-source .gwf format resolution and GWF reader kwarg filtering."
+  - path: gwexpy/timeseries/collections.py
+    change: "Filtered GWF reader kwargs before calling GWpy read_timeseriesdict."
+  - path: gwexpy/timeseries/timeseries.py
+    change: "Filtered GWF reader kwargs before calling GWpy read_timeseriesdict for single-channel reads."
+  - path: tests/timeseries/test_io_gwf_timeseriesdict.py
+    change: "Added TDD regressions for list-source autodetect, nproc handling, and kwarg filter behavior."
+  - path: docs/developers/plans/manifests/audit-manifest-356-gwf-gwpy4-compat.yaml
+    change: "Recorded release target, dependency order, scope, validation, and review notes."
+validation:
+  red:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/timeseries/test_io_gwf_timeseriesdict.py -p no:cacheprovider"
+      result: "5 failed, 7 passed, 2 skipped; failures reproduced list-source autodetect and unsupported nproc behavior before implementation."
+  completed:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/timeseries/test_io_gwf_timeseriesdict.py -p no:cacheprovider"
+      result: "12 passed, 2 skipped."
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/timeseries/test_io_gwf_framecpp.py tests/timeseries/test_io_gwf_lalframe.py tests/timeseries/test_io_gwf_framel.py -p no:cacheprovider"
+      result: "3 skipped; optional frame backends unavailable in this environment."
+    - cmd: "rtk ruff check gwexpy/timeseries/_gwf_io.py gwexpy/timeseries/collections.py gwexpy/timeseries/timeseries.py tests/timeseries/test_io_gwf_timeseriesdict.py"
+      result: "No issues found."
+    - cmd: "rtk ruff format --check gwexpy/timeseries/_gwf_io.py gwexpy/timeseries/collections.py gwexpy/timeseries/timeseries.py tests/timeseries/test_io_gwf_timeseriesdict.py"
+      result: "4 files already formatted."
+review:
+  human_review_required: false
+  physics_review_required: false
+  rationale: "Compatibility/read-dispatch change only; no numerical algorithms, physics formulas, units, or statistical behavior changed."
+release_notes:
+  target: "v0.1.2 hotfix integration release"
+  user_visible_change: "TimeSeriesDict.read and TimeSeries.read accept GWpy 4 GWF list inputs with legacy nproc-style reader kwargs where supported."
+deferred_follow_ups:
+  - "Keep #356 behind #373 and #374 in the v0.1.2 integration PR to avoid reviewing GWF behavior on stale I/O proxy imports."
+  - "Run the full timeseries GWF suite again in an environment with frameCPP, framel, and lalframe optional backends installed."

--- a/gwexpy/timeseries/_gwf_io.py
+++ b/gwexpy/timeseries/_gwf_io.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from pathlib import Path
 from typing import Any
 
@@ -71,7 +72,9 @@ def _sync_gwf_registry_aliases() -> None:
     all_formats = set(canonical_formats + alias_formats)
 
     for fmt in all_formats:
-        io_registry.register_reader(fmt, TimeSeriesMatrix, _read_timeseriesmatrix_gwf, force=True)
+        io_registry.register_reader(
+            fmt, TimeSeriesMatrix, _read_timeseriesmatrix_gwf, force=True
+        )
 
     for alias, canonical in _GWF_ALIAS_TO_CANONICAL.items():
         canonical_reader = _safe_get_reader(canonical, TimeSeries)
@@ -99,7 +102,9 @@ def _sync_gwf_registry_aliases() -> None:
                 alias, TimeSeriesMatrix, canonical_matrix_reader, force=True
             )
         if canonical_matrix_writer is not None:
-            io_registry.register_writer(alias, TimeSeriesMatrix, canonical_matrix_writer, force=True)
+            io_registry.register_writer(
+                alias, TimeSeriesMatrix, canonical_matrix_writer, force=True
+            )
 
     _GWF_REGISTRY_SYNCED = True
 
@@ -143,14 +148,49 @@ def _resolve_gwf_format(source: Any, fmt: Any) -> str | None:
             return _normalize_gwf_format(fmt)
         return None
 
-    try:
-        path = Path(source)
-    except TypeError:
-        return None
-
-    if path.suffix.lower() == ".gwf":
+    if _looks_like_gwf_path(source):
         return "gwf"
+
+    if isinstance(source, (list, tuple)) and source:
+        if all(_looks_like_gwf_path(item) for item in source):
+            return "gwf"
     return None
+
+
+def _looks_like_gwf_path(source: Any) -> bool:
+    try:
+        return Path(source).suffix.lower() == ".gwf"
+    except (TypeError, ValueError):
+        return False
+
+
+def _filter_gwf_reader_kwargs(reader: Any, kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Normalize GWF reader parallel kwargs for GWpy/backend signature drift."""
+    try:
+        parameters = inspect.signature(reader).parameters
+    except (TypeError, ValueError):
+        return dict(kwargs)
+
+    accepts_kwargs = any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in parameters.values()
+    )
+
+    def accepts(name: str) -> bool:
+        return accepts_kwargs or name in parameters
+
+    filtered = dict(kwargs)
+    if "nproc" in filtered:
+        nproc = filtered.pop("nproc")
+        if accepts("nproc"):
+            filtered["nproc"] = nproc
+        elif accepts("parallel") and "parallel" not in filtered:
+            filtered["parallel"] = nproc
+
+    if "parallel" in filtered and not accepts("parallel"):
+        filtered.pop("parallel")
+
+    return filtered
 
 
 def _normalize_gwf_channels(channels: Any) -> list[str] | None:
@@ -203,14 +243,18 @@ def _extract_gwf_read_args(
 
     if len(args) > 1:
         if has_start_kw and not has_channel_alias_kw:
-            raise TypeError("Cannot specify both positional and keyword 'start' for GWF read.")
+            raise TypeError(
+                "Cannot specify both positional and keyword 'start' for GWF read."
+            )
         start = args[1]
     else:
         start = gwf_kwargs.pop("start", None)
 
     if len(args) > 2:
         if has_end_kw and not has_channel_alias_kw:
-            raise TypeError("Cannot specify both positional and keyword 'end' for GWF read.")
+            raise TypeError(
+                "Cannot specify both positional and keyword 'end' for GWF read."
+            )
         end = args[2]
     else:
         end = gwf_kwargs.pop("end", None)
@@ -233,6 +277,7 @@ def _extract_gwf_read_args(
 
 __all__ = [
     "_extract_gwf_read_args",
+    "_filter_gwf_reader_kwargs",
     "_normalize_gwf_channels",
     "_normalize_gwf_format",
     "_resolve_gwf_format",

--- a/gwexpy/timeseries/collections.py
+++ b/gwexpy/timeseries/collections.py
@@ -45,6 +45,7 @@ from gwexpy.types.mixin._plot_mixin import PlotMixin
 from ._gwf_io import (
     _GWF_BACKENDS,
     _extract_gwf_read_args,
+    _filter_gwf_reader_kwargs,
     _format_gwf_import_error,
     _resolve_gwf_format,
 )
@@ -148,8 +149,14 @@ class TimeSeriesDict(PlotMixin, DictMapMixin, PhaseMethodsMixin, BaseTimeSeriesD
             "dttxml",
         }:
             direct_readers = {
-                "mseed": ("gwexpy.timeseries.io.seismic", "read_miniseed_timeseriesdict"),
-                "miniseed": ("gwexpy.timeseries.io.seismic", "read_miniseed_timeseriesdict"),
+                "mseed": (
+                    "gwexpy.timeseries.io.seismic",
+                    "read_miniseed_timeseriesdict",
+                ),
+                "miniseed": (
+                    "gwexpy.timeseries.io.seismic",
+                    "read_miniseed_timeseriesdict",
+                ),
                 "sac": ("gwexpy.timeseries.io.seismic", "read_sac_timeseriesdict"),
                 "gse2": ("gwexpy.timeseries.io.seismic", "read_gse2_timeseriesdict"),
                 "knet": ("gwexpy.timeseries.io.seismic", "read_knet_timeseriesdict"),
@@ -159,7 +166,10 @@ class TimeSeriesDict(PlotMixin, DictMapMixin, PhaseMethodsMixin, BaseTimeSeriesD
                 "ats.mth5": ("gwexpy.timeseries.io.ats", "read_timeseriesdict_ats"),
                 "gbd": ("gwexpy.timeseries.io.gbd", "read_timeseriesdict_gbd"),
                 "tdms": ("gwexpy.timeseries.io.tdms", "read_timeseriesdict_tdms"),
-                "xml.diaggui": ("gwexpy.timeseries.io.dttxml", "read_timeseriesdict_dttxml"),
+                "xml.diaggui": (
+                    "gwexpy.timeseries.io.dttxml",
+                    "read_timeseriesdict_dttxml",
+                ),
                 "dttxml": ("gwexpy.timeseries.io.dttxml", "read_timeseriesdict_dttxml"),
             }
             module_name, func_name = direct_readers[fmt]
@@ -177,6 +187,7 @@ class TimeSeriesDict(PlotMixin, DictMapMixin, PhaseMethodsMixin, BaseTimeSeriesD
                 kwargs,
                 allow_multiple_channels=True,
             )
+            gwf_kwargs = _filter_gwf_reader_kwargs(read_timeseriesdict, gwf_kwargs)
             TimeSeries = cast(Any, ConverterRegistry.get_constructor("TimeSeries"))
             backend = gwf_kwargs.pop("backend", _GWF_BACKENDS[gwf_format])
             try:
@@ -213,6 +224,7 @@ class TimeSeriesDict(PlotMixin, DictMapMixin, PhaseMethodsMixin, BaseTimeSeriesD
         if p is not None and p.is_dir() and (fmt in (None, "csv", "txt")):
             from gwexpy.io.collection_dir import read_collection_dir
             from gwexpy.io.utils import apply_unit
+
             TimeSeries = cast(Any, ConverterRegistry.get_constructor("TimeSeries"))
 
             _, items = read_collection_dir(
@@ -567,7 +579,9 @@ class TimeSeriesDict(PlotMixin, DictMapMixin, PhaseMethodsMixin, BaseTimeSeriesD
         if isinstance(other, BaseTimeSeries):
             from gwexpy.interop._registry import ConverterRegistry
 
-            FrequencySeriesDict = ConverterRegistry.get_constructor("FrequencySeriesDict")
+            FrequencySeriesDict = ConverterRegistry.get_constructor(
+                "FrequencySeriesDict"
+            )
             new_dict = FrequencySeriesDict()
             for key, ts in self.items():
                 new_dict[key] = ts.csd(
@@ -624,7 +638,9 @@ class TimeSeriesDict(PlotMixin, DictMapMixin, PhaseMethodsMixin, BaseTimeSeriesD
         if isinstance(other, BaseTimeSeries):
             from gwexpy.interop._registry import ConverterRegistry
 
-            FrequencySeriesDict = ConverterRegistry.get_constructor("FrequencySeriesDict")
+            FrequencySeriesDict = ConverterRegistry.get_constructor(
+                "FrequencySeriesDict"
+            )
             new_dict = FrequencySeriesDict()
             for key, ts in self.items():
                 new_dict[key] = ts.coherence(
@@ -1316,7 +1332,9 @@ class TimeSeriesList(PlotMixin, ListMapMixin, PhaseMethodsMixin, BaseTimeSeriesL
         if isinstance(other, BaseTimeSeries):
             from gwexpy.interop._registry import ConverterRegistry
 
-            FrequencySeriesList = ConverterRegistry.get_constructor("FrequencySeriesList")
+            FrequencySeriesList = ConverterRegistry.get_constructor(
+                "FrequencySeriesList"
+            )
             new_list = FrequencySeriesList()
             for ts in self:
                 list.append(
@@ -1380,7 +1398,9 @@ class TimeSeriesList(PlotMixin, ListMapMixin, PhaseMethodsMixin, BaseTimeSeriesL
         if isinstance(other, BaseTimeSeries):
             from gwexpy.interop._registry import ConverterRegistry
 
-            FrequencySeriesList = ConverterRegistry.get_constructor("FrequencySeriesList")
+            FrequencySeriesList = ConverterRegistry.get_constructor(
+                "FrequencySeriesList"
+            )
             new_list = FrequencySeriesList()
             for ts in self:
                 list.append(
@@ -1835,6 +1855,7 @@ class TimeSeriesList(PlotMixin, ListMapMixin, PhaseMethodsMixin, BaseTimeSeriesL
         if p is not None and p.is_dir() and (fmt in (None, "csv", "txt")):
             from gwexpy.io.collection_dir import read_collection_dir
             from gwexpy.io.utils import apply_unit
+
             TimeSeries = cast(Any, ConverterRegistry.get_constructor("TimeSeries"))
 
             _, items = read_collection_dir(

--- a/gwexpy/timeseries/timeseries.py
+++ b/gwexpy/timeseries/timeseries.py
@@ -10,6 +10,7 @@ The implementation is modularized across several files:
 
 This module integrates all Mixins into a single TimeSeries class.
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -29,6 +30,7 @@ from ._core import TimeSeriesCore
 from ._gwf_io import (
     _GWF_BACKENDS,
     _extract_gwf_read_args,
+    _filter_gwf_reader_kwargs,
     _format_gwf_import_error,
     _resolve_gwf_format,
 )
@@ -43,7 +45,6 @@ from ._statistics import StatisticsMixin
 # Import legacy for remaining methods
 
 if TYPE_CHECKING:
-
     from gwexpy.timeseries import TimeSeriesDict
 
 
@@ -149,7 +150,11 @@ class TimeSeries(
         """
         fmt = kwargs.get("format")
         source_path = Path(source) if isinstance(source, (str, Path)) else None
-        if fmt == "csv" or (fmt is None and source_path is not None and source_path.suffix.lower() == ".csv"):
+        if fmt == "csv" or (
+            fmt is None
+            and source_path is not None
+            and source_path.suffix.lower() == ".csv"
+        ):
             from .io.csv_enhanced import read_timeseries_csv
 
             return read_timeseries_csv(source, **kwargs)
@@ -166,6 +171,7 @@ class TimeSeries(
                 kwargs,
                 allow_multiple_channels=False,
             )
+            gwf_kwargs = _filter_gwf_reader_kwargs(read_timeseriesdict, gwf_kwargs)
             backend = gwf_kwargs.pop("backend", _GWF_BACKENDS[gwf_format])
             try:
                 if channels is None:
@@ -199,7 +205,11 @@ class TimeSeries(
         """
         fmt = kwargs.get("format")
         target_path = Path(target) if isinstance(target, (str, Path)) else None
-        if fmt == "csv" or (fmt is None and target_path is not None and target_path.suffix.lower() == ".csv"):
+        if fmt == "csv" or (
+            fmt is None
+            and target_path is not None
+            and target_path.suffix.lower() == ".csv"
+        ):
             from .io.csv_enhanced import write_timeseries_csv
 
             write_kwargs = dict(kwargs)
@@ -290,7 +300,6 @@ class TimeSeries(
         from gwexpy.io.pickle_compat import timeseries_reduce_args
 
         return timeseries_reduce_args(self)
-
 
     # Basic operations (tail, crop, append, find_peaks) are inherited from TimeSeriesCore
 

--- a/tests/timeseries/test_io_gwf_timeseriesdict.py
+++ b/tests/timeseries/test_io_gwf_timeseriesdict.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from gwexpy.timeseries import TimeSeries, TimeSeriesDict
+from gwexpy.timeseries import TimeSeries, TimeSeriesDict, _gwf_io
 from gwexpy.timeseries._gwf_io import _extract_gwf_read_args, _resolve_gwf_format
 
 FIXTURE_DATA = Path(__file__).parent.parent / "fixtures" / "data" / "test.gwf"
@@ -48,6 +48,24 @@ def test_read_gwf_timeseriesdict_autodetects_extension_and_channels():
     assert CHANNEL in tsd
 
 
+@pytest.mark.skipif(not FIXTURE_DATA.exists(), reason="test.gwf fixture not found")
+@pytest.mark.skipif(not has_gwf_backend(), reason="gwf backend not available")
+def test_read_gwf_timeseriesdict_autodetects_list_source_with_nproc_alias():
+    tsd = TimeSeriesDict.read([FIXTURE_DATA], CHANNEL, nproc=1)
+
+    assert isinstance(tsd, TimeSeriesDict)
+    assert list(tsd) == [CHANNEL]
+
+
+@pytest.mark.skipif(not FIXTURE_DATA.exists(), reason="test.gwf fixture not found")
+@pytest.mark.skipif(not has_gwf_backend(), reason="gwf backend not available")
+def test_read_gwf_timeseriesdict_explicit_format_drops_unsupported_nproc():
+    tsd = TimeSeriesDict.read([FIXTURE_DATA], CHANNEL, format="lalframe", nproc=1)
+
+    assert isinstance(tsd, TimeSeriesDict)
+    assert list(tsd) == [CHANNEL]
+
+
 def test_read_gwf_timeseries_with_autodetect_requires_backend():
     pytest.skip("Backend-dependent integration test for .gwf without explicit format")
 
@@ -64,6 +82,7 @@ def test_gwf_format_resolution_prefers_explicit_format_over_extension():
     assert _resolve_gwf_format(path, "lalframe") == "gwf.lalframe"
     assert _resolve_gwf_format(path, "hdf5") is None
     assert _resolve_gwf_format(path, None) == "gwf"
+    assert _resolve_gwf_format([path], None) == "gwf"
 
 
 def test_extract_gwf_read_args_supports_name_fallback_and_channel_aliases():
@@ -115,7 +134,8 @@ def test_extract_gwf_read_args_no_start_end_leak_with_channel_alias():
 
 def test_extract_gwf_read_args_rejects_positional_keyword_overlap():
     with pytest.raises(
-        TypeError, match="Cannot specify both positional and keyword 'start' for GWF read"
+        TypeError,
+        match="Cannot specify both positional and keyword 'start' for GWF read",
     ):
         _extract_gwf_read_args(
             ("K1:CAL-CS_PROC_DARM_DISPLACEMENT_DQ", 10.0),
@@ -129,6 +149,30 @@ def test_extract_gwf_read_args_rejects_positional_keyword_overlap():
             ("K1:CAL-CS_PROC_DARM_DISPLACEMENT_DQ", 10.0, 20.0),
             {"format": "gwf", "end": 30.0},
         )
+
+
+def test_filter_gwf_reader_kwargs_preserves_unknown_kwargs_except_parallel_aliases():
+    def reader(source, channels, *, parallel=None, scaled=None):
+        return None
+
+    filtered = _gwf_io._filter_gwf_reader_kwargs(
+        reader,
+        {"nproc": 2, "scaled": True, "custom": "kept"},
+    )
+
+    assert filtered == {"parallel": 2, "scaled": True, "custom": "kept"}
+
+
+def test_filter_gwf_reader_kwargs_drops_parallel_aliases_when_reader_rejects_them():
+    def reader(source, channels, *, scaled=None):
+        return None
+
+    filtered = _gwf_io._filter_gwf_reader_kwargs(
+        reader,
+        {"nproc": 2, "parallel": 3, "scaled": True, "custom": "kept"},
+    )
+
+    assert filtered == {"scaled": True, "custom": "kept"}
 
 
 def test_read_gwf_timeseries_with_single_channel_by_format_gwf():


### PR DESCRIPTION
Target release: **v0.1.2**
Part of: #372
Order: **03/10**
Depends on: #373, #374
Closes: #356

## Summary
- Detect non-empty list/tuple sources of `.gwf` paths as GWF inputs when `format` is omitted.
- Normalize legacy `nproc` and `parallel` GWF reader kwargs against the selected GWpy 4 reader signature before dispatch.
- Apply the compatibility filter in both `TimeSeriesDict.read` and single-channel `TimeSeries.read` GWF paths.
- Add an audit manifest for the v0.1.2 release queue.

## Validation
- `rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/timeseries/test_io_gwf_timeseriesdict.py -p no:cacheprovider` -> 12 passed, 2 skipped
- `rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/timeseries/test_io_gwf_framecpp.py tests/timeseries/test_io_gwf_lalframe.py tests/timeseries/test_io_gwf_framel.py -p no:cacheprovider` -> 3 skipped, optional frame backends unavailable
- `rtk ruff check gwexpy/timeseries/_gwf_io.py gwexpy/timeseries/collections.py gwexpy/timeseries/timeseries.py tests/timeseries/test_io_gwf_timeseriesdict.py` -> no issues
- `rtk ruff format --check gwexpy/timeseries/_gwf_io.py gwexpy/timeseries/collections.py gwexpy/timeseries/timeseries.py tests/timeseries/test_io_gwf_timeseriesdict.py` -> already formatted
- `rtk python -c "import yaml; yaml.safe_load(open('docs/developers/plans/manifests/audit-manifest-356-gwf-gwpy4-compat.yaml', encoding='utf-8'))"` -> parsed
- `rtk git diff --check` -> clean

## Review Notes
- Compatibility/read-dispatch change only; no numerical algorithms, physics formulas, units, or statistical behavior changed.
- Remaining backend coverage should be rerun in an environment with frameCPP, framel, and lalframe optional backends installed.
