### PR TITLE
[AGENT:validation] Preserve Histogram HDF5 flow metadata

### DIFF
--- a/docs/developers/plans/manifests/audit-manifest-363-histogram-hdf5-flow.yaml
+++ b/docs/developers/plans/manifests/audit-manifest-363-histogram-hdf5-flow.yaml
@@ -1,0 +1,65 @@
+issue: 363
+title: "Preserve Histogram HDF5 flow-bin metadata on round-trip"
+branch: codex/issue-363-histogram-hdf5-flow
+date: 2026-05-07
+agent: Codex
+target_release: v0.1.2
+release_order: "04/10"
+tracker: 372
+depends_on:
+  issues:
+    - 357
+    - 371
+    - 356
+  pull_requests:
+    - 373
+    - 374
+    - 375
+skills:
+  - github:github
+  - task-planner
+  - code-reviewer-pro
+  - release-coordinator
+  - superpowers:test-driven-development
+  - superpowers:using-git-worktrees
+scope:
+  summary: "Persist Histogram HDF5 flow-bin totals and flow-bin sumw2 values."
+  included:
+    - "Write underflow and overflow scalar metadata to Histogram HDF5 attributes."
+    - "Write underflow_sumw2 and overflow_sumw2 scalar metadata when present."
+    - "Restore those values through Histogram.read without changing legacy files that lack the attributes."
+    - "Add regression coverage for HDF5 round-trip preservation with unit and xunit metadata."
+  excluded:
+    - "No changes to histogram fill, rebin, covariance propagation, unit conversion, or statistical formulas."
+    - "No release publication, tagging, PyPI/TestPyPI upload, or build artifacts."
+changed_files:
+  - path: gwexpy/histogram/io/_hdf5.py
+    change: "Stored and restored flow-bin HDF5 attributes for underflow, overflow, and flow-bin sumw2 values."
+  - path: tests/histogram/test_histogram_io.py
+    change: "Added a regression test covering flow-bin HDF5 round-trip persistence."
+  - path: docs/developers/plans/manifests/audit-manifest-363-histogram-hdf5-flow.yaml
+    change: "Recorded release target, dependency order, scope, validation, and review requirements."
+validation:
+  red:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/histogram/test_histogram_io.py -p no:cacheprovider"
+      result: "1 failed, 1 passed; underflow round-tripped as 0.0 instead of 3.0 before implementation."
+  completed:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/histogram/test_histogram_io.py -p no:cacheprovider"
+      result: "2 passed."
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/histogram/test_histogram_io.py tests/histogram/test_histogram_collections.py tests/histogram/test_histogram_contracts.py -p no:cacheprovider"
+      result: "14 passed."
+    - cmd: "rtk ruff check gwexpy/histogram/io/_hdf5.py tests/histogram/test_histogram_io.py"
+      result: "No issues found."
+    - cmd: "rtk ruff format --check gwexpy/histogram/io/_hdf5.py tests/histogram/test_histogram_io.py"
+      result: "2 files already formatted."
+review:
+  human_review_required: true
+  physics_review_required: false
+  statistics_metadata_review_required: true
+  rationale: "The change preserves existing Histogram statistical metadata on disk; it does not change statistical calculations, but should receive human review because flow-bin sumw2 values are statistical metadata."
+release_notes:
+  target: "v0.1.2 hotfix integration release"
+  user_visible_change: "Histogram HDF5 round-trips now preserve underflow, overflow, underflow_sumw2, and overflow_sumw2 metadata."
+deferred_follow_ups:
+  - "Keep #363 behind #373, #374, and #375 in the v0.1.2 integration PR."
+  - "Consider documenting the Histogram HDF5 attribute schema if a formal HDF5 compatibility document is added."

--- a/gwexpy/histogram/io/_hdf5.py
+++ b/gwexpy/histogram/io/_hdf5.py
@@ -8,7 +8,9 @@ if TYPE_CHECKING:
     from gwexpy.histogram import Histogram
 
 
-def write_hdf5_dataset(hist: Histogram, f: h5py.Group | h5py.File, path: str | None = "data") -> None:
+def write_hdf5_dataset(
+    hist: Histogram, f: h5py.Group | h5py.File, path: str | None = "data"
+) -> None:
     """Write a Histogram to an HDF5 group or file.
 
     Parameters
@@ -37,6 +39,12 @@ def write_hdf5_dataset(hist: Histogram, f: h5py.Group | h5py.File, path: str | N
     # Standard metadata mapping aligned with gwexpy patterns
     group.attrs["unit"] = str(hist.unit)
     group.attrs["xunit"] = str(hist.xunit)
+    group.attrs["underflow"] = hist.underflow.to(hist.unit).value
+    group.attrs["overflow"] = hist.overflow.to(hist.unit).value
+    if hist.underflow_sumw2 is not None:
+        group.attrs["underflow_sumw2"] = hist.underflow_sumw2.to(hist.unit**2).value
+    if hist.overflow_sumw2 is not None:
+        group.attrs["overflow_sumw2"] = hist.overflow_sumw2.to(hist.unit**2).value
 
     if hist.name:
         group.attrs["name"] = hist.name
@@ -44,7 +52,9 @@ def write_hdf5_dataset(hist: Histogram, f: h5py.Group | h5py.File, path: str | N
         group.attrs["channel"] = str(getattr(hist.channel, "name", hist.channel))
 
 
-def read_hdf5_dataset(cls: type[Histogram], f: h5py.Group | h5py.File, path: str | None = "data") -> Histogram:
+def read_hdf5_dataset(
+    cls: type[Histogram], f: h5py.Group | h5py.File, path: str | None = "data"
+) -> Histogram:
     """Read a Histogram from an HDF5 group or file.
 
     Parameters
@@ -76,6 +86,14 @@ def read_hdf5_dataset(cls: type[Histogram], f: h5py.Group | h5py.File, path: str
         kwargs["cov"] = group["cov"][:]
     if "sumw2" in group:
         kwargs["sumw2"] = group["sumw2"][:]
+    if "underflow" in group.attrs:
+        kwargs["underflow"] = group.attrs["underflow"]
+    if "overflow" in group.attrs:
+        kwargs["overflow"] = group.attrs["overflow"]
+    if "underflow_sumw2" in group.attrs:
+        kwargs["underflow_sumw2"] = group.attrs["underflow_sumw2"]
+    if "overflow_sumw2" in group.attrs:
+        kwargs["overflow_sumw2"] = group.attrs["overflow_sumw2"]
 
     unit = group.attrs.get("unit")
     if isinstance(unit, bytes):
@@ -100,5 +118,5 @@ def read_hdf5_dataset(cls: type[Histogram], f: h5py.Group | h5py.File, path: str
         xunit=xunit,
         name=name,
         channel=channel,
-        **kwargs
+        **kwargs,
     )

--- a/tests/histogram/test_histogram_io.py
+++ b/tests/histogram/test_histogram_io.py
@@ -1,5 +1,3 @@
-import os
-
 import numpy as np
 import pytest
 
@@ -26,3 +24,36 @@ def test_hdf5_roundtrip(tmp_path):
     assert h2.xunit == hist.xunit
     assert np.allclose(h2.values.value, hist.values.value)
     assert np.allclose(h2.sumw2.value, hist.sumw2.value)
+
+
+def test_hdf5_roundtrip_preserves_flow_bin_metadata(tmp_path):
+    hist = Histogram(
+        values=[10, 20],
+        edges=[0, 1, 2],
+        unit="V",
+        xunit="Hz",
+        sumw2=[1, 2],
+        underflow=3,
+        overflow=4,
+        underflow_sumw2=5,
+        overflow_sumw2=6,
+        name="flow_h",
+    )
+    fpath = tmp_path / "flow.h5"
+
+    hist.write(fpath, format="hdf5")
+    h2 = Histogram.read(fpath, format="hdf5")
+
+    assert h2.underflow.unit == hist.underflow.unit
+    assert h2.overflow.unit == hist.overflow.unit
+    assert np.allclose(h2.underflow.value, hist.underflow.value)
+    assert np.allclose(h2.overflow.value, hist.overflow.value)
+
+    assert h2.underflow_sumw2 is not None
+    assert h2.overflow_sumw2 is not None
+    assert hist.underflow_sumw2 is not None
+    assert hist.overflow_sumw2 is not None
+    assert h2.underflow_sumw2.unit == hist.underflow_sumw2.unit
+    assert h2.overflow_sumw2.unit == hist.overflow_sumw2.unit
+    assert np.allclose(h2.underflow_sumw2.value, hist.underflow_sumw2.value)
+    assert np.allclose(h2.overflow_sumw2.value, hist.overflow_sumw2.value)


### PR DESCRIPTION
Target release: **v0.1.2**
Part of: #372
Order: **04/10**
Depends on: #373, #374, #375
Closes: #363

## Summary
- Preserve Histogram HDF5 `underflow` and `overflow` scalar metadata.
- Preserve `underflow_sumw2` and `overflow_sumw2` when present.
- Keep legacy HDF5 files compatible when those attributes are absent.
- Add an audit manifest for the v0.1.2 release queue.

## Validation
- `rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/histogram/test_histogram_io.py -p no:cacheprovider` -> 2 passed
- `rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/histogram/test_histogram_io.py tests/histogram/test_histogram_collections.py tests/histogram/test_histogram_contracts.py -p no:cacheprovider` -> 14 passed
- `rtk ruff check gwexpy/histogram/io/_hdf5.py tests/histogram/test_histogram_io.py` -> no issues
- `rtk ruff format --check gwexpy/histogram/io/_hdf5.py tests/histogram/test_histogram_io.py` -> already formatted
- `rtk python -c "import yaml; yaml.safe_load(open('docs/developers/plans/manifests/audit-manifest-363-histogram-hdf5-flow.yaml', encoding='utf-8'))"` -> parsed
- `rtk git diff --check` -> clean

## Review Notes
- This preserves existing statistical metadata on disk; it does not change histogram fill/rebin/covariance formulas.
- Human review requested because flow-bin `sumw2` values are statistical metadata.
