### PR TITLE
[AGENT:validation] Handle ats.mth5 compatibility drift cleanly

### DIFF
--- a/docs/developers/plans/manifests/audit-manifest-364-ats-mth5-compat.yaml
+++ b/docs/developers/plans/manifests/audit-manifest-364-ats-mth5-compat.yaml
@@ -1,0 +1,68 @@
+issue: 364
+title: "Handle ats.mth5 drift with clean compatibility error"
+branch: codex/issue-364-ats-mth5-compat
+date: 2026-05-07
+agent: Codex
+target_release: v0.1.2
+release_order: "05/10"
+tracker: 372
+depends_on:
+  issues:
+    - 357
+    - 371
+    - 356
+    - 363
+  pull_requests:
+    - 373
+    - 374
+    - 375
+    - 376
+skills:
+  - github:github
+  - task-planner
+  - code-reviewer-pro
+  - release-coordinator
+  - superpowers:test-driven-development
+  - superpowers:using-git-worktrees
+scope:
+  summary: "Convert ats.mth5 optional-dependency API drift into clean ImportError guidance."
+  included:
+    - "Detect installed-but-incompatible mth5 packages that lack mth5.io.metronix.metronix_atss."
+    - "Raise ImportError with the installed mth5 version, required API path, and native format='ats' fallback guidance."
+    - "Keep the native ATS reader path unchanged."
+    - "Add regression coverage for the incompatible mth5 shape."
+  excluded:
+    - "No broad mth5 version support expansion or ATSS filename normalization."
+    - "No default native ATS parser behavior changes."
+    - "No release publication, tagging, PyPI/TestPyPI upload, or build artifacts."
+changed_files:
+  - path: gwexpy/timeseries/io/ats.py
+    change: "Added ats.mth5 compatibility error formatting for missing or drifted mth5 Metronix APIs."
+  - path: tests/io/test_seismic_public_io.py
+    change: "Added regression coverage for installed mth5 packages without mth5.io.metronix."
+  - path: docs/developers/plans/manifests/audit-manifest-364-ats-mth5-compat.yaml
+    change: "Recorded release target, dependency order, scope, validation, and review notes."
+validation:
+  red:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_seismic_public_io.py::test_ats_mth5_incompatible_dependency_raises_clean_importerror -p no:cacheprovider"
+      result: "1 failed; incompatible fake mth5 surfaced AttributeError before implementation."
+  completed:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_seismic_public_io.py -p no:cacheprovider"
+      result: "9 passed."
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_seismic_public_io.py tests/io/test_ats_reader.py tests/io/test_io_contract.py::test_current_public_boundary_decisions_are_recorded -p no:cacheprovider"
+      result: "13 passed."
+    - cmd: "rtk ruff check gwexpy/timeseries/io/ats.py tests/io/test_seismic_public_io.py"
+      result: "No issues found."
+    - cmd: "rtk ruff format --check gwexpy/timeseries/io/ats.py tests/io/test_seismic_public_io.py"
+      result: "2 files already formatted."
+review:
+  human_review_required: false
+  physics_review_required: false
+  statistics_metadata_review_required: false
+  rationale: "Optional dependency error-handling change only; no data parsing, numerical behavior, physics, units, or statistics changed."
+release_notes:
+  target: "v0.1.2 hotfix integration release"
+  user_visible_change: "TimeSeries.read(..., format='ats.mth5') now reports incompatible mth5 installs with clean guidance instead of AttributeError."
+deferred_follow_ups:
+  - "Keep #364 behind #373, #374, #375, and #376 in the v0.1.2 integration PR."
+  - "Evaluate full mth5/ATSS compatibility separately if maintainers want broader version support."

--- a/gwexpy/timeseries/io/ats.py
+++ b/gwexpy/timeseries/io/ats.py
@@ -1,4 +1,5 @@
 """Read Metronix ATS files for gwexpy."""
+
 from __future__ import annotations
 
 import datetime
@@ -64,13 +65,13 @@ def identify_ats(origin, filepath, fileobj, *args, **kwargs):
     if filepath is None:
         return False
     try:
-        with open(filepath, 'rb') as f:
+        with open(filepath, "rb") as f:
             header = f.read(4)
             if len(header) < 4:
                 return False
 
-            header_size = struct.unpack('<H', header[0:2])[0]
-            header_vers = struct.unpack('<h', header[2:4])[0]
+            header_size = struct.unpack("<H", header[0:2])[0]
+            header_vers = struct.unpack("<h", header[2:4])[0]
 
             # Metronix ATS header is always >= 1024 bytes
             # Version must be in supported list
@@ -264,6 +265,19 @@ def _read_timeseries_ats_file(f, *, unit=None, epoch=None, **kwargs):
     return ts
 
 
+def _format_ats_mth5_import_error(mth5: Any | None = None) -> ImportError:
+    version = (
+        "not installed" if mth5 is None else getattr(mth5, "__version__", "unknown")
+    )
+    return ImportError(
+        "format 'ats.mth5' requires a compatible mth5 installation exposing "
+        "mth5.io.metronix.metronix_atss. "
+        f"Installed mth5 version: {version}. "
+        "Install a compatible mth5 release with Metronix ATS support, "
+        "or use format='ats' for gwexpy's native ATS reader."
+    )
+
+
 def read_timeseries_ats_mth5(source, **kwargs):
     """Read Metronix ATS/ATSS file using mth5 library.
 
@@ -274,11 +288,16 @@ def read_timeseries_ats_mth5(source, **kwargs):
     """
     try:
         mth5 = ensure_dependency("mth5")
+    except ImportError as exc:
+        raise _format_ats_mth5_import_error() from exc
+
+    try:
         metronix_atss = mth5.io.metronix.metronix_atss
-    except ImportError:
-        raise ImportError(
-            "mth5 library is required to use this reader. Install it via pip."
-        )
+    except AttributeError as exc:
+        raise _format_ats_mth5_import_error(mth5) from exc
+
+    if not hasattr(metronix_atss, "read_atss"):
+        raise _format_ats_mth5_import_error(mth5)
 
     # mth5 requires .atss extension?
     # Based on investigation, it checks .suffix in _get_file_type.

--- a/tests/io/test_seismic_public_io.py
+++ b/tests/io/test_seismic_public_io.py
@@ -72,9 +72,9 @@ def test_win_alias_family_public_surface_is_dict_first(monkeypatch):
 
     monkeypatch.setattr(win_io, "_read_win_fixed", lambda *a, **k: stream)
 
-    assert str(next(iter(TimeSeriesDict.read("dummy.win", format="win").keys()))).endswith(
-        "A1_01"
-    )
+    assert str(
+        next(iter(TimeSeriesDict.read("dummy.win", format="win").keys()))
+    ).endswith("A1_01")
     assert str(
         next(iter(TimeSeriesDict.read("dummy.cnt", format="win32").keys()))
     ).endswith("A1_01")
@@ -99,3 +99,24 @@ def test_ats_mth5_missing_dependency_raises_clean_importerror():
 
     with pytest.raises(ImportError):
         TimeSeries.read(fixture, format="ats.mth5")
+
+
+def test_ats_mth5_incompatible_dependency_raises_clean_importerror(
+    monkeypatch, tmp_path
+):
+    from types import SimpleNamespace
+
+    from gwexpy.timeseries.io import ats as ats_io
+
+    fake_mth5 = SimpleNamespace(__version__="0.6.7", io=SimpleNamespace())
+    monkeypatch.setattr(ats_io, "ensure_dependency", lambda name: fake_mth5)
+    source = tmp_path / "sample.ats"
+    source.write_bytes(b"")
+
+    with pytest.raises(ImportError) as exc:
+        TimeSeries.read(source, format="ats.mth5")
+
+    message = str(exc.value)
+    assert "ats.mth5" in message
+    assert "mth5.io.metronix.metronix_atss" in message
+    assert "format='ats'" in message


### PR DESCRIPTION
Target release: **v0.1.2**
Part of: #372
Order: **05/10**
Depends on: #373, #374, #375, #376
Closes: #364

## Summary
- Convert missing or drifted `mth5.io.metronix.metronix_atss` support into a clean `ImportError`.
- Include installed `mth5` version, required API path, and native `format='ats'` fallback guidance.
- Keep the native ATS reader path unchanged.
- Add an audit manifest for the v0.1.2 release queue.

## Validation
- `rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_seismic_public_io.py -p no:cacheprovider` -> 9 passed
- `rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_seismic_public_io.py tests/io/test_ats_reader.py tests/io/test_io_contract.py::test_current_public_boundary_decisions_are_recorded -p no:cacheprovider` -> 13 passed
- `rtk ruff check gwexpy/timeseries/io/ats.py tests/io/test_seismic_public_io.py` -> no issues
- `rtk ruff format --check gwexpy/timeseries/io/ats.py tests/io/test_seismic_public_io.py` -> already formatted
- `rtk python -c "import yaml; yaml.safe_load(open('docs/developers/plans/manifests/audit-manifest-364-ats-mth5-compat.yaml', encoding='utf-8'))"` -> parsed
- `rtk git diff --check` -> clean

## Review Notes
- Optional dependency error-handling only; no ATS parsing, numerical behavior, physics, units, or statistics changed.
