### PR TITLE
[AGENT:validation] Fix FrequencySeries DTT XML autodetect

### DIFF
--- a/docs/developers/plans/manifests/audit-manifest-362-frequency-dttxml-identify.yaml
+++ b/docs/developers/plans/manifests/audit-manifest-362-frequency-dttxml-identify.yaml
@@ -1,0 +1,80 @@
+issue: 362
+title: "Fix FrequencySeries DTT XML auto-identify gaps"
+branch: codex/issue-362-frequency-dttxml-identify
+date: 2026-05-07
+agent: Codex
+target_release: v0.1.2
+release_order: "09/10"
+tracker: 372
+depends_on:
+  issues:
+    - 357
+    - 371
+    - 356
+    - 363
+    - 364
+    - 366
+    - 367
+    - 365
+  pull_requests:
+    - 373
+    - 374
+    - 375
+    - 376
+    - 377
+    - 378
+    - 379
+    - 380
+skills:
+  - github:github
+  - task-planner
+  - code-reviewer-pro
+  - release-coordinator
+  - superpowers:test-driven-development
+  - superpowers:using-git-worktrees
+scope:
+  summary: "Route FrequencySeries and FrequencySeriesDict DTT XML auto-detected inputs to the existing DTT XML reader."
+  included:
+    - "Add shared .xml/.xml.gz DTT XML source detection for frequency-domain DTT XML handling."
+    - "Route FrequencySeriesDict.read('*.xml') through read_frequencyseriesdict_dttxml when format is omitted."
+    - "Route FrequencySeries.read('*.xml.gz') through the DTT XML reader when format is omitted."
+    - "Keep existing explicit xml.diaggui/dttxml behavior and TimeSeries DTT XML tests intact."
+  excluded:
+    - "No GWF, frame, or nproc behavior changes."
+    - "No broad public API expansion beyond current frequency-domain DTT XML contract."
+    - "No release publication, tagging, PyPI/TestPyPI upload, or build artifacts."
+changed_files:
+  - path: gwexpy/frequencyseries/io/dttxml.py
+    change: "Added shared DTT XML filename detection and reused it in registered identifiers."
+  - path: gwexpy/frequencyseries/frequencyseries.py
+    change: "Used the shared detector so FrequencySeries.read handles .xml and .xml.gz auto-detected DTT XML inputs."
+  - path: gwexpy/frequencyseries/collections.py
+    change: "Used the shared detector so FrequencySeriesDict.read routes auto-detected DTT XML inputs without relying on registry identification."
+  - path: tests/io/test_frequencyseries_io.py
+    change: "Added FrequencySeriesDict .xml and FrequencySeries .xml.gz auto-detect regressions."
+  - path: docs/developers/plans/manifests/audit-manifest-362-frequency-dttxml-identify.yaml
+    change: "Recorded release target, dependency order, scope, validation, and review notes."
+validation:
+  red:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_frequencyseries_io.py::TestFrequencySeriesDttxml -p no:cacheprovider"
+      result: "2 failed, 8 passed; FrequencySeriesDict .xml and FrequencySeries .xml.gz auto-detect fell through to IORegistryError before implementation."
+  completed:
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_frequencyseries_io.py::TestFrequencySeriesDttxml tests/io/test_dttxml_reader.py -p no:cacheprovider"
+      result: "24 passed."
+    - cmd: "rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_frequencyseries_io.py tests/io/test_dttxml_reader.py tests/io/test_dttxml_common.py -p no:cacheprovider"
+      result: "45 passed."
+    - cmd: "rtk ruff check gwexpy/frequencyseries/io/dttxml.py gwexpy/frequencyseries/frequencyseries.py gwexpy/frequencyseries/collections.py tests/io/test_frequencyseries_io.py"
+      result: "No issues found."
+    - cmd: "rtk ruff format --check gwexpy/frequencyseries/io/dttxml.py gwexpy/frequencyseries/frequencyseries.py gwexpy/frequencyseries/collections.py tests/io/test_frequencyseries_io.py"
+      result: "4 files already formatted."
+review:
+  human_review_required: false
+  physics_review_required: false
+  statistics_metadata_review_required: false
+  rationale: "DTT XML dispatch/identifier consistency change only; no data parsing semantics, numerical behavior, physics, units, or statistics changed."
+release_notes:
+  target: "v0.1.2 hotfix integration release"
+  user_visible_change: "FrequencySeriesDict.read('*.xml') and FrequencySeries.read('*.xml.gz') now route consistently to the DTT XML reader."
+deferred_follow_ups:
+  - "Keep #362 behind #373, #374, #375, #376, #377, #378, #379, and #380 in the v0.1.2 integration PR."
+  - "Do not broaden frequency-domain DTT XML public API claims without a separate contract/documentation PR."

--- a/gwexpy/frequencyseries/collections.py
+++ b/gwexpy/frequencyseries/collections.py
@@ -249,9 +249,11 @@ class FrequencySeriesBaseDict(OrderedDict[str, _FS]):
                         orig_key = keymap.get(grp_name, grp_name)
                         out[orig_key] = fs
                     return out
-        if fmt in ("xml.diaggui", "dttxml"):
-            from .io.dttxml import read_frequencyseriesdict_dttxml
+        from .io.dttxml import _looks_like_dttxml, read_frequencyseriesdict_dttxml
 
+        if fmt in ("xml.diaggui", "dttxml") or (
+            fmt is None and _looks_like_dttxml(source)
+        ):
             return read_frequencyseriesdict_dttxml(source, *args, **kwargs)
         from astropy.io import registry
 
@@ -537,7 +539,9 @@ class FrequencySeriesDict(DictMapMixin, FrequencySeriesBaseDict[FrequencySeries]
 
         from gwexpy.interop import from_finesse_frequency_response
 
-        return cast(FrequencySeriesDict, from_finesse_frequency_response(cls, sol, unit=unit))
+        return cast(
+            FrequencySeriesDict, from_finesse_frequency_response(cls, sol, unit=unit)
+        )
 
     @classmethod
     def from_finesse_noise(
@@ -561,7 +565,9 @@ class FrequencySeriesDict(DictMapMixin, FrequencySeriesBaseDict[FrequencySeries]
 
         from gwexpy.interop import from_finesse_noise
 
-        return cast(FrequencySeriesDict, from_finesse_noise(cls, sol, output=output, unit=unit))
+        return cast(
+            FrequencySeriesDict, from_finesse_noise(cls, sol, output=output, unit=unit)
+        )
 
     # ===============================
     # 8. PySpice Interop
@@ -642,7 +648,10 @@ class FrequencySeriesDict(DictMapMixin, FrequencySeriesBaseDict[FrequencySeries]
 
         from gwexpy.interop import from_skrf_network
 
-        return cast(FrequencySeriesDict, from_skrf_network(cls, ntwk, parameter=parameter, unit=unit))
+        return cast(
+            FrequencySeriesDict,
+            from_skrf_network(cls, ntwk, parameter=parameter, unit=unit),
+        )
 
     def write(self, target: str, *args: Any, **kwargs: Any) -> Any:
         """Write dict to file (HDF5, ROOT, etc.)."""

--- a/gwexpy/frequencyseries/frequencyseries.py
+++ b/gwexpy/frequencyseries/frequencyseries.py
@@ -5,10 +5,10 @@ Representation of a frequency series.
 This module extends `gwpy.frequencyseries.FrequencySeries` with matrix support,
 enhanced signal analysis, fitting capabilities, and deep metadata propagation.
 """
+
 from __future__ import annotations
 
 from enum import Enum
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, SupportsIndex, TypeVar, cast
 
 import numpy as np
@@ -140,12 +140,11 @@ class FrequencySeries(
     def read(cls, source, *args, **kwargs):  # type: ignore[override]
         """Read a ``FrequencySeries`` from a supported source."""
         fmt = kwargs.get("format")
-        source_path = Path(source) if isinstance(source, (str, Path)) else None
-        if fmt in ("xml.diaggui", "dttxml") or (
-            fmt is None and source_path is not None and source_path.suffix.lower() == ".xml"
-        ):
-            from .io.dttxml import read_frequencyseriesdict_dttxml
+        from .io.dttxml import _looks_like_dttxml, read_frequencyseriesdict_dttxml
 
+        if fmt in ("xml.diaggui", "dttxml") or (
+            fmt is None and _looks_like_dttxml(source)
+        ):
             fsd = read_frequencyseriesdict_dttxml(source, *args, **kwargs)
             if not fsd:
                 raise ValueError("No channels found in xml.diaggui")
@@ -1034,9 +1033,7 @@ class FrequencySeries(
             epoch=self.epoch,
         )
 
-    def to_control_frd(
-        self, frequency_unit: Literal["rad/s", "Hz"] = "Hz"
-    ) -> Any:
+    def to_control_frd(self, frequency_unit: Literal["rad/s", "Hz"] = "Hz") -> Any:
         """Convert to control.FRD."""
         from gwexpy.interop import to_control_frd
 
@@ -1656,7 +1653,9 @@ class FrequencySeries(
 
 # Preserve the inherited Unified I/O docstring structure so Astropy can
 # append format tables during reader/writer registration.
-_frequencyseries_read_func = getattr(FrequencySeries.read, "__func__", FrequencySeries.read)
+_frequencyseries_read_func = getattr(
+    FrequencySeries.read, "__func__", FrequencySeries.read
+)
 _frequencyseries_read_func.__doc__ = BaseFrequencySeries.read.__doc__
 
 

--- a/gwexpy/frequencyseries/io/dttxml.py
+++ b/gwexpy/frequencyseries/io/dttxml.py
@@ -1,4 +1,5 @@
 """Frequency-domain DTT XML reader."""
+
 from __future__ import annotations
 
 from datetime import UTC
@@ -25,6 +26,15 @@ from ..frequencyseries import FrequencySeries
 from ..matrix import FrequencySeriesMatrix
 
 _DTTXML_FORMATS = ("xml.diaggui", "dttxml")
+
+
+def _looks_like_dttxml(source) -> bool:
+    if source is None:
+        return False
+    if hasattr(source, "name"):
+        source = source.name
+    source_text = str(source).lower()
+    return source_text.endswith(".xml") or source_text.endswith(".xml.gz")
 
 
 def _build_epoch(value, timezone):
@@ -249,10 +259,10 @@ for _fmt in _DTTXML_FORMATS:
 io_registry.register_identifier(
     "xml.diaggui",
     FrequencySeries,
-    lambda *args, **kwargs: str(args[1]).endswith(".xml"),
+    lambda *args, **kwargs: _looks_like_dttxml(args[1] if len(args) > 1 else None),
 )
 io_registry.register_identifier(
     "xml.diaggui",
     FrequencySeriesDict,
-    lambda *args, **kwargs: str(args[1]).endswith(".xml"),
+    lambda *args, **kwargs: _looks_like_dttxml(args[1] if len(args) > 1 else None),
 )

--- a/tests/io/test_frequencyseries_io.py
+++ b/tests/io/test_frequencyseries_io.py
@@ -15,7 +15,10 @@ class TestFrequencySeriesHdf5:
     def test_roundtrip(self, tmp_path):
         fs = FrequencySeries(
             np.array([1.0, 2.0, 3.0, 4.0]),
-            f0=0, df=10, unit="1/Hz", name="test_psd",
+            f0=0,
+            df=10,
+            unit="1/Hz",
+            name="test_psd",
         )
         path = tmp_path / "fs.hdf5"
         fs.write(str(path), format="hdf5")
@@ -24,14 +27,22 @@ class TestFrequencySeriesHdf5:
         assert np.isclose(fs2.df.value, fs.df.value)
 
     def test_dict_roundtrip(self, tmp_path):
-        fsd = FrequencySeriesDict({
-            "H1:ASD": FrequencySeries(
-                np.arange(5.0), frequencies=np.arange(5.0), unit="1", name="H1:ASD",
-            ),
-            "L1:ASD": FrequencySeries(
-                np.arange(5.0) * 2, frequencies=np.arange(5.0), unit="1", name="L1:ASD",
-            ),
-        })
+        fsd = FrequencySeriesDict(
+            {
+                "H1:ASD": FrequencySeries(
+                    np.arange(5.0),
+                    frequencies=np.arange(5.0),
+                    unit="1",
+                    name="H1:ASD",
+                ),
+                "L1:ASD": FrequencySeries(
+                    np.arange(5.0) * 2,
+                    frequencies=np.arange(5.0),
+                    unit="1",
+                    name="L1:ASD",
+                ),
+            }
+        )
         path = tmp_path / "fsd.hdf5"
         fsd.write(str(path), format="hdf5")
         fsd2 = FrequencySeriesDict.read(str(path), format="hdf5")
@@ -86,6 +97,24 @@ class TestFrequencySeriesDttxml:
         with pytest.raises(ValueError, match="products"):
             FrequencySeries.read(str(dummy))
 
+    def test_frequencyseriesdict_auto_detected_xml_reaches_dttxml_reader(
+        self, tmp_path
+    ):
+        dummy = tmp_path / "dummy.xml"
+        dummy.write_text("<dttxml></dttxml>")
+        with pytest.raises(ValueError, match="products"):
+            FrequencySeriesDict.read(str(dummy))
+
+    def test_frequencyseries_auto_detected_xml_gz_reaches_dttxml_reader(self, tmp_path):
+        import gzip
+
+        dummy = tmp_path / "dummy.xml.gz"
+        with gzip.open(dummy, "wb") as fp:
+            fp.write(b"<dttxml></dttxml>")
+
+        with pytest.raises(ValueError, match="products"):
+            FrequencySeries.read(str(dummy))
+
     def test_legacy_alias_resolves_to_canonical_reader(self):
         from gwpy.io.registry import default_registry as io_registry
 
@@ -99,7 +128,10 @@ class TestFrequencySeriesCsv:
     def test_roundtrip_with_metadata(self, tmp_path):
         fs = FrequencySeries(
             np.array([10.0, 20.0, 30.0]),
-            f0=0, df=5, unit="m/Hz", name="csv_test",
+            f0=0,
+            df=5,
+            unit="m/Hz",
+            name="csv_test",
         )
         path = tmp_path / "fs.csv"
         fs.write(str(path), format="csv")


### PR DESCRIPTION
Target release: **v0.1.2**
Part of: #372
Order: **09/10**
Depends on: #373, #374, #375, #376, #377, #378, #379, #380
Closes: #362

## Summary
- Add shared `.xml` / `.xml.gz` DTT XML detection for frequency-domain DTT XML handling.
- Route `FrequencySeriesDict.read('*.xml')` through the existing DTT XML reader when `format` is omitted.
- Route `FrequencySeries.read('*.xml.gz')` consistently through DTT XML handling.
- Keep public API scope limited to the existing frequency-domain DTT XML contract.
- Add an audit manifest for the v0.1.2 release queue.

## Validation
- `rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_frequencyseries_io.py::TestFrequencySeriesDttxml tests/io/test_dttxml_reader.py -p no:cacheprovider` -> 24 passed
- `rtk env MPLCONFIGDIR=/tmp/gwexpy-mpl pytest -q tests/io/test_frequencyseries_io.py tests/io/test_dttxml_reader.py tests/io/test_dttxml_common.py -p no:cacheprovider` -> 45 passed
- `rtk ruff check gwexpy/frequencyseries/io/dttxml.py gwexpy/frequencyseries/frequencyseries.py gwexpy/frequencyseries/collections.py tests/io/test_frequencyseries_io.py` -> no issues
- `rtk ruff format --check gwexpy/frequencyseries/io/dttxml.py gwexpy/frequencyseries/frequencyseries.py gwexpy/frequencyseries/collections.py tests/io/test_frequencyseries_io.py` -> already formatted
- `rtk python -c "import yaml; yaml.safe_load(open('docs/developers/plans/manifests/audit-manifest-362-frequency-dttxml-identify.yaml', encoding='utf-8'))"` -> parsed
- `rtk git diff --check` -> clean

## Review Notes
- Dispatch/identifier consistency only; no DTT XML product parsing semantics, numerical behavior, physics, units, or statistics changed.
