### PR TITLE
[AGENT:finalize_work] Align I/O docs and public contract autodetect notes

### DIFF
--- a/docs/developers/contracts/public_io_contract.json
+++ b/docs/developers/contracts/public_io_contract.json
@@ -324,8 +324,8 @@
                     "EventTable"
                 ]
             },
-            "public_auto_identify": false,
-            "registry_auto_identify": false,
+            "public_auto_identify": true,
+            "registry_auto_identify": true,
             "required_args": {
                 "read": [],
                 "write": []
@@ -336,6 +336,7 @@
             ],
             "notes": [
                 "Published CSV direct I/O is limited to TimeSeries and TimeSeriesDict.",
+                "Single-file CSV is a lightweight exchange path; do not rely on it for complete name, channel, or unit metadata preservation across GWpy-compatible readers.",
                 "TimeSeriesDict supports both single-file CSV reads and manifest-backed collection-directory reads and writes.",
                 "Broader registry adapters such as TimeSeriesMatrix, FrequencySeries, Spectrogram, and EventTable remain implementation surface only."
             ],
@@ -474,8 +475,8 @@
                     "EventTable"
                 ]
             },
-            "public_auto_identify": false,
-            "registry_auto_identify": false,
+            "public_auto_identify": true,
+            "registry_auto_identify": true,
             "required_args": {
                 "read": [],
                 "write": []
@@ -484,6 +485,7 @@
             "metadata_requirements": [],
             "notes": [
                 "Published ROOT direct I/O is intentionally limited to EventTable.",
+                "EventTable .root files are auto-identified by the live registry when the ROOT backend is available.",
                 "Collection .write(..., format=\"root\") helpers remain PyROOT-based interop conveniences and are not part of the published direct-I/O contract."
             ],
             "optional_dependencies": [],
@@ -1308,7 +1310,8 @@
             "metadata_requirements": [],
             "notes": [
                 "Public direct I/O covers the TimeSeries family only.",
-                "The legacy alias 'netcdf4' must remain equivalent to the canonical 'nc' token."
+                "The legacy alias 'netcdf4' must remain equivalent to the canonical 'nc' format token.",
+                "The public auto-identified extension is .nc; .netcdf4 is a format-token alias, not a documented extension alias."
             ],
             "optional_dependencies": [
                 "xarray",

--- a/docs/developers/contracts/public_io_contract.json
+++ b/docs/developers/contracts/public_io_contract.json
@@ -485,14 +485,16 @@
             "metadata_requirements": [],
             "notes": [
                 "Published ROOT direct I/O is intentionally limited to EventTable.",
-                "EventTable .root files are auto-identified by the live registry when the ROOT backend is available.",
+                "EventTable .root files are auto-identified by the live registry; read/write require the optional uproot backend.",
                 "Collection .write(..., format=\"root\") helpers remain PyROOT-based interop conveniences and are not part of the published direct-I/O contract."
             ],
-            "optional_dependencies": [],
+            "optional_dependencies": [
+                "uproot"
+            ],
             "extras": [],
             "unavailable_behavior": {
-                "read": "available_in_base_install",
-                "write": "available_in_base_install"
+                "read": "raises_import_error",
+                "write": "raises_import_error"
             }
         },
         {

--- a/docs/web/en/user_guide/io_formats.md
+++ b/docs/web/en/user_guide/io_formats.md
@@ -216,11 +216,11 @@ The key rule here is not to mix up “format choice” with “library conversio
 
 | Format | R / W | Main entry | Best for | Notes |
 |---|:---:|---|---|---|
-| **CSV** (`.csv`) | ○ / ○ | `TimeSeries.read(..., format="csv")`, `TimeSeriesDict.read(..., format="csv")`, `TimeSeriesDict.write(..., format="csv")` | Lightweight exchange and inspection | `TimeSeriesDict` supports single-file reads and collection-directory layouts |
+| **CSV** (`.csv`) | ○ / ○ | `TimeSeries.read("data.csv")`, `TimeSeriesDict.read("data.csv")`, `TimeSeriesDict.write(..., format="csv")` | Lightweight exchange and inspection | Auto-identifies `.csv`; simple CSV exchange is metadata-light |
 | **TXT** (`.txt`) | ○ / ○ | `TimeSeries.read(..., format="txt")`, `TimeSeriesDict.read(dir, format="txt")`, `TimeSeriesDict.write(dir, format="txt")` | Plain-text exchange | Multi-channel direct I/O uses collection directories |
-| **nc** (`.nc`) | ○ / ○ | `TimeSeries.read(..., format="nc")`, `TimeSeriesDict.read(..., format="nc")`, `TimeSeriesMatrix.read(..., format="nc")`, `.write(..., format="nc")` | Scientific storage for time-series-oriented data | Direct I/O here is centered on TimeSeries classes; legacy alias: `netcdf4` |
+| **nc** (`.nc`) | ○ / ○ | `TimeSeries.read(..., format="nc")`, `TimeSeriesDict.read(..., format="nc")`, `TimeSeriesMatrix.read(..., format="nc")`, `.write(..., format="nc")` | Scientific storage for time-series-oriented data | Direct I/O here is centered on TimeSeries classes; legacy format alias: `netcdf4` |
 | **Zarr** (`.zarr`) | ○ / ○ | `TimeSeries.read(..., format="zarr")`, `TimeSeriesDict.read(..., format="zarr")`, `TimeSeriesMatrix.read(..., format="zarr")`, `.write(..., format="zarr")` | Chunked storage and parallel workflows | Direct I/O here is centered on TimeSeries classes |
-| **ROOT** (`.root`) | ○ / ○ | `EventTable.read(..., format="root")`, `EventTable.write(..., format="root")` | EventTable I/O | Direct I/O here is EventTable only |
+| **ROOT** (`.root`) | ○ / ○ | `EventTable.read("events.root")`, `EventTable.write(..., format="root")` | EventTable I/O | Auto-identifies `.root`; direct I/O here is EventTable only |
 
 - Purpose: show the general-purpose direct-I/O routes without mixing them with interop-only bridges
 - Input: CSV, Zarr, ROOT, or other general exchange formats
@@ -232,13 +232,13 @@ from gwexpy.table import EventTable
 
 ascii_data = TimeSeriesDict.read("data.csv")
 chunked = TimeSeriesDict.read("data.zarr", format="zarr")
-events = EventTable.read("events.root", format="root")
+events = EventTable.read("events.root")
 ```
 
-- **CSV** remains useful for lightweight exchange and inspection.
+- **CSV** remains useful for lightweight exchange and inspection. Treat simple CSV files as metadata-light: use HDF5, GWF, Zarr, NetCDF, or a manifest-backed collection directory when name, channel, and unit metadata must be preserved.
 - **TXT** direct I/O is more limited: single-series paths are explicit `format="txt"`, and multi-channel paths use collection directories.
 - **Pickle** portability notes still exist in class references, but Pickle is not a published direct `.read()` / `.write()` format on this page.
-- **NetCDF4 / Zarr** are treated here only as **direct TimeSeries-style I/O**. Field/xarray bridges belong to interop.
+- **NetCDF4 / Zarr** are treated here only as **direct TimeSeries-style I/O**. Field/xarray bridges belong to interop. For NetCDF, `netcdf4` is a legacy format token alias for `nc`; `.netcdf4` is not a documented auto-identified extension alias.
 - **Zarr** direct I/O now expects per-array timing metadata explicitly. `sample_rate` is the primary key, `dt` is accepted as a fallback, and reads raise `ValueError` if neither is present unless you intentionally recover a legacy store with `sample_rate_override=...` or `dt_override=...`.
 - **ROOT** object-level export/import belongs to interop. This page only covers EventTable direct I/O.
 

--- a/docs/web/en/user_guide/io_formats.md
+++ b/docs/web/en/user_guide/io_formats.md
@@ -220,7 +220,7 @@ The key rule here is not to mix up “format choice” with “library conversio
 | **TXT** (`.txt`) | ○ / ○ | `TimeSeries.read(..., format="txt")`, `TimeSeriesDict.read(dir, format="txt")`, `TimeSeriesDict.write(dir, format="txt")` | Plain-text exchange | Multi-channel direct I/O uses collection directories |
 | **nc** (`.nc`) | ○ / ○ | `TimeSeries.read(..., format="nc")`, `TimeSeriesDict.read(..., format="nc")`, `TimeSeriesMatrix.read(..., format="nc")`, `.write(..., format="nc")` | Scientific storage for time-series-oriented data | Direct I/O here is centered on TimeSeries classes; legacy format alias: `netcdf4` |
 | **Zarr** (`.zarr`) | ○ / ○ | `TimeSeries.read(..., format="zarr")`, `TimeSeriesDict.read(..., format="zarr")`, `TimeSeriesMatrix.read(..., format="zarr")`, `.write(..., format="zarr")` | Chunked storage and parallel workflows | Direct I/O here is centered on TimeSeries classes |
-| **ROOT** (`.root`) | ○ / ○ | `EventTable.read("events.root")`, `EventTable.write(..., format="root")` | EventTable I/O | Auto-identifies `.root`; direct I/O here is EventTable only |
+| **ROOT** (`.root`) | ○ / ○ | `EventTable.read("events.root")`, `EventTable.write(..., format="root")` | EventTable I/O | Auto-identifies `.root`; direct I/O here is EventTable only and requires `uproot` |
 
 - Purpose: show the general-purpose direct-I/O routes without mixing them with interop-only bridges
 - Input: CSV, Zarr, ROOT, or other general exchange formats
@@ -240,7 +240,7 @@ events = EventTable.read("events.root")
 - **Pickle** portability notes still exist in class references, but Pickle is not a published direct `.read()` / `.write()` format on this page.
 - **NetCDF4 / Zarr** are treated here only as **direct TimeSeries-style I/O**. Field/xarray bridges belong to interop. For NetCDF, `netcdf4` is a legacy format token alias for `nc`; `.netcdf4` is not a documented auto-identified extension alias.
 - **Zarr** direct I/O now expects per-array timing metadata explicitly. `sample_rate` is the primary key, `dt` is accepted as a fallback, and reads raise `ValueError` if neither is present unless you intentionally recover a legacy store with `sample_rate_override=...` or `dt_override=...`.
-- **ROOT** object-level export/import belongs to interop. This page only covers EventTable direct I/O.
+- **ROOT** object-level export/import belongs to interop. This page only covers EventTable direct I/O, which requires `uproot`.
 
 <a id="io-formats-en-d"></a>
 

--- a/docs/web/ja/user_guide/io_formats.md
+++ b/docs/web/ja/user_guide/io_formats.md
@@ -215,11 +215,11 @@ ats = TimeSeries.read("data.atss", format="ats.mth5")
 
 | 形式 | 読 / 写 | 主な入口 | 用途 | 備考 |
 |---|:---:|---|---|---|
-| **CSV** (`.csv`) | ○ / ○ | `TimeSeries.read(..., format="csv")`, `TimeSeriesDict.read(..., format="csv")`, `TimeSeriesDict.write(..., format="csv")` | 軽量な交換、目視確認 | `TimeSeriesDict` は単一 CSV 読み込みと collection directory の両方に対応 |
+| **CSV** (`.csv`) | ○ / ○ | `TimeSeries.read("data.csv")`, `TimeSeriesDict.read("data.csv")`, `TimeSeriesDict.write(..., format="csv")` | 軽量な交換、目視確認 | `.csv` は自動判定されます。単純な CSV 交換は metadata-light です |
 | **TXT** (`.txt`) | ○ / ○ | `TimeSeries.read(..., format="txt")`, `TimeSeriesDict.read(dir, format="txt")`, `TimeSeriesDict.write(dir, format="txt")` | プレーンテキスト交換 | 複数チャネルの direct I/O は collection directory を使う |
-| **nc** (`.nc`) | ○ / ○ | `TimeSeries.read(..., format="nc")`, `TimeSeriesDict.read(..., format="nc")`, `TimeSeriesMatrix.read(..., format="nc")`, `.write(..., format="nc")` | 時系列系の科学データ保存 | direct I/O は TimeSeries 系中心。旧 alias: `netcdf4` |
+| **nc** (`.nc`) | ○ / ○ | `TimeSeries.read(..., format="nc")`, `TimeSeriesDict.read(..., format="nc")`, `TimeSeriesMatrix.read(..., format="nc")`, `.write(..., format="nc")` | 時系列系の科学データ保存 | direct I/O は TimeSeries 系中心。旧 format alias: `netcdf4` |
 | **Zarr** (`.zarr`) | ○ / ○ | `TimeSeries.read(..., format="zarr")`, `TimeSeriesDict.read(..., format="zarr")`, `TimeSeriesMatrix.read(..., format="zarr")`, `.write(..., format="zarr")` | chunked 保存、並列処理 | direct I/O は TimeSeries 系中心 |
-| **ROOT** (`.root`) | ○ / ○ | `EventTable.read(..., format="root")`, `EventTable.write(..., format="root")` | EventTable の入出力 | 直 I/O は EventTable のみ |
+| **ROOT** (`.root`) | ○ / ○ | `EventTable.read("events.root")`, `EventTable.write(..., format="root")` | EventTable の入出力 | `.root` は自動判定されます。直 I/O は EventTable のみ |
 
 - 目的: 汎用交換向けの direct I/O を、interop 専用の橋渡しと混同せず整理する
 - 入力: CSV, Zarr, ROOT などの汎用形式
@@ -231,13 +231,13 @@ from gwexpy.table import EventTable
 
 ascii_data = TimeSeriesDict.read("data.csv")
 chunked = TimeSeriesDict.read("data.zarr", format="zarr")
-events = EventTable.read("events.root", format="root")
+events = EventTable.read("events.root")
 ```
 
-- **CSV** は素朴ですが、共有や確認には依然として有用です。
+- **CSV** は素朴ですが、共有や確認には依然として有用です。単純な CSV ファイルは metadata-light と考えてください。`name`、`channel`、`unit` まで保持したい場合は HDF5、GWF、Zarr、NetCDF、または manifest 付き collection directory を使います。
 - **TXT** の direct I/O はより限定的で、単一 series は `format="txt"` 明示、複数チャネルは collection directory 前提です。
 - **Pickle** の可搬性メモは各クラスの reference に残していますが、このページでは Pickle を public direct `.read()` / `.write()` 形式としては扱いません。
-- **NetCDF4 / Zarr** はこのページでは **TimeSeries 系の direct I/O** としてだけ扱います。Field と xarray の橋渡しは interop 側を見てください。
+- **NetCDF4 / Zarr** はこのページでは **TimeSeries 系の direct I/O** としてだけ扱います。Field と xarray の橋渡しは interop 側を見てください。NetCDF の `netcdf4` は `nc` の旧 format token alias であり、`.netcdf4` は公開された自動判定 extension alias ではありません。
 - **Zarr** の direct I/O では、配列ごとの timing metadata を明示的に要求します。`sample_rate` を優先し、`dt` は fallback として受け付けます。どちらも無い場合は `ValueError` を送出し、legacy store を意図的に救済したい場合だけ `sample_rate_override=...` または `dt_override=...` を指定してください。
 - **ROOT** の object-level 変換はここでは扱いません。I/O ガイドでは EventTable の直 I/O のみ扱います。
 

--- a/docs/web/ja/user_guide/io_formats.md
+++ b/docs/web/ja/user_guide/io_formats.md
@@ -219,7 +219,7 @@ ats = TimeSeries.read("data.atss", format="ats.mth5")
 | **TXT** (`.txt`) | ○ / ○ | `TimeSeries.read(..., format="txt")`, `TimeSeriesDict.read(dir, format="txt")`, `TimeSeriesDict.write(dir, format="txt")` | プレーンテキスト交換 | 複数チャネルの direct I/O は collection directory を使う |
 | **nc** (`.nc`) | ○ / ○ | `TimeSeries.read(..., format="nc")`, `TimeSeriesDict.read(..., format="nc")`, `TimeSeriesMatrix.read(..., format="nc")`, `.write(..., format="nc")` | 時系列系の科学データ保存 | direct I/O は TimeSeries 系中心。旧 format alias: `netcdf4` |
 | **Zarr** (`.zarr`) | ○ / ○ | `TimeSeries.read(..., format="zarr")`, `TimeSeriesDict.read(..., format="zarr")`, `TimeSeriesMatrix.read(..., format="zarr")`, `.write(..., format="zarr")` | chunked 保存、並列処理 | direct I/O は TimeSeries 系中心 |
-| **ROOT** (`.root`) | ○ / ○ | `EventTable.read("events.root")`, `EventTable.write(..., format="root")` | EventTable の入出力 | `.root` は自動判定されます。直 I/O は EventTable のみ |
+| **ROOT** (`.root`) | ○ / ○ | `EventTable.read("events.root")`, `EventTable.write(..., format="root")` | EventTable の入出力 | `.root` は自動判定されます。直 I/O は EventTable のみで、`uproot` が必要です |
 
 - 目的: 汎用交換向けの direct I/O を、interop 専用の橋渡しと混同せず整理する
 - 入力: CSV, Zarr, ROOT などの汎用形式
@@ -239,7 +239,7 @@ events = EventTable.read("events.root")
 - **Pickle** の可搬性メモは各クラスの reference に残していますが、このページでは Pickle を public direct `.read()` / `.write()` 形式としては扱いません。
 - **NetCDF4 / Zarr** はこのページでは **TimeSeries 系の direct I/O** としてだけ扱います。Field と xarray の橋渡しは interop 側を見てください。NetCDF の `netcdf4` は `nc` の旧 format token alias であり、`.netcdf4` は公開された自動判定 extension alias ではありません。
 - **Zarr** の direct I/O では、配列ごとの timing metadata を明示的に要求します。`sample_rate` を優先し、`dt` は fallback として受け付けます。どちらも無い場合は `ValueError` を送出し、legacy store を意図的に救済したい場合だけ `sample_rate_override=...` または `dt_override=...` を指定してください。
-- **ROOT** の object-level 変換はここでは扱いません。I/O ガイドでは EventTable の直 I/O のみ扱います。
+- **ROOT** の object-level 変換はここでは扱いません。I/O ガイドでは `uproot` を必要とする EventTable の直 I/O のみ扱います。
 
 <a id="io-formats-ja-d"></a>
 

--- a/tests/io/test_io_contract.py
+++ b/tests/io/test_io_contract.py
@@ -515,6 +515,9 @@ def test_current_public_boundary_decisions_are_recorded():
     assert _api_classes(entries["root"], "registry_api", "write") == ["EventTable"]
     assert entries["root"]["public_auto_identify"] is True
     assert entries["root"]["registry_auto_identify"] is True
+    assert entries["root"]["optional_dependencies"] == ["uproot"]
+    assert entries["root"]["unavailable_behavior"]["read"] == "raises_import_error"
+    assert entries["root"]["unavailable_behavior"]["write"] == "raises_import_error"
     assert _api_classes(entries["hdf5"], "public_api", "read") == [
         "TimeSeries",
         "TimeSeriesDict",

--- a/tests/io/test_io_contract.py
+++ b/tests/io/test_io_contract.py
@@ -283,8 +283,8 @@ def test_current_public_boundary_decisions_are_recorded():
         "Spectrogram",
         "EventTable",
     ]
-    assert entries["csv"]["public_auto_identify"] is False
-    assert entries["csv"]["registry_auto_identify"] is False
+    assert entries["csv"]["public_auto_identify"] is True
+    assert entries["csv"]["registry_auto_identify"] is True
     assert entries["csv"]["metadata_requirements"]
     assert _api_classes(entries["txt"], "public_api", "read") == [
         "TimeSeries",
@@ -513,8 +513,8 @@ def test_current_public_boundary_decisions_are_recorded():
     ]
     assert _api_classes(entries["root"], "registry_api", "read") == ["EventTable"]
     assert _api_classes(entries["root"], "registry_api", "write") == ["EventTable"]
-    assert entries["root"]["public_auto_identify"] is False
-    assert entries["root"]["registry_auto_identify"] is False
+    assert entries["root"]["public_auto_identify"] is True
+    assert entries["root"]["registry_auto_identify"] is True
     assert _api_classes(entries["hdf5"], "public_api", "read") == [
         "TimeSeries",
         "TimeSeriesDict",

--- a/tests/table/test_root_eventtable_io.py
+++ b/tests/table/test_root_eventtable_io.py
@@ -21,6 +21,9 @@ def test_eventtable_root_roundtrip(tmp_path):
 
     events.write(path, format="root")
     events2 = EventTable.read(path, format="root")
+    events_auto = EventTable.read(path)
 
     assert len(events2) == 2
     assert list(events2["snr"]) == [8.0, 9.5]
+    assert len(events_auto) == 2
+    assert list(events_auto["snr"]) == [8.0, 9.5]


### PR DESCRIPTION
## Summary
- align CSV and ROOT auto-identify flags with live public behavior
- document CSV as metadata-light and clarify NetCDF4 alias vs .netcdf4 extension behavior
- add ROOT EventTable auto-identify regression coverage when the optional backend is available

## Validation
- pytest -q tests/io/test_io_docs_contract_sync.py tests/io/test_io_contract.py tests/io/test_csv_txt_contract.py tests/table/test_root_eventtable_io.py
- ruff check tests/table/test_root_eventtable_io.py tests/io/test_io_docs_contract_sync.py tests/io/test_io_contract.py tests/io/test_csv_txt_contract.py
- python -m json.tool docs/developers/contracts/public_io_contract.json

Refs #370