### PR TITLE
[AGENT:validation] Parse SegmentTable span CSV values

### DIFF
--- a/docs/developers/plans/manifests/audit-manifest-365-segmenttable-span-csv.yaml
+++ b/docs/developers/plans/manifests/audit-manifest-365-segmenttable-span-csv.yaml
@@ -1,0 +1,72 @@
+issue: 365
+title: "Parse span column in SegmentTable.read_csv"
+branch: codex/issue-365-segmenttable-span-csv
+date: 2026-05-07
+agent: Codex
+target_release: v0.1.2
+release_order: "08/10"
+tracker: 372
+depends_on:
+  issues:
+    - 357
+    - 371
+    - 356
+    - 363
+    - 364
+    - 366
+    - 367
+  pull_requests:
+    - 373
+    - 374
+    - 375
+    - 376
+    - 377
+    - 378
+    - 379
+skills:
+  - github:github
+  - task-planner
+  - code-reviewer-pro
+  - release-coordinator
+  - superpowers:test-driven-development
+  - superpowers:using-git-worktrees
+scope:
+  summary: "Allow SegmentTable.read_csv to parse simple serialized span columns."
+  included:
+    - "Parse span strings in '(start, end)', 'Segment(start, end)', and '[start ... end)' forms."
+    - "Keep start/end CSV construction behavior intact."
+    - "Raise a clear ValueError for unparseable span strings."
+    - "Add focused regression coverage for span-column CSV input."
+  excluded:
+    - "No SegmentTable.write implementation or HDF5 persistence work from #355."
+    - "No changes to SegmentTable constructor type validation outside read_csv coercion."
+    - "No release publication, tagging, PyPI/TestPyPI upload, or build artifacts."
+changed_files:
+  - path: gwexpy/table/segment_table.py
+    change: "Added read_csv span-string coercion helpers before constructor validation."
+  - path: tests/table/test_segment_table_new.py
+    change: "Added span-column CSV parse and invalid-span regression tests."
+  - path: docs/developers/plans/manifests/audit-manifest-365-segmenttable-span-csv.yaml
+    change: "Recorded release target, dependency order, scope, validation, and review notes."
+validation:
+  red:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/table/test_segment_table_new.py::test_segment_table_read_csv_parses_span_column -p no:cacheprovider"
+      result: "1 failed; span strings reached SegmentTable constructor as str before implementation."
+  completed:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/table/test_segment_table_new.py tests/table/test_segment_table.py::TestSegmentTableInit tests/table/test_segment_table.py::TestSegmentTableFactory tests/table/test_segment_table_contracts.py -p no:cacheprovider"
+      result: "21 passed."
+    - cmd: "rtk ruff check gwexpy/table/segment_table.py tests/table/test_segment_table_new.py"
+      result: "No issues found."
+    - cmd: "rtk ruff format --check gwexpy/table/segment_table.py tests/table/test_segment_table_new.py"
+      result: "2 files already formatted."
+review:
+  human_review_required: false
+  physics_review_required: false
+  statistics_metadata_review_required: false
+  rationale: "CSV parsing/validation change only; no segment algebra, numerical calculations, physics, units, or statistics changed."
+release_notes:
+  target: "v0.1.2 hotfix integration release"
+  user_visible_change: "SegmentTable.read_csv now accepts simple serialized span columns instead of failing with a constructor TypeError."
+deferred_follow_ups:
+  - "Keep #365 behind #373, #374, #375, #376, #377, #378, and #379 in the v0.1.2 integration PR."
+  - "Handle SegmentTable.write and HDF5 persistence only in #355 or a later feature PR."

--- a/gwexpy/table/segment_table.py
+++ b/gwexpy/table/segment_table.py
@@ -6,6 +6,7 @@ values or heavy *payload* objects such as :class:`~gwpy.timeseries.TimeSeries`.
 Payload columns are stored as :class:`~gwexpy.table.segment_cell.SegmentCell`
 instances that support lazy loading and optional caching.
 """
+
 from __future__ import annotations
 
 import copy
@@ -32,6 +33,50 @@ _PAYLOAD_KINDS = frozenset(
 
 #: All valid kinds.
 _ALL_KINDS = _META_KINDS | _PAYLOAD_KINDS
+
+
+def _parse_span_string(value: str) -> Any:
+    """Parse simple serialized Segment forms used in CSV files."""
+    from gwpy.segments import Segment
+
+    text = value.strip()
+    if text.startswith("Segment(") and text.endswith(")"):
+        inner = text[len("Segment(") : -1]
+    elif len(text) >= 2 and text[0] in "([" and text[-1] in ")]":
+        inner = text[1:-1]
+    else:
+        raise ValueError(
+            "Could not parse SegmentTable 'span' value "
+            f"{value!r}; expected '(start, end)', 'Segment(start, end)', "
+            "or '[start ... end)'."
+        )
+
+    separator = "..." if "..." in inner else ","
+    parts = [part.strip() for part in inner.split(separator)]
+    if len(parts) != 2:
+        raise ValueError(
+            "Could not parse SegmentTable 'span' value "
+            f"{value!r}; expected exactly two endpoints."
+        )
+
+    try:
+        start, end = (float(part) for part in parts)
+    except ValueError as exc:
+        raise ValueError(
+            "Could not parse SegmentTable 'span' value "
+            f"{value!r}; endpoints must be numeric."
+        ) from exc
+    return Segment(start, end)
+
+
+def _coerce_span_value(value: Any) -> Any:
+    from gwpy.segments import Segment
+
+    if isinstance(value, Segment):
+        return value
+    if isinstance(value, str):
+        return _parse_span_string(value)
+    return value
 
 
 # ---------------------------------------------------------------------------
@@ -206,7 +251,9 @@ class SegmentTable:
                     f"Length of '{name}' ({len(data)}) does not match "
                     f"number of segments ({n})."
                 )
-        df = pd.DataFrame({"span": list(segments), **{k: list(v) for k, v in meta_columns.items()}})
+        df = pd.DataFrame(
+            {"span": list(segments), **{k: list(v) for k, v in meta_columns.items()}}
+        )
         return cls(df)
 
     @classmethod
@@ -241,9 +288,7 @@ class SegmentTable:
             df = pd.DataFrame(table)
 
         if span not in df.columns:
-            raise ValueError(
-                f"Column {span!r} not found in provided table."
-            )
+            raise ValueError(f"Column {span!r} not found in provided table.")
         if span != "span":
             df = df.rename(columns={span: "span"})
         return cls(df)
@@ -280,6 +325,8 @@ class SegmentTable:
         if "span" not in df.columns:
             s1, s2 = span_cols
             df["span"] = [Segment(float(s), float(e)) for s, e in zip(df[s1], df[s2])]
+        else:
+            df["span"] = [_coerce_span_value(value) for value in df["span"]]
         return cls(df)
 
     # Alias for backward compatibility or ease of use
@@ -332,7 +379,9 @@ class SegmentTable:
         self,
         name: str,
         data: Optional[Sequence[Any]] = None,
-        loader: Optional[Union[Sequence[Callable[[], Any]], Callable[[int], Callable[[], Any]]]] = None,
+        loader: Optional[
+            Union[Sequence[Callable[[], Any]], Callable[[int], Callable[[], Any]]]
+        ] = None,
         kind: str = "timeseries",
     ) -> None:
         """Add a payload column (lazy-loadable).
@@ -370,9 +419,7 @@ class SegmentTable:
                 f"Must be one of: {sorted(_PAYLOAD_KINDS)}."
             )
         if data is None and loader is None:
-            raise ValueError(
-                "At least one of 'data' or 'loader' must be provided."
-            )
+            raise ValueError("At least one of 'data' or 'loader' must be provided.")
 
         n = len(self)
 
@@ -400,9 +447,11 @@ class SegmentTable:
                 # Standard pattern: loader(segment) -> payload
                 for i in range(n):
                     seg = self._meta.at[i, "span"]
+
                     # Capture current segment in a closure
                     def _wrap_loader(s=seg, ldr=loader):
                         return ldr(s)
+
                     cells.append(SegmentCell(loader=_wrap_loader))
             else:
                 # Sequence of callables
@@ -821,7 +870,12 @@ class SegmentTable:
         df = self._meta.copy()
         if not meta_only:
             for col, cells in self._payload.items():
-                df[col] = [c.get() if c.is_loaded() else c._summary(self._schema.get(col, "object")) for c in cells]
+                df[col] = [
+                    c.get()
+                    if c.is_loaded()
+                    else c._summary(self._schema.get(col, "object"))
+                    for c in cells
+                ]
         return df
 
     def copy(self, deep: bool = False) -> SegmentTable:
@@ -906,7 +960,9 @@ class SegmentTable:
         """Scatter plot of two scalar columns."""
         from gwexpy.table.segment_plot import scatter_segment_table
 
-        return scatter_segment_table(self, x, y, color=color, selection=selection, **kwargs)
+        return scatter_segment_table(
+            self, x, y, color=color, selection=selection, **kwargs
+        )
 
     def hist(
         self,
@@ -948,7 +1004,9 @@ class SegmentTable:
         """Overlay payload from multiple rows."""
         from gwexpy.table.segment_plot import overlay_segment_table
 
-        return overlay_segment_table(self, column, rows, separate=separate, sharex=sharex, **kwargs)
+        return overlay_segment_table(
+            self, column, rows, separate=separate, sharex=sharex, **kwargs
+        )
 
     def overlay_spectra(
         self,
@@ -999,7 +1057,6 @@ class SegmentTable:
     # Display
     # ------------------------------------------------------------------
 
-
     def __repr__(self) -> str:
         n_rows = len(self)
         n_payload = len(self._payload)
@@ -1013,7 +1070,9 @@ class SegmentTable:
         else:
             span_summary = "[]"
 
-        col_display = str(all_cols) if n_cols <= 8 else str(all_cols[:8])[:-1] + ", ...]"
+        col_display = (
+            str(all_cols) if n_cols <= 8 else str(all_cols[:8])[:-1] + ", ...]"
+        )
         return (
             f"SegmentTable(n_rows={n_rows}, n_cols={n_cols}, payload={n_payload}, "
             f"columns={col_display})\n"
@@ -1113,6 +1172,7 @@ def _infer_kind(values: list[Any]) -> str:
     if isinstance(sample, FrequencySeries):
         return "frequencyseries"
     import numbers
+
     if isinstance(sample, (str, bool, numbers.Number)):
         return "meta"
     return "object"

--- a/tests/table/test_segment_table_new.py
+++ b/tests/table/test_segment_table_new.py
@@ -9,11 +9,9 @@ from gwexpy.table import SegmentTable
 def test_segment_table_read_csv(tmp_path):
     # Prepare sample CSV
     csv_path = tmp_path / "test_segments.csv"
-    df = pd.DataFrame({
-        "start": [100.0, 200.0],
-        "end": [110.0, 210.0],
-        "label": ["A", "B"]
-    })
+    df = pd.DataFrame(
+        {"start": [100.0, 200.0], "end": [110.0, 210.0], "label": ["A", "B"]}
+    )
     df.to_csv(csv_path, index=False)
 
     # Load via read_csv
@@ -24,6 +22,32 @@ def test_segment_table_read_csv(tmp_path):
     assert isinstance(st.row(0)["span"], Segment)
     assert st.row(0)["span"].start == 100.0
     assert st.row(1)["label"] == "B"
+
+
+def test_segment_table_read_csv_parses_span_column(tmp_path):
+    csv_path = tmp_path / "spans.csv"
+    csv_path.write_text(
+        'span,label\n"(0, 1)",A\n"Segment(2, 3)",B\n"[4 ... 5)",C\n',
+        encoding="utf-8",
+    )
+
+    st = SegmentTable.read_csv(csv_path)
+
+    assert [st.row(i)["span"] for i in range(3)] == [
+        Segment(0, 1),
+        Segment(2, 3),
+        Segment(4, 5),
+    ]
+    assert [st.row(i)["label"] for i in range(3)] == ["A", "B", "C"]
+
+
+def test_segment_table_read_csv_rejects_unparseable_span_column(tmp_path):
+    csv_path = tmp_path / "bad_spans.csv"
+    csv_path.write_text("span,label\nnot-a-span,A\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Could not parse SegmentTable 'span' value"):
+        SegmentTable.read_csv(csv_path)
+
 
 def test_segment_table_iteration():
     segs = [Segment(0, 5), Segment(5, 10)]
@@ -38,6 +62,7 @@ def test_segment_table_iteration():
     # Test list comprehension usage
     metas = [row["meta"] for row in st]
     assert metas == [1, 2]
+
 
 def test_segment_table_add_series_loader_segment():
     segs = [Segment(0, 5), Segment(5, 10)]


### PR DESCRIPTION
Target release: **v0.1.2**
Part of: #372
Order: **08/10**
Depends on: #373, #374, #375, #376, #377, #378, #379
Closes: #365

## Summary
- Parse simple serialized `span` values in `SegmentTable.read_csv`.
- Supported forms: `(start, end)`, `Segment(start, end)`, and `[start ... end)`.
- Keep existing `start,end` CSV behavior intact.
- Raise a clear `ValueError` for unparseable span strings.
- Add an audit manifest for the v0.1.2 release queue.

## Validation
- `rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/table/test_segment_table_new.py tests/table/test_segment_table.py::TestSegmentTableInit tests/table/test_segment_table.py::TestSegmentTableFactory tests/table/test_segment_table_contracts.py -p no:cacheprovider` -> 21 passed
- `rtk ruff check gwexpy/table/segment_table.py tests/table/test_segment_table_new.py` -> no issues
- `rtk ruff format --check gwexpy/table/segment_table.py tests/table/test_segment_table_new.py` -> already formatted
- `rtk python -c "import yaml; yaml.safe_load(open('docs/developers/plans/manifests/audit-manifest-365-segmenttable-span-csv.yaml', encoding='utf-8'))"` -> parsed
- `rtk git diff --check` -> clean

## Review Notes
- CSV parsing/validation only; no `SegmentTable.write`, HDF5 persistence, segment algebra, physics, units, or statistics changed.
