### PR TITLE
[AGENT:validation] Fix stale I/O examples in docs

### DIFF
--- a/docs/developers/plans/manifests/audit-manifest-369-docs-io-examples.yaml
+++ b/docs/developers/plans/manifests/audit-manifest-369-docs-io-examples.yaml
@@ -1,0 +1,91 @@
+issue: 369
+tracker: 372
+branch: codex/issue-369-docs-io-examples
+date: 2026-05-07
+agent: Codex
+skills:
+  - github:github
+  - task-planner
+  - code-reviewer-pro
+  - release-coordinator
+  - superpowers:test-driven-development
+  - superpowers:using-git-worktrees
+  - superpowers:executing-plans
+target_release: v0.1.2
+release_order: "10/10"
+depends_on_prs:
+  - 373
+  - 374
+  - 375
+  - 376
+  - 377
+  - 378
+  - 379
+  - 380
+  - 381
+scope:
+  summary: "Fix stale I/O examples in landing pages and tutorials for the v0.1.2 hotfix lane."
+  runtime_code_changed: false
+  physics_behavior_changed: false
+  public_api_changed: false
+  docs_changed: true
+  tests_changed: true
+  included:
+    - "Correct landing-page FrequencySeriesMatrix imports to use gwexpy.frequencyseries."
+    - "Remove a tutorial example that presents an NDS channel name as a TimeSeries.read path."
+    - "Align the seismic ObsPy tutorial with the public TimeSeriesDict reader boundary for mseed and sac."
+    - "Add docs contract guards for these examples."
+  excluded:
+    - "No runtime I/O implementation changes."
+    - "No DTT XML paper/manuscript claim changes beyond the v0.1.2 issue scope."
+    - "No distribution packaging or release publication."
+commands:
+  - cmd: "rtk pytest tests/io/test_io_docs_contract_sync.py -q"
+    result: "RED: 5 passed, 3 failed before docs edits; failures covered stale landing import, NDS channel-as-path example, and seismic TimeSeries.read examples."
+  - cmd: "rtk pytest tests/io/test_io_docs_contract_sync.py -q"
+    result: "GREEN: 8 passed after docs edits."
+  - cmd: "rtk rg -n <stale docs patterns> docs/index.rst docs/web/en/index.rst docs/web/ja/index.rst docs/web/en/user_guide/tutorials/case_schumann_resonance.ipynb docs/web/en/user_guide/tutorials/case_seismic_obspy.ipynb"
+    result: "No stale examples found in the changed docs."
+  - cmd: "rtk python -m json.tool docs/web/en/user_guide/tutorials/case_schumann_resonance.ipynb"
+    result: "Notebook JSON parsed successfully."
+  - cmd: "rtk python -m json.tool docs/web/en/user_guide/tutorials/case_seismic_obspy.ipynb"
+    result: "Notebook JSON parsed successfully."
+  - cmd: "rtk python -c \"from gwexpy.frequencyseries import FrequencySeriesMatrix; print(FrequencySeriesMatrix.__name__)\""
+    result: "Import smoke passed; command emitted an existing matplotlib writable-cache warning before printing FrequencySeriesMatrix."
+changed_files:
+  - path: docs/index.rst
+    change: "Corrected the quick-demo FrequencySeriesMatrix import."
+  - path: docs/web/en/index.rst
+    change: "Corrected the English landing-page FrequencySeriesMatrix import."
+  - path: docs/web/ja/index.rst
+    change: "Corrected the Japanese landing-page FrequencySeriesMatrix import."
+  - path: docs/web/en/user_guide/tutorials/case_schumann_resonance.ipynb
+    change: "Replaced the NDS channel-name TimeSeries.read example with NDS/GWOSC fetch workflow wording."
+  - path: docs/web/en/user_guide/tutorials/case_seismic_obspy.ipynb
+    change: "Changed MiniSEED/SAC read examples from TimeSeries.read to TimeSeriesDict.read using canonical mseed and sac format names."
+  - path: tests/io/test_io_docs_contract_sync.py
+    change: "Added docs regression guards for stale landing imports, channel-name read examples, and seismic public reader boundaries."
+validation:
+  completed:
+    - cmd: "rtk pytest tests/io/test_io_docs_contract_sync.py -q"
+      result: "8 passed."
+    - cmd: "rtk ruff check tests/io/test_io_docs_contract_sync.py"
+      result: "No issues found."
+    - cmd: "rtk ruff format --check tests/io/test_io_docs_contract_sync.py"
+      result: "1 file already formatted after applying ruff format."
+    - cmd: "rtk python -m json.tool docs/web/en/user_guide/tutorials/case_schumann_resonance.ipynb"
+      result: "parsed successfully."
+    - cmd: "rtk python -m json.tool docs/web/en/user_guide/tutorials/case_seismic_obspy.ipynb"
+      result: "parsed successfully."
+    - cmd: "rtk python -c \"from gwexpy.frequencyseries import FrequencySeriesMatrix; print(FrequencySeriesMatrix.__name__)\""
+      result: "printed FrequencySeriesMatrix."
+    - cmd: "rtk python -c \"import pathlib, yaml; yaml.safe_load(pathlib.Path('docs/developers/plans/manifests/audit-manifest-369-docs-io-examples.yaml').read_text())\""
+      result: "parsed successfully."
+    - cmd: "rtk git diff --check"
+      result: "clean."
+human_review:
+  required: false
+  reason: "Docs/test-only correction; no runtime, physics, statistical, or data model behavior changed."
+deferred:
+  - "Track paper/manuscript DTT XML overclaims separately from this hotfix-scoped docs issue."
+  - "Track broader verification-doc coverage overclaims separately from this hotfix-scoped docs issue."

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -93,7 +93,7 @@ Quick Demo
 
 .. code-block:: python
 
-   from gwexpy.timeseries import FrequencySeriesMatrix
+   from gwexpy.frequencyseries import FrequencySeriesMatrix
    fsmtx = FrequencySeriesMatrix.read("data.hdf5")
    fsmtx.fit(model="lorentzian").plot()
 

--- a/docs/web/en/index.rst
+++ b/docs/web/en/index.rst
@@ -66,7 +66,7 @@ v\ |release| · Python ≥ 3.11 · Last updated: |today|
      </section>
      <section class="gw-hub-panel">
        <p>3-line demo</p>
-       <pre><code>from gwexpy.timeseries import FrequencySeriesMatrix
+       <pre><code>from gwexpy.frequencyseries import FrequencySeriesMatrix
     fsmtx = FrequencySeriesMatrix.read("data.hdf5")
     fsmtx[2, 0].fit(model="lorentzian").plot()</code></pre>
      </section>

--- a/docs/web/en/user_guide/tutorials/case_schumann_resonance.ipynb
+++ b/docs/web/en/user_guide/tutorials/case_schumann_resonance.ipynb
@@ -675,7 +675,7 @@
     "\n",
     "### Next steps\n",
     "\n",
-    "- Load real data: `TimeSeries.read('K1:PEM-MAG_EXV_EAST_X_DQ', start, end)`.\n",
+    "- Load real data with the NDS/GWOSC fetch workflow, then pass the resulting `TimeSeries` into this analysis.\n",
     "- Compute multi-channel Schumann coherence with `BifrequencyMap.propagate()` to\n",
     "  estimate the magnetic coupling contribution to DARM noise.\n",
     "- Track daily/seasonal variations by looping over GPS time segments."
@@ -690,7 +690,7 @@
     ]
    },
    "source": [
-    "## まとめ\n\n| ステップ | ツール | 出力 |\n|---------|--------|------|\n| ロバスト PSD | `bootstrap_spectrogram(return_map=True)` | 中央値 PSD + 1σ 帯 |\n| 不確かさモデル | `BifrequencyMap` (ブートストラップから) | 周波数ビン間共分散行列 |\n| ピーク特性評価 | `fit_series(lorentzian_q, cov=cov_map)` | 各モードの f₀、Q、振幅 |\n| 時間監視 | `Spectrogram.crop_frequencies()` | 振幅時系列 |\n\n### ポイント\n\n- **ブートストラップリサンプリング**は、単一セグメント推定がノイジーな狭帯域ピークに対して\n  信頼できる不確かさ推定を与えます。\n- **BifrequencyMap 共分散**は GLS フィットに不可欠です。`fit_series` に `cov=cov_map` を\n  渡すことで、周波数ビン間の相関が自動的に考慮されます。\n- `lorentzian_q` パラメタライゼーションにより、各シューマンモードの物理的に意味のある\n  **Q ファクター**が直接得られます。\n- このワークフローは実際の KAGRA PEM 磁力計データにそのまま適用できます。\n- 信頼できる同定には、既知の周波数に合うことだけでなく、幅・共分散構造・時間発展を合わせて見ることが重要です。\n\n### 次のステップ\n\n- 実データの読み込み: `TimeSeries.read('K1:PEM-MAG_EXV_EAST_X_DQ', start, end)`.\n- `BifrequencyMap.propagate()` と組み合わせて、DARM ノイズへの磁気結合寄与を推定する。\n- GPS 時間セグメントをループして、シューマン共鳴パラメータの日変化・季節変化を追跡する。"
+    "## まとめ\n\n| ステップ | ツール | 出力 |\n|---------|--------|------|\n| ロバスト PSD | `bootstrap_spectrogram(return_map=True)` | 中央値 PSD + 1σ 帯 |\n| 不確かさモデル | `BifrequencyMap` (ブートストラップから) | 周波数ビン間共分散行列 |\n| ピーク特性評価 | `fit_series(lorentzian_q, cov=cov_map)` | 各モードの f₀、Q、振幅 |\n| 時間監視 | `Spectrogram.crop_frequencies()` | 振幅時系列 |\n\n### ポイント\n\n- **ブートストラップリサンプリング**は、単一セグメント推定がノイジーな狭帯域ピークに対して\n  信頼できる不確かさ推定を与えます。\n- **BifrequencyMap 共分散**は GLS フィットに不可欠です。`fit_series` に `cov=cov_map` を\n  渡すことで、周波数ビン間の相関が自動的に考慮されます。\n- `lorentzian_q` パラメタライゼーションにより、各シューマンモードの物理的に意味のある\n  **Q ファクター**が直接得られます。\n- このワークフローは実際の KAGRA PEM 磁力計データにそのまま適用できます。\n- 信頼できる同定には、既知の周波数に合うことだけでなく、幅・共分散構造・時間発展を合わせて見ることが重要です。\n\n### 次のステップ\n\n- 実データの読み込み: NDS/GWOSC fetch ワークフローで `TimeSeries` を取得してから、この解析に渡す。\n- `BifrequencyMap.propagate()` と組み合わせて、DARM ノイズへの磁気結合寄与を推定する。\n- GPS 時間セグメントをループして、シューマン共鳴パラメータの日変化・季節変化を追跡する。"
    ]
   }
  ],

--- a/docs/web/en/user_guide/tutorials/case_seismic_obspy.ipynb
+++ b/docs/web/en/user_guide/tutorials/case_seismic_obspy.ipynb
@@ -33,7 +33,7 @@
     "- Cross-correlation of seismic channels with gravitational-wave data\n",
     "\n",
     "**Legacy migration note:**  \n",
-    "If your code used `obspy.read()` directly followed by manual numpy processing, replace it with `TimeSeries.read(format='miniseed')` and gwexpy's high-level signal processing methods.  \n",
+    "If your code used `obspy.read()` directly followed by manual numpy processing, replace file reads with `TimeSeriesDict.read(format='mseed')` and gwexpy's high-level signal processing methods.  \n",
     "See the [Interop / Conversion Guide](../interop.md) and [Interop API reference](../../reference/api/interop.rst) for the current public interop surface."
    ]
   },
@@ -59,7 +59,7 @@
     "\n",
     "**レガシーコード移行メモ:**  \n",
     "`obspy.read()` で読み込んで手動で numpy 処理していたコードは、  \n",
-    "`TimeSeries.read(format='miniseed')` + gwexpy の高レベル API に置き換えられます。  \n",
+    "`TimeSeriesDict.read(format='mseed')` + gwexpy の高レベル API に置き換えられます。  \n",
     "現在の public interop surface は [Interop / 変換ガイド](../interop.md) と [Interop API リファレンス](../../reference/api/interop.rst) を参照してください。"
    ]
   },
@@ -81,7 +81,7 @@
     "import numpy as np\n",
     "from astropy import units as u\n",
     "\n",
-    "from gwexpy.timeseries import TimeSeries\n",
+    "from gwexpy.timeseries import TimeSeries, TimeSeriesDict\n",
     "\n",
     "# ObsPy is an optional dependency\n",
     "try:\n",
@@ -103,9 +103,9 @@
     ]
    },
    "source": [
-    "## 1. Route 1: `TimeSeries.read(format='miniseed')`\n",
+    "## 1. Route 1: `TimeSeriesDict.read(format='mseed')`\n",
     "\n",
-    "gwexpy's I/O layer supports reading MiniSEED files directly, returning a `TimeSeries` object with correct units and time axis."
+    "gwexpy's I/O layer supports reading MiniSEED files directly, returning a `TimeSeriesDict` whose values preserve units and time axes."
    ]
   },
   {
@@ -117,9 +117,9 @@
     ]
    },
    "source": [
-    "## 1. ルート 1: `TimeSeries.read(format='miniseed')`\n",
+    "## 1. ルート 1: `TimeSeriesDict.read(format='mseed')`\n",
     "\n",
-    "gwexpy の I/O レイヤーは MiniSEED ファイルを直接読み込み、正しい単位と時間軸を持つ `TimeSeries` を返します。"
+    "gwexpy の I/O レイヤーは MiniSEED ファイルを直接読み込み、正しい単位と時間軸を保つ `TimeSeriesDict` を返します。"
    ]
   },
   {
@@ -139,24 +139,25 @@
     "# --- Route 1: Read MiniSEED via gwexpy I/O ---\n",
     "# Replace the path below with your actual MiniSEED file\n",
     "#\n",
-    "# ts_seismic = TimeSeries.read(\n",
+    "# tsd_seismic = TimeSeriesDict.read(\n",
     "#     \"path/to/seismic.mseed\",\n",
-    "#     format='miniseed',\n",
+    "#     format='mseed',\n",
     "# )\n",
     "#\n",
     "# Or read SAC format:\n",
-    "# ts_seismic = TimeSeries.read(\"path/to/seismic.sac\", format='sac')\n",
+    "# tsd_seismic = TimeSeriesDict.read(\"path/to/seismic.sac\", format='sac')\n",
+    "# ts_seismic = next(iter(tsd_seismic.values()))\n",
     "#\n",
     "# For FDSN web service (requires network access):\n",
-    "# ts_seismic = TimeSeries.read(\n",
+    "# tsd_seismic = TimeSeriesDict.read(\n",
     "#     \"IU.ANMO.00.BHZ\",\n",
-    "#     format='miniseed',\n",
+    "#     format='mseed',\n",
     "#     start=1234567890,\n",
     "#     end=1234568090,\n",
     "# )\n",
     "\n",
-    "print(\"Route 1: TimeSeries.read(format='miniseed') or format='sac'\")\n",
-    "print(\"This returns a TimeSeries with GPS time axis, units, and channel name.\")"
+    "print(\"Route 1: TimeSeriesDict.read(format='mseed') or format='sac'\")\n",
+    "print(\"This returns a TimeSeriesDict; select a channel value for single-series analysis.\")"
    ]
   },
   {
@@ -566,9 +567,10 @@
     "\n",
     "**After (gwexpy):**\n",
     "```python\n",
-    "from gwexpy.timeseries import TimeSeries\n",
+    "from gwexpy.timeseries import TimeSeries, TimeSeriesDict\n",
     "\n",
-    "ts = TimeSeries.read(\"seismic.mseed\", format='miniseed')\n",
+    "tsd = TimeSeriesDict.read(\"seismic.mseed\", format='mseed')\n",
+    "ts = next(iter(tsd.values()))\n",
     "# Or: ts = TimeSeries.from_obspy_trace(obspy.read(\"seismic.mseed\")[0])\n",
     "\n",
     "ts_bp  = ts.bandpass(0.1, 1.0)\n",
@@ -605,9 +607,10 @@
     "\n",
     "**移行後（gwexpy）:**\n",
     "```python\n",
-    "from gwexpy.timeseries import TimeSeries\n",
+    "from gwexpy.timeseries import TimeSeries, TimeSeriesDict\n",
     "\n",
-    "ts = TimeSeries.read(\"seismic.mseed\", format='miniseed')\n",
+    "tsd = TimeSeriesDict.read(\"seismic.mseed\", format='mseed')\n",
+    "ts = next(iter(tsd.values()))\n",
     "# または: ts = TimeSeries.from_obspy_trace(obspy.read(\"seismic.mseed\")[0])\n",
     "\n",
     "ts_bp = ts.bandpass(0.1, 1.0)\n",
@@ -629,8 +632,8 @@
     "\n",
     "| Task | gwexpy API |\n",
     "|------|------------|\n",
-    "| Read MiniSEED file | `TimeSeries.read(path, format='miniseed')` |\n",
-    "| Read SAC file | `TimeSeries.read(path, format='sac')` |\n",
+    "| Read MiniSEED file | `TimeSeriesDict.read(path, format='mseed')` |\n",
+    "| Read SAC file | `TimeSeriesDict.read(path, format='sac')` |\n",
     "| Convert from obspy Trace | `TimeSeries.from_obspy_trace(tr, unit=...)` |\n",
     "| Convert to obspy Trace | `ts.to_obspy_trace()` or `to_obspy(ts)` |\n",
     "| Bandpass filter | `ts.bandpass(fmin, fmax)` |\n",
@@ -656,8 +659,8 @@
     "\n",
     "| 操作 | gwexpy API |\n",
     "|------|------------|\n",
-    "| MiniSEED 読み込み | `TimeSeries.read(path, format='miniseed')` |\n",
-    "| SAC 読み込み | `TimeSeries.read(path, format='sac')` |\n",
+    "| MiniSEED 読み込み | `TimeSeriesDict.read(path, format='mseed')` |\n",
+    "| SAC 読み込み | `TimeSeriesDict.read(path, format='sac')` |\n",
     "| obspy Trace から変換 | `TimeSeries.from_obspy_trace(tr, unit=...)` |\n",
     "| obspy Trace に変換 | `ts.to_obspy_trace()` または `to_obspy(ts)` |\n",
     "| 帯域フィルタ | `ts.bandpass(fmin, fmax)` |\n",

--- a/docs/web/ja/index.rst
+++ b/docs/web/ja/index.rst
@@ -69,7 +69,7 @@ v\ |release| · Python ≥ 3.11 · 最終更新: |today|
      </section>
      <section class="gw-hub-panel">
        <p>3-line demo</p>
-       <pre><code>from gwexpy.timeseries import FrequencySeriesMatrix
+       <pre><code>from gwexpy.frequencyseries import FrequencySeriesMatrix
    fsmtx = FrequencySeriesMatrix.read("data.hdf5")
    fsmtx[2, 0].fit(model="lorentzian").plot()</code></pre>
      </section>

--- a/tests/io/test_io_docs_contract_sync.py
+++ b/tests/io/test_io_docs_contract_sync.py
@@ -11,6 +11,15 @@ EN_GUIDE = ROOT / "docs/web/en/user_guide/io_formats.md"
 JA_GUIDE = ROOT / "docs/web/ja/user_guide/io_formats.md"
 EN_INSTALL = ROOT / "docs/web/en/user_guide/installation.md"
 JA_INSTALL = ROOT / "docs/web/ja/user_guide/installation.md"
+LANDING_PAGES = (
+    ROOT / "docs/index.rst",
+    ROOT / "docs/web/en/index.rst",
+    ROOT / "docs/web/ja/index.rst",
+)
+SCHUMANN_TUTORIAL = (
+    ROOT / "docs/web/en/user_guide/tutorials/case_schumann_resonance.ipynb"
+)
+SEISMIC_TUTORIAL = ROOT / "docs/web/en/user_guide/tutorials/case_seismic_obspy.ipynb"
 
 
 def _load_contract() -> dict[str, dict]:
@@ -85,8 +94,14 @@ def test_docs_mark_frequency_dttxml_as_implementation_only():
     ja = _read(JA_GUIDE)
 
     assert contract["xml.diaggui"]["public_api"]["read"] == ["TimeSeriesDict"]
-    assert "Frequency-domain DTTXML direct shims and registry adapters are implementation-only" in en
-    assert "周波数領域の DTTXML direct shim と registry adapter は implementation-only" in ja
+    assert (
+        "Frequency-domain DTTXML direct shims and registry adapters are implementation-only"
+        in en
+    )
+    assert (
+        "周波数領域の DTTXML direct shim と registry adapter は implementation-only"
+        in ja
+    )
 
 
 def test_optional_dependency_matrix_matches_contract():
@@ -117,6 +132,41 @@ def test_optional_dependency_matrix_matches_contract():
     wav = contract["wav"]
     assert wav["unavailable_behavior"]["read"] == "warns_and_skips_optional_metadata"
     assert "`.read(..., extract_metadata=True)` warns and skips metadata" in en
-    assert "`.read(..., extract_metadata=True)` は警告を出し、metadata を省略します" in ja
+    assert (
+        "`.read(..., extract_metadata=True)` は警告を出し、metadata を省略します" in ja
+    )
     assert "`audio` or `all` source-extra syntax" in en
     assert "`audio` または `all` のソース導入形式" in ja
+
+
+def test_landing_pages_import_frequency_matrix_from_frequencyseries():
+    for page in LANDING_PAGES:
+        text = _read(page)
+        assert "from gwexpy.timeseries import FrequencySeriesMatrix" not in text
+        assert "from gwexpy.frequencyseries import FrequencySeriesMatrix" in text
+
+
+def test_tutorials_do_not_present_channel_names_as_read_paths():
+    text = _read(SCHUMANN_TUTORIAL)
+
+    assert "TimeSeries.read('K1:PEM-MAG_EXV_EAST_X_DQ', start, end)" not in text
+    assert "NDS/GWOSC fetch workflow" in text
+
+
+def test_seismic_tutorial_uses_public_dict_reader_boundary():
+    text = _read(SEISMIC_TUTORIAL)
+
+    stale_examples = (
+        "TimeSeries.read(format='miniseed')",
+        "TimeSeries.read(\"seismic.mseed\", format='miniseed')",
+        "TimeSeries.read(path, format='miniseed')",
+        "TimeSeries.read(path, format='sac')",
+        "TimeSeries.read(\"path/to/seismic.sac\", format='sac')",
+    )
+
+    for example in stale_examples:
+        assert example not in text
+
+    assert "TimeSeriesDict.read(format='mseed')" in text
+    assert "TimeSeriesDict.read(path, format='mseed')" in text
+    assert "TimeSeriesDict.read(path, format='sac')" in text


### PR DESCRIPTION
## Target release
v0.1.2 (order 10/10 in #372)

## Dependencies
Depends on the v0.1.2 hotfix PR chain: #373, #374, #375, #376, #377, #378, #379, #380, #381.

## Summary
- Fix landing-page FrequencySeriesMatrix imports to use gwexpy.frequencyseries.
- Remove a tutorial example that treats an NDS channel name as a TimeSeries.read path.
- Align the seismic ObsPy tutorial with the public TimeSeriesDict reader boundary for mseed/sac.
- Add docs contract guards for these stale examples.

## Validation
- RED: rtk pytest tests/io/test_io_docs_contract_sync.py -q -> 5 passed, 3 failed before docs edits.
- GREEN: rtk pytest tests/io/test_io_docs_contract_sync.py -q -> 8 passed.
- rtk ruff check tests/io/test_io_docs_contract_sync.py -> No issues found.
- rtk ruff format --check tests/io/test_io_docs_contract_sync.py -> already formatted.
- Notebook JSON parse passed for the changed Schumann and seismic notebooks.
- Manifest YAML parse passed.
- rtk git diff --check -> clean.

Closes #369.