### PR TITLE
[AGENT:validation] Fix seismic auto-identify registration

### DIFF
--- a/docs/developers/plans/manifests/audit-manifest-367-seismic-auto-identify.yaml
+++ b/docs/developers/plans/manifests/audit-manifest-367-seismic-auto-identify.yaml
@@ -1,0 +1,72 @@
+issue: 367
+title: "Fix public seismic auto-identify registration"
+branch: codex/issue-367-seismic-auto-identify
+date: 2026-05-07
+agent: Codex
+target_release: v0.1.2
+release_order: "07/10"
+tracker: 372
+depends_on:
+  issues:
+    - 357
+    - 371
+    - 356
+    - 363
+    - 364
+    - 366
+  pull_requests:
+    - 373
+    - 374
+    - 375
+    - 376
+    - 377
+    - 378
+skills:
+  - github:github
+  - task-planner
+  - code-reviewer-pro
+  - release-coordinator
+  - superpowers:test-driven-development
+  - superpowers:using-git-worktrees
+scope:
+  summary: "Register public seismic file extensions for registry auto-identification."
+  included:
+    - "Add extension identifiers for mseed, sac, gse2, and knet registrations."
+    - "Add regression coverage that exercises registry identify_format without reading payloads."
+    - "Verify explicit-format seismic readers still pass in the focused public I/O coverage."
+  excluded:
+    - "No ObsPy optional-dependency import behavior changes."
+    - "No seismic parsing, units, timestamps, or write-path behavior changes."
+    - "No release publication, tagging, PyPI/TestPyPI upload, or build artifacts."
+changed_files:
+  - path: gwexpy/timeseries/io/seismic.py
+    change: "Added extension metadata to the public seismic register_timeseries_format calls."
+  - path: tests/io/test_seismic_public_io.py
+    change: "Added auto-identify coverage for mseed, sac, gse2, and knet."
+  - path: docs/developers/plans/manifests/audit-manifest-367-seismic-auto-identify.yaml
+    change: "Recorded release target, dependency order, scope, validation, and review notes."
+validation:
+  red:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_seismic_public_io.py::test_public_seismic_extensions_auto_identify -p no:cacheprovider"
+      result: "4 failed; mseed, sac, gse2, and knet identified as [] before extension registration."
+  completed:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_seismic_public_io.py::test_public_seismic_extensions_auto_identify tests/io/test_seismic_public_io.py::test_mseed_public_dict_roundtrip_and_alias tests/io/test_seismic_public_io.py::test_obsby_backed_public_dict_roundtrip tests/io/test_seismic_public_io.py::test_knet_public_surface_is_dict_first tests/io/test_io_contract.py::test_current_public_boundary_decisions_are_recorded tests/io/test_io_improvements.py::test_register_timeseries_format_auto_adapt tests/io/test_io_improvements.py::test_register_timeseries_format_aliases_do_not_duplicate_identifiers -p no:cacheprovider"
+      result: "12 passed."
+    - cmd: "rtk ruff check gwexpy/timeseries/io/seismic.py tests/io/test_seismic_public_io.py"
+      result: "No issues found."
+    - cmd: "rtk ruff format --check gwexpy/timeseries/io/seismic.py tests/io/test_seismic_public_io.py"
+      result: "2 files already formatted."
+  dependency_gated:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_seismic_public_io.py tests/io/test_io_contract.py::test_current_public_boundary_decisions_are_recorded tests/io/test_io_improvements.py::test_register_timeseries_format_auto_adapt tests/io/test_io_improvements.py::test_register_timeseries_format_aliases_do_not_duplicate_identifiers -p no:cacheprovider"
+      result: "1 failed, 14 passed; the failure is the known ats.mth5 AttributeError fixed by prerequisite PR #377."
+review:
+  human_review_required: false
+  physics_review_required: false
+  statistics_metadata_review_required: false
+  rationale: "Registry metadata change only; no data parsing, numerical behavior, physics, units, timestamps, or statistics changed."
+release_notes:
+  target: "v0.1.2 hotfix integration release"
+  user_visible_change: "mseed, sac, gse2, and knet now auto-identify through the registry according to the public I/O contract."
+deferred_follow_ups:
+  - "Keep #367 behind #373, #374, #375, #376, #377, and #378 in the v0.1.2 integration PR."
+  - "Re-run the full seismic public I/O file after #377 is merged into the integration branch."

--- a/gwexpy/timeseries/io/seismic.py
+++ b/gwexpy/timeseries/io/seismic.py
@@ -1,4 +1,5 @@
 """Read and write ObsPy-supported seismic formats."""
+
 from __future__ import annotations
 
 import numpy as np
@@ -55,7 +56,11 @@ def _trace_to_timeseries(trace, *, unit, timezone, epoch_override):
 
 def _read_obspy_stream(format_name, source, *, pad=np.nan, gap="pad", **kwargs):
     obspy = _import_obspy()
-    if not isinstance(source, (str, bytes)) and not hasattr(source, "__fspath__") and hasattr(source, "name"):
+    if (
+        not isinstance(source, (str, bytes))
+        and not hasattr(source, "__fspath__")
+        and hasattr(source, "name")
+    ):
         source = source.name
     try:
         stream = obspy.read(source, format=format_name, **kwargs)
@@ -231,10 +236,13 @@ register_timeseries_format(
     "mseed",
     aliases=("miniseed",),
     reader_dict=read_miniseed_timeseriesdict,
-    reader_single=lambda *a, **k: _adapt_timeseries(read_miniseed_timeseriesdict, *a, **k),
+    reader_single=lambda *a, **k: _adapt_timeseries(
+        read_miniseed_timeseriesdict, *a, **k
+    ),
     reader_matrix=lambda *a, **k: _adapt_matrix(read_miniseed_timeseriesdict, *a, **k),
     writer_dict=write_miniseed,
     writer_single=lambda ts, f, **k: write_miniseed({ts.name: ts}, f, **k),
+    extension="mseed",
     auto_adapt=False,
 )
 
@@ -246,6 +254,7 @@ register_timeseries_format(
     reader_matrix=lambda *a, **k: _adapt_matrix(read_sac_timeseriesdict, *a, **k),
     writer_dict=write_sac,
     writer_single=lambda ts, f, **k: write_sac({ts.name: ts}, f, **k),
+    extension="sac",
     auto_adapt=False,
 )
 
@@ -257,6 +266,7 @@ register_timeseries_format(
     reader_matrix=lambda *a, **k: _adapt_matrix(read_gse2_timeseriesdict, *a, **k),
     writer_dict=write_gse2,
     writer_single=lambda ts, f, **k: write_gse2({ts.name: ts}, f, **k),
+    extension="gse2",
     auto_adapt=False,
 )
 
@@ -266,5 +276,6 @@ register_timeseries_format(
     reader_dict=read_knet_timeseriesdict,
     reader_single=lambda *a, **k: _adapt_timeseries(read_knet_timeseriesdict, *a, **k),
     reader_matrix=lambda *a, **k: _adapt_matrix(read_knet_timeseriesdict, *a, **k),
+    extension="knet",
     auto_adapt=False,
 )

--- a/tests/io/test_seismic_public_io.py
+++ b/tests/io/test_seismic_public_io.py
@@ -6,12 +6,26 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from gwpy.io.registry import default_registry as io_registry
 
 from gwexpy.timeseries import TimeSeries, TimeSeriesDict
 
 
 def _make_single_series():
     return TimeSeries(np.arange(8, dtype=float), sample_rate=4, name="SIG")
+
+
+@pytest.mark.parametrize("fmt", ["mseed", "sac", "gse2", "knet"])
+def test_public_seismic_extensions_auto_identify(tmp_path, fmt):
+    path = tmp_path / f"sample.{fmt}"
+    path.write_bytes(b"not a seismic payload")
+
+    assert fmt in io_registry.identify_format(
+        "read", TimeSeriesDict, str(path), None, (), {}
+    )
+    assert fmt in io_registry.identify_format(
+        "read", TimeSeries, str(path), None, (), {}
+    )
 
 
 @pytest.mark.parametrize("fmt", ["mseed", "miniseed"])
@@ -72,9 +86,9 @@ def test_win_alias_family_public_surface_is_dict_first(monkeypatch):
 
     monkeypatch.setattr(win_io, "_read_win_fixed", lambda *a, **k: stream)
 
-    assert str(next(iter(TimeSeriesDict.read("dummy.win", format="win").keys()))).endswith(
-        "A1_01"
-    )
+    assert str(
+        next(iter(TimeSeriesDict.read("dummy.win", format="win").keys()))
+    ).endswith("A1_01")
     assert str(
         next(iter(TimeSeriesDict.read("dummy.cnt", format="win32").keys()))
     ).endswith("A1_01")


### PR DESCRIPTION
Target release: **v0.1.2**
Part of: #372
Order: **07/10**
Depends on: #373, #374, #375, #376, #377, #378
Closes: #367

## Summary
- Register extension identifiers for `mseed`, `sac`, `gse2`, and `knet`.
- Add registry auto-identify coverage that does not require reading payloads.
- Keep ObsPy optional-dependency behavior and seismic parsing unchanged.
- Add an audit manifest for the v0.1.2 release queue.

## Validation
- `rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_seismic_public_io.py::test_public_seismic_extensions_auto_identify tests/io/test_seismic_public_io.py::test_mseed_public_dict_roundtrip_and_alias tests/io/test_seismic_public_io.py::test_obsby_backed_public_dict_roundtrip tests/io/test_seismic_public_io.py::test_knet_public_surface_is_dict_first tests/io/test_io_contract.py::test_current_public_boundary_decisions_are_recorded tests/io/test_io_improvements.py::test_register_timeseries_format_auto_adapt tests/io/test_io_improvements.py::test_register_timeseries_format_aliases_do_not_duplicate_identifiers -p no:cacheprovider` -> 12 passed
- `rtk ruff check gwexpy/timeseries/io/seismic.py tests/io/test_seismic_public_io.py` -> no issues
- `rtk ruff format --check gwexpy/timeseries/io/seismic.py tests/io/test_seismic_public_io.py` -> already formatted
- `rtk python -c "import yaml; yaml.safe_load(open('docs/developers/plans/manifests/audit-manifest-367-seismic-auto-identify.yaml', encoding='utf-8'))"` -> parsed
- `rtk git diff --check` -> clean

## Dependency-Gated Check
- `tests/io/test_seismic_public_io.py` as a whole still hits the known `ats.mth5` AttributeError on main; that is fixed by prerequisite #377. This PR is intentionally scoped to seismic extension registration.

## Review Notes
- Registry metadata only; no data parsing, numerical behavior, physics, units, timestamps, or statistics changed.
