### PR TITLE
[AGENT:finalize_work] Speed up FrequencySeries CSV reads

### DIFF
--- a/gwexpy/frequencyseries/frequencyseries.py
+++ b/gwexpy/frequencyseries/frequencyseries.py
@@ -8,7 +8,11 @@ enhanced signal analysis, fitting capabilities, and deep metadata propagation.
 
 from __future__ import annotations
 
+import csv
+import io
+import os
 from enum import Enum
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, SupportsIndex, TypeVar, cast
 
 import numpy as np
@@ -46,6 +50,66 @@ except ImportError:
 # =============================
 # FrequencySeries
 # =============================
+
+
+def _read_simple_frequencyseries_csv(cls, source, **kwargs):
+    """Read a two-column numeric CSV without reconstructing the x-axis."""
+    delimiter = kwargs.pop("delimiter", None)
+    encoding = kwargs.pop("encoding", "utf-8")
+    comment_char = kwargs.pop("comment_char", "#")
+    if kwargs:
+        return None
+
+    from gwexpy.timeseries.io.csv_enhanced import (
+        _detect_delimiter,
+        _detect_skip_rows,
+        _parse_comment_metadata,
+    )
+
+    if hasattr(source, "read"):
+        text = source.read()
+        if isinstance(text, bytes):
+            text = text.decode(encoding)
+    else:
+        text = Path(os.fspath(source)).read_text(encoding=encoding)
+
+    lines = text.splitlines()
+    metadata = _parse_comment_metadata(lines, comment_char)
+    if delimiter is None:
+        delimiter = _detect_delimiter("\n".join(lines[:20]))
+    skip = _detect_skip_rows(lines, delimiter, comment_char)
+
+    data_lines = []
+    for line in lines[skip:]:
+        stripped = line.strip()
+        if not stripped or stripped.startswith(comment_char):
+            continue
+        data_lines.append(stripped)
+    if not data_lines:
+        return None
+
+    rows = []
+    reader = csv.reader(io.StringIO("\n".join(data_lines)), delimiter=delimiter)
+    for row in reader:
+        try:
+            values = [float(value.strip()) for value in row if value.strip()]
+        except ValueError:
+            return None
+        if len(values) != 2:
+            return None
+        rows.append(values)
+    if not rows:
+        return None
+
+    raw = np.asarray(rows, dtype=float)
+    unit = u.Unit(metadata["unit"]) if metadata.get("unit") else None
+    return cls(
+        raw[:, 1],
+        frequencies=raw[:, 0],
+        unit=unit,
+        name=metadata.get("name") or None,
+        channel=metadata.get("channel") or None,
+    )
 
 
 class FrequencySeries(
@@ -140,6 +204,9 @@ class FrequencySeries(
     def read(cls, source, *args, **kwargs):  # type: ignore[override]
         """Read a ``FrequencySeries`` from a supported source."""
         fmt = kwargs.get("format")
+        source_path = None
+        if isinstance(source, (str, os.PathLike)):
+            source_path = Path(os.fspath(source))
         from .io.dttxml import _looks_like_dttxml, read_frequencyseriesdict_dttxml
 
         if fmt in ("xml.diaggui", "dttxml") or (
@@ -149,6 +216,20 @@ class FrequencySeries(
             if not fsd:
                 raise ValueError("No channels found in xml.diaggui")
             return fsd[next(iter(fsd.keys()))]
+        csv_source = (
+            fmt == "csv"
+            or (
+                fmt is None
+                and source_path is not None
+                and source_path.suffix.lower() == ".csv"
+            )
+        )
+        if csv_source and not args:
+            csv_kwargs = dict(kwargs)
+            csv_kwargs.pop("format", None)
+            fs = _read_simple_frequencyseries_csv(cls, source, **csv_kwargs)
+            if fs is not None:
+                return fs
         return super().read(source, *args, **kwargs)
 
     def __new__(

--- a/tests/io/test_frequencyseries_io.py
+++ b/tests/io/test_frequencyseries_io.py
@@ -134,6 +134,41 @@ class TestFrequencySeriesDttxml:
 
 
 class TestFrequencySeriesCsv:
+    def test_read_two_column_numeric_csv_with_format(self, tmp_path):
+        path = tmp_path / "two_col_numeric.csv"
+        path.write_text("1.0,10.0\n2.0,20.0\n3.0,30.0\n", encoding="utf-8")
+
+        fs = FrequencySeries.read(str(path), format="csv")
+
+        np.testing.assert_allclose(fs.frequencies.value, np.array([1.0, 2.0, 3.0]))
+        np.testing.assert_allclose(fs.value, np.array([10.0, 20.0, 30.0]))
+        assert fs.epoch is None
+
+    def test_read_two_column_numeric_csv_with_auto_detected_suffix(self, tmp_path):
+        path = tmp_path / "auto_detect.csv"
+        path.write_text("4.0,1.0\n5.0,2.0\n", encoding="utf-8")
+
+        fs = FrequencySeries.read(str(path))
+
+        np.testing.assert_allclose(fs.frequencies.value, np.array([4.0, 5.0]))
+        np.testing.assert_allclose(fs.value, np.array([1.0, 2.0]))
+
+    def test_read_csv_preserves_nonuniform_frequency_column(self, tmp_path):
+        path = tmp_path / "nonuniform.csv"
+        path.write_text("1.0,10.0\n2.0,20.0\n4.0,30.0\n", encoding="utf-8")
+
+        fs = FrequencySeries.read(str(path), format="csv")
+
+        np.testing.assert_allclose(fs.frequencies.value, np.array([1.0, 2.0, 4.0]))
+        np.testing.assert_allclose(fs.value, np.array([10.0, 20.0, 30.0]))
+
+    def test_read_csv_with_positional_args_keeps_registry_path(self, tmp_path):
+        path = tmp_path / "positional.csv"
+        path.write_text("1.0,10.0\n2.0,20.0\n", encoding="utf-8")
+
+        with pytest.raises(TypeError):
+            FrequencySeries.read(path, "unexpected", format="csv")
+
     def test_roundtrip_with_metadata(self, tmp_path):
         fs = FrequencySeries(
             np.array([10.0, 20.0, 30.0]),


### PR DESCRIPTION
## Summary

Fixes #391.

Adds a narrow CSV fast path for `FrequencySeries.read()` when reading simple CSV inputs through:

- `FrequencySeries.read(path, format="csv")`
- `FrequencySeries.read(path)` for `.csv` paths

The fast path uses a dedicated lightweight two-column parser so the first CSV column is preserved exactly as the `FrequencySeries` frequency axis.

## Motivation

The existing `FrequencySeries.read(..., format="csv")` path fell through to GWpy's generic ASCII reader. For small 2-column numeric CSV files this was much slower than GWexpy's existing TimeSeries CSV reader.

Local timing on a 4096-row, 2-column numeric CSV:

- fast path, explicit `format="csv"`: about `0.005 s/call`
- fast path, `.csv` auto-detect: about `0.005 s/call`
- GWpy generic `FrequencySeries.read(..., format="csv")`: about `0.102 s/call`

## Correctness and compatibility

- DTTXML handling remains first in the `FrequencySeries.read()` dispatch.
- HDF5 and other formats still fall through to `super().read()`.
- CSV fast path is used only when no positional `*args` are supplied; calls with positional arguments keep the existing registry path rather than silently dropping arguments.
- The parser falls back to the existing registry path for unsupported CSV shapes or extra kwargs.
- Non-uniform frequency grids are preserved because the axis comes directly from column 0, not from a reconstructed `(f0, df)` grid.
- No TimeSeries-derived `epoch` is copied into the `FrequencySeries`, because the CSV first column represents frequency rather than GPS time.

## Tests

- `rtk pytest -q tests/io/test_frequencyseries_io.py tests/io/test_reader_edge_cases.py`
- `rtk ruff check gwexpy/frequencyseries/frequencyseries.py tests/io/test_frequencyseries_io.py tests/io/test_reader_edge_cases.py`

## Review notes

- A reviewer checked the final diff and found no blockers.
- Qodo flagged a correctness issue in the first implementation where the fast path used a TimeSeries-reconstructed axis. This was fixed by adding the dedicated two-column parser and a non-uniform frequency regression test.
- Optional future hardening: document or test multi-column FrequencySeries CSV behavior beyond the 2-column case requested in #391.
