### PR TITLE
[AGENT:validation] Fix compressed audio auto-identify

### DIFF
--- a/docs/developers/plans/manifests/audit-manifest-366-audio-auto-identify.yaml
+++ b/docs/developers/plans/manifests/audit-manifest-366-audio-auto-identify.yaml
@@ -1,0 +1,72 @@
+issue: 366
+title: "Fix public audio auto-identify registration"
+branch: codex/issue-366-audio-auto-identify
+date: 2026-05-07
+agent: Codex
+target_release: v0.1.2
+release_order: "06/10"
+tracker: 372
+depends_on:
+  issues:
+    - 357
+    - 371
+    - 356
+    - 363
+    - 364
+  pull_requests:
+    - 373
+    - 374
+    - 375
+    - 376
+    - 377
+skills:
+  - github:github
+  - task-planner
+  - code-reviewer-pro
+  - release-coordinator
+  - superpowers:test-driven-development
+  - superpowers:using-git-worktrees
+scope:
+  summary: "Restore compressed-audio registry auto-identification and clean missing-codec behavior."
+  included:
+    - "Normalize registered extensions so dotted values like .flac match file paths correctly."
+    - "Add public auto-identify coverage for flac, ogg, mp3, and m4a."
+    - "Raise clean ImportError guidance when pydub is present but ffmpeg/libav is missing."
+    - "Skip compressed-audio round-trip tests when no external codec backend is available."
+  excluded:
+    - "No WAV registration or reader behavior changes."
+    - "No broad audio metadata documentation cleanup."
+    - "No release publication, tagging, PyPI/TestPyPI upload, or build artifacts."
+changed_files:
+  - path: gwexpy/timeseries/io/_registration.py
+    change: "Normalized extension suffix handling for generated registry identifiers."
+  - path: gwexpy/timeseries/io/audio.py
+    change: "Converted missing ffmpeg/libav FileNotFoundError cases into clean ImportError guidance."
+  - path: tests/io/test_compressed_audio_public_io.py
+    change: "Added compressed-audio auto-identify coverage, codec clean-error tests, and codec-backend skip logic."
+  - path: docs/developers/plans/manifests/audit-manifest-366-audio-auto-identify.yaml
+    change: "Recorded release target, dependency order, scope, validation, and review notes."
+validation:
+  red:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_compressed_audio_public_io.py::test_compressed_audio_public_extensions_auto_identify -p no:cacheprovider"
+      result: "4 failed; flac, ogg, mp3, and m4a identified as [] before extension normalization."
+  completed:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_compressed_audio_public_io.py::test_compressed_audio_public_extensions_auto_identify tests/io/test_io_improvements.py::test_register_timeseries_format_auto_adapt tests/io/test_io_improvements.py::test_register_timeseries_format_aliases_do_not_duplicate_identifiers -p no:cacheprovider"
+      result: "6 passed."
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_compressed_audio_public_io.py tests/io/test_audio_metadata.py tests/io/test_optional_deps.py tests/io/test_io_improvements.py::test_register_timeseries_format_auto_adapt tests/io/test_io_improvements.py::test_register_timeseries_format_aliases_do_not_duplicate_identifiers -p no:cacheprovider"
+      result: "31 passed, 6 skipped, 1 warning; skips were compressed-audio round-trips without ffmpeg/libav and optional dependency skips."
+    - cmd: "rtk ruff check gwexpy/timeseries/io/_registration.py gwexpy/timeseries/io/audio.py tests/io/test_compressed_audio_public_io.py"
+      result: "No issues found."
+    - cmd: "rtk ruff format --check gwexpy/timeseries/io/_registration.py gwexpy/timeseries/io/audio.py tests/io/test_compressed_audio_public_io.py"
+      result: "3 files already formatted."
+review:
+  human_review_required: false
+  physics_review_required: false
+  statistics_metadata_review_required: false
+  rationale: "I/O registry and optional external codec error-handling changes only; no numerical, physics, units, or statistics behavior changed."
+release_notes:
+  target: "v0.1.2 hotfix integration release"
+  user_visible_change: "flac, ogg, mp3, and m4a now auto-identify through the registry, and missing ffmpeg/libav reports clean install guidance."
+deferred_follow_ups:
+  - "Keep #366 behind #373, #374, #375, #376, and #377 in the v0.1.2 integration PR."
+  - "Address broader audio metadata documentation cleanup separately from this registry hotfix."

--- a/gwexpy/timeseries/io/_registration.py
+++ b/gwexpy/timeseries/io/_registration.py
@@ -4,6 +4,7 @@ This module provides utilities to register TimeSeries I/O handlers
 with automatic adapter generation for TimeSeriesDict, TimeSeries,
 and TimeSeriesMatrix types.
 """
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -17,6 +18,10 @@ if TYPE_CHECKING:
 __all__ = ["register_timeseries_format"]
 
 
+def _extension_suffix(extension: str) -> str:
+    return f".{extension.lower().lstrip('.')}"
+
+
 def _ensure_registry_docstring(data_class: type[Any], method_name: str) -> None:
     """Ensure Astropy registry doc updates see a multi-line method docstring."""
     method = getattr(data_class, method_name, None)
@@ -26,10 +31,16 @@ def _ensure_registry_docstring(data_class: type[Any], method_name: str) -> None:
     doc = getattr(method, "__doc__", None)
     if isinstance(doc, str):
         lines = doc.splitlines()
-        has_indented_content = any(line.strip() and line[:1].isspace() for line in lines[1:])
+        has_indented_content = any(
+            line.strip() and line[:1].isspace() for line in lines[1:]
+        )
         if len(lines) >= 2 and has_indented_content:
             return
-        summary = lines[0].strip() if lines and lines[0].strip() else f"{data_class.__name__}.{method_name}"
+        summary = (
+            lines[0].strip()
+            if lines and lines[0].strip()
+            else f"{data_class.__name__}.{method_name}"
+        )
     else:
         summary = f"{data_class.__name__}.{method_name}"
 
@@ -150,7 +161,9 @@ def register_timeseries_format(
     # Register TimeSeriesDict reader
     if reader_dict is not None:
         if not reader_dict.__doc__ or not reader_dict.__doc__.strip():
-            reader_dict.__doc__ = f"\n    Read {format_name} data into a TimeSeriesDict.\n    "
+            reader_dict.__doc__ = (
+                f"\n    Read {format_name} data into a TimeSeriesDict.\n    "
+            )
         for registered_name in format_names:
             io_registry.register_reader(
                 registered_name, TimeSeriesDict, reader_dict, force=force
@@ -166,12 +179,16 @@ def register_timeseries_format(
                 raise ValueError(f"No data found in {format_name} file")
             return tsd[next(iter(tsd.keys()))]
 
-        _adapted_single_reader.__doc__ = f"\n    Read {format_name} data into a TimeSeries.\n    "
+        _adapted_single_reader.__doc__ = (
+            f"\n    Read {format_name} data into a TimeSeries.\n    "
+        )
         reader_single = _adapted_single_reader
 
     if reader_single is not None:
         if not reader_single.__doc__ or not reader_single.__doc__.strip():
-            reader_single.__doc__ = f"\n    Read {format_name} data into a TimeSeries.\n    "
+            reader_single.__doc__ = (
+                f"\n    Read {format_name} data into a TimeSeries.\n    "
+            )
         for registered_name in format_names:
             io_registry.register_reader(
                 registered_name, TimeSeries, reader_single, force=force
@@ -185,12 +202,16 @@ def register_timeseries_format(
             tsd = reader_dict(*args, **kwargs)
             return tsd.to_matrix()
 
-        _adapted_matrix_reader.__doc__ = f"\n    Read {format_name} data into a TimeSeriesMatrix.\n    "
+        _adapted_matrix_reader.__doc__ = (
+            f"\n    Read {format_name} data into a TimeSeriesMatrix.\n    "
+        )
         reader_matrix = _adapted_matrix_reader
 
     if reader_matrix is not None:
         if not reader_matrix.__doc__ or not reader_matrix.__doc__.strip():
-            reader_matrix.__doc__ = f"\n    Read {format_name} data into a TimeSeriesMatrix.\n    "
+            reader_matrix.__doc__ = (
+                f"\n    Read {format_name} data into a TimeSeriesMatrix.\n    "
+            )
         for registered_name in format_names:
             io_registry.register_reader(
                 registered_name, TimeSeriesMatrix, reader_matrix, force=force
@@ -199,7 +220,9 @@ def register_timeseries_format(
     # Register TimeSeriesDict writer
     if writer_dict is not None:
         if not writer_dict.__doc__ or not writer_dict.__doc__.strip():
-            writer_dict.__doc__ = f"\n    Write TimeSeriesDict to {format_name} format.\n    "
+            writer_dict.__doc__ = (
+                f"\n    Write TimeSeriesDict to {format_name} format.\n    "
+            )
         for registered_name in format_names:
             io_registry.register_writer(
                 registered_name, TimeSeriesDict, writer_dict, force=force
@@ -215,12 +238,16 @@ def register_timeseries_format(
             tsd = TimeSeriesDict({ts.name: ts})
             return writer_dict(tsd, target, *args, **kwargs)
 
-        _adapted_single_writer.__doc__ = f"\n    Write TimeSeries to {format_name} format.\n    "
+        _adapted_single_writer.__doc__ = (
+            f"\n    Write TimeSeries to {format_name} format.\n    "
+        )
         writer_single = _adapted_single_writer
 
     if writer_single is not None:
         if not writer_single.__doc__ or not writer_single.__doc__.strip():
-            writer_single.__doc__ = f"\n    Write TimeSeries to {format_name} format.\n    "
+            writer_single.__doc__ = (
+                f"\n    Write TimeSeries to {format_name} format.\n    "
+            )
         for registered_name in format_names:
             io_registry.register_writer(
                 registered_name, TimeSeries, writer_single, force=force
@@ -234,12 +261,16 @@ def register_timeseries_format(
             tsd = tsm.to_dict()
             return writer_dict(tsd, target, *args, **kwargs)
 
-        _adapted_matrix_writer.__doc__ = f"\n    Write TimeSeriesMatrix to {format_name} format.\n    "
+        _adapted_matrix_writer.__doc__ = (
+            f"\n    Write TimeSeriesMatrix to {format_name} format.\n    "
+        )
         writer_matrix = _adapted_matrix_writer
 
     if writer_matrix is not None:
         if not writer_matrix.__doc__ or not writer_matrix.__doc__.strip():
-            writer_matrix.__doc__ = f"\n    Write TimeSeriesMatrix to {format_name} format.\n    "
+            writer_matrix.__doc__ = (
+                f"\n    Write TimeSeriesMatrix to {format_name} format.\n    "
+            )
         for registered_name in format_names:
             io_registry.register_writer(
                 registered_name, TimeSeriesMatrix, writer_matrix, force=force
@@ -249,6 +280,7 @@ def register_timeseries_format(
     if identifier_dict is None:
         # Create combined identifier if magic_identifier is provided
         if magic_identifier is not None:
+
             def _combined_identifier(origin, filepath, fileobj, *args, **kwargs):
                 """Check magic number first, then fall back to extension."""
                 # 1. Try magic number identification (high reliability)
@@ -261,7 +293,7 @@ def register_timeseries_format(
 
                 # 2. Fall back to extension check
                 if extension is not None and filepath is not None:
-                    return str(filepath).lower().endswith(f".{extension}")
+                    return str(filepath).lower().endswith(_extension_suffix(extension))
 
                 return False
 
@@ -273,7 +305,7 @@ def register_timeseries_format(
                 # args[1] is the source path in gwpy's identifier signature
                 if len(args) < 2:
                     return False
-                return str(args[1]).lower().endswith(f".{extension}")
+                return str(args[1]).lower().endswith(_extension_suffix(extension))
 
             identifier_dict = _extension_identifier
 
@@ -287,4 +319,6 @@ def register_timeseries_format(
     if identifier_single is not None:
         io_registry.register_identifier(format_name, TimeSeries, identifier_single)
         # TimeSeriesMatrix typically uses the same identifier
-        io_registry.register_identifier(format_name, TimeSeriesMatrix, identifier_single)
+        io_registry.register_identifier(
+            format_name, TimeSeriesMatrix, identifier_single
+        )

--- a/gwexpy/timeseries/io/audio.py
+++ b/gwexpy/timeseries/io/audio.py
@@ -3,6 +3,7 @@
 pydub requires ffmpeg or libav for most formats.
 FLAC decoding may work without ffmpeg if the audioop module is available.
 """
+
 from __future__ import annotations
 
 from collections.abc import Iterable
@@ -34,6 +35,15 @@ def _import_pydub():
             "Install with `pip install 'gwexpy[audio]'`. "
             "MP3/M4A encoding also requires ffmpeg (`apt install ffmpeg` or equivalent)."
         ) from exc
+
+
+def _format_audio_codec_error(exc: FileNotFoundError) -> ImportError:
+    return ImportError(
+        "ffmpeg or libav is required for compressed audio formats "
+        "(MP3, FLAC, OGG, M4A). Install ffmpeg (`apt install ffmpeg`, "
+        "`brew install ffmpeg`, or equivalent), or install libav and ensure "
+        "the codec executable is on PATH."
+    )
 
 
 def read_timeseriesdict_audio(
@@ -78,7 +88,10 @@ def read_timeseriesdict_audio(
     if format_hint is not None:
         seg_kwargs["format"] = format_hint
 
-    seg = AudioSegment.from_file(str(source), **seg_kwargs)
+    try:
+        seg = AudioSegment.from_file(str(source), **seg_kwargs)
+    except FileNotFoundError as exc:
+        raise _format_audio_codec_error(exc) from exc
 
     n_channels = seg.channels
     sample_rate = seg.frame_rate
@@ -211,7 +224,10 @@ def write_timeseriesdict_audio(tsd, target, *, format_hint=None, **kwargs):
         ext = str(target).rsplit(".", 1)[-1].lower()
         export_fmt = ext
 
-    seg.export(str(target), format=export_fmt, **kwargs)
+    try:
+        seg.export(str(target), format=export_fmt, **kwargs)
+    except FileNotFoundError as exc:
+        raise _format_audio_codec_error(exc) from exc
 
 
 def write_timeseries_audio(ts, target, **kwargs):

--- a/tests/io/test_compressed_audio_public_io.py
+++ b/tests/io/test_compressed_audio_public_io.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import shutil
+
 import numpy as np
 import pytest
+from gwpy.io.registry import default_registry as io_registry
 
 from gwexpy.timeseries import TimeSeries, TimeSeriesDict
 
@@ -11,14 +14,24 @@ from gwexpy.timeseries import TimeSeries, TimeSeriesDict
 def _make_tsd():
     return TimeSeriesDict(
         {
-            "L": TimeSeries(np.array([0.0, 0.25, -0.25, 0.5], dtype=float), sample_rate=8, name="L"),
-            "R": TimeSeries(np.array([0.5, -0.5, 0.25, -0.25], dtype=float), sample_rate=8, name="R"),
+            "L": TimeSeries(
+                np.array([0.0, 0.25, -0.25, 0.5], dtype=float), sample_rate=8, name="L"
+            ),
+            "R": TimeSeries(
+                np.array([0.5, -0.5, 0.25, -0.25], dtype=float), sample_rate=8, name="R"
+            ),
         }
     )
 
 
+def _has_audio_codec_backend() -> bool:
+    return shutil.which("ffmpeg") is not None or shutil.which("avconv") is not None
+
+
 @pytest.mark.parametrize("fmt", ["flac", "ogg", "mp3", "m4a"])
-def test_compressed_audio_missing_pydub_raises_clean_importerror(monkeypatch, tmp_path, fmt):
+def test_compressed_audio_missing_pydub_raises_clean_importerror(
+    monkeypatch, tmp_path, fmt
+):
     from gwexpy.timeseries.io import audio as audio_io
 
     def _boom():
@@ -37,9 +50,61 @@ def test_compressed_audio_missing_pydub_raises_clean_importerror(monkeypatch, tm
         _make_tsd().write(path, format=fmt)
 
 
+def test_compressed_audio_missing_codec_on_read_raises_clean_importerror(
+    monkeypatch, tmp_path
+):
+    from gwexpy.timeseries.io import audio as audio_io
+
+    class MissingCodecAudioSegment:
+        @classmethod
+        def from_file(cls, *args, **kwargs):
+            raise FileNotFoundError("ffmpeg")
+
+    monkeypatch.setattr(audio_io, "_import_pydub", lambda: MissingCodecAudioSegment)
+    path = tmp_path / "sample.mp3"
+    path.write_bytes(b"not an audio payload")
+
+    with pytest.raises(ImportError, match="ffmpeg or libav"):
+        TimeSeriesDict.read(path, format="mp3")
+
+
+def test_compressed_audio_missing_codec_on_write_raises_clean_importerror(
+    monkeypatch, tmp_path
+):
+    from gwexpy.timeseries.io import audio as audio_io
+
+    class MissingCodecAudioSegment:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def export(self, *args, **kwargs):
+            raise FileNotFoundError("ffmpeg")
+
+    monkeypatch.setattr(audio_io, "_import_pydub", lambda: MissingCodecAudioSegment)
+    path = tmp_path / "sample.mp3"
+
+    with pytest.raises(ImportError, match="ffmpeg or libav"):
+        _make_tsd().write(path, format="mp3")
+
+
+@pytest.mark.parametrize("fmt", ["flac", "ogg", "mp3", "m4a"])
+def test_compressed_audio_public_extensions_auto_identify(tmp_path, fmt):
+    path = tmp_path / f"sample.{fmt}"
+    path.write_bytes(b"not an audio payload")
+
+    assert fmt in io_registry.identify_format(
+        "read", TimeSeriesDict, str(path), None, (), {}
+    )
+    assert fmt in io_registry.identify_format(
+        "read", TimeSeries, str(path), None, (), {}
+    )
+
+
 @pytest.mark.parametrize("fmt", ["flac", "ogg", "mp3", "m4a"])
 def test_compressed_audio_public_roundtrip_when_dependency_available(tmp_path, fmt):
     pytest.importorskip("pydub")
+    if not _has_audio_codec_backend():
+        pytest.skip("ffmpeg/libav is required for compressed audio round-trip")
 
     tsd = _make_tsd()
     path = tmp_path / f"sample.{fmt}"


### PR DESCRIPTION
Target release: **v0.1.2**
Part of: #372
Order: **06/10**
Depends on: #373, #374, #375, #376, #377
Closes: #366

## Summary
- Normalize registry extension suffixes so dotted registrations like `.flac` identify correctly.
- Add auto-identify coverage for `flac`, `ogg`, `mp3`, and `m4a`.
- Convert missing ffmpeg/libav codec backend failures into clean `ImportError` guidance.
- Skip compressed-audio round-trip tests when pydub is installed but no external codec backend is available.
- Add an audit manifest for the v0.1.2 release queue.

## Validation
- `rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_compressed_audio_public_io.py::test_compressed_audio_public_extensions_auto_identify tests/io/test_io_improvements.py::test_register_timeseries_format_auto_adapt tests/io/test_io_improvements.py::test_register_timeseries_format_aliases_do_not_duplicate_identifiers -p no:cacheprovider` -> 6 passed
- `rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_compressed_audio_public_io.py tests/io/test_audio_metadata.py tests/io/test_optional_deps.py tests/io/test_io_improvements.py::test_register_timeseries_format_auto_adapt tests/io/test_io_improvements.py::test_register_timeseries_format_aliases_do_not_duplicate_identifiers -p no:cacheprovider` -> 31 passed, 6 skipped, 1 warning
- `rtk ruff check gwexpy/timeseries/io/_registration.py gwexpy/timeseries/io/audio.py tests/io/test_compressed_audio_public_io.py` -> no issues
- `rtk ruff format --check gwexpy/timeseries/io/_registration.py gwexpy/timeseries/io/audio.py tests/io/test_compressed_audio_public_io.py` -> already formatted
- `rtk python -c "import yaml; yaml.safe_load(open('docs/developers/plans/manifests/audit-manifest-366-audio-auto-identify.yaml', encoding='utf-8'))"` -> parsed
- `rtk git diff --check` -> clean

## Review Notes
- I/O registry and optional external codec error handling only; no numerical, physics, units, or statistics behavior changed.
