### PR TITLE
[AGENT:release] Prepare v0.1.3 release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,8 +2,8 @@
   "title": "GWexpy: Extending GWpy with metadata-preserving multidimensional abstractions for detector commissioning",
   "description": "GWexpy is an open-source Python library that extends the GWpy ecosystem with workflow-level abstractions and I/O adapters tailored for detector commissioning and laboratory-scale experimental diagnostics. GWexpy provides TimeSeriesMatrix containers, commissioning-oriented analysis primitives including transfer-function estimators and coherence-ranking utilities, and lossless format adapters for common experimental data formats.",
   "upload_type": "software",
-  "publication_date": "2026-05-08",
-  "version": "0.1.2",
+  "publication_date": "2026-05-12",
+  "version": "0.1.3",
   "license": {
     "id": "MIT"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 ## [Unreleased]
 
+## [0.1.3] - 2026-05-12
+
+### Fixed
+
+- **timeseries/gwf**: Fixed multi-file GWF reads for `TimeSeries` and
+  `TimeSeriesDict` inputs.
+- **timeseries/matrix**: Fixed ndscope HDF5 auto-detection for
+  `TimeSeriesMatrix.read()`.
+- **io/contracts**: Aligned public I/O docs and contract metadata with current
+  autodetection behavior.
+- **frequencyseries/csv**: Added a dedicated CSV fast path that preserves the
+  original frequency column values.
+- **timeseries/zarr**: Fixed matrix round-trip coverage under zarr 3 and
+  removed timeout-prone fixture behavior.
+- **plot/geomap**: Treat PyGMT installations without a loadable GMT shared
+  library as an unavailable optional backend instead of failing at import time.
+
+### Known Issues
+
+- **netcdf**: The bundled NetCDF fixture can fail the TimeSeries reader
+  time-coordinate contract in some cases (#393). Generated NetCDF round-trip
+  coverage still passes; users relying on NetCDF fixtures should verify that
+  their files expose an explicit time coordinate.
+
 ## [0.1.2] - 2026-05-08
 
 ### Narrow v0.1.2 hotfix scope
@@ -215,6 +239,10 @@ First stable release of GWexpy for SoftwareX publication. This release focuses o
 - Fixed unit propagation in complex matrix operations.
 - Corrected IFFT amplitude scaling for one-sided spectra.
 
-[Unreleased]: https://github.com/tatsuki-washimi/gwexpy/compare/v0.1.0b2...HEAD
+[Unreleased]: https://github.com/tatsuki-washimi/gwexpy/compare/v0.1.3...HEAD
+[0.1.3]: https://github.com/tatsuki-washimi/gwexpy/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/tatsuki-washimi/gwexpy/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/tatsuki-washimi/gwexpy/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/tatsuki-washimi/gwexpy/compare/v0.1.0b2...v0.1.0
 [0.1.0b2]: https://github.com/tatsuki-washimi/gwexpy/compare/v0.1.0b1...v0.1.0b2
 [0.1.0b1]: https://github.com/tatsuki-washimi/gwexpy/releases/tag/v0.1.0b1

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ authors:
 - family-names: "Washimi"
   given-names: "Tatsuki"
 title: "GWexpy: Extended Analysis Utilities for Gravitational Wave Data"
-version: 0.1.2
-date-released: 2026-05-08
+version: 0.1.3
+date-released: 2026-05-12
 url: "https://github.com/tatsuki-washimi/gwexpy"
 repository-code: "https://github.com/tatsuki-washimi/gwexpy"
 license: MIT

--- a/gwexpy/_version.py
+++ b/gwexpy/_version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"

--- a/gwexpy/plot/geomap.py
+++ b/gwexpy/plot/geomap.py
@@ -15,7 +15,7 @@ if not _SKIP_PYGMT:
 
         pygmt = _pygmt
         HAS_PYGMT = True
-    except (ImportError, OSError, RuntimeError) as exc:
+    except Exception as exc:
         HAS_PYGMT = False
         _PYGMT_IMPORT_ERROR = exc
 else:


### PR DESCRIPTION
## Summary

Prepare the `v0.1.3` patch release.

This PR:

- bumps version metadata to `0.1.3`
- updates `CITATION.cff` and `.zenodo.json` release dates to `2026-05-12`
- adds the `CHANGELOG.md` entry for merged I/O stability fixes
- records #393 as a known NetCDF fixture issue, not a release blocker
- hardens the optional PyGMT backend import path when `pygmt` is installed but `libgmt.so` is not loadable

## Release scope

- #389 multi-file GWF reads
- #390 ndscope `TimeSeriesMatrix` auto-detection
- #392 I/O docs and contract alignment
- #394 `FrequencySeries` CSV fast path
- #396 zarr 3 matrix round-trip fixture/runtime stabilization

Open issues #393, #395, #388, #355, #294, and #274 were reviewed. None block `v0.1.3`; #393 is documented as a known issue.

## Verification

- [x] `python scripts/check_release_metadata.py`
- [x] `python scripts/ci/run_gate.py pr-fast --fixtures`
  - first run exposed a local optional backend failure when `pygmt` exists without `libgmt.so`
  - fixed in this PR and reran successfully: `5642 passed, 92 skipped, 13 deselected, 6 xfailed`
- [x] `python scripts/ci/run_gate.py io-contract --fixtures`
  - `817 passed, 13 skipped, 1 deselected`
  - confirmed built wheel import: `gwexpy version: 0.1.3`
- [x] `python scripts/ci/run_gate.py io-optional`
  - `47 passed, 2 skipped`
- [x] `python scripts/ci/run_gate.py io-zarr --fixtures`
  - `20 passed`
- [x] `python -m build`
  - built `gwexpy-0.1.3.tar.gz`
  - built `gwexpy-0.1.3-py3-none-any.whl`
- [x] `python scripts/check_release_artifacts.py dist`
- [x] `twine check dist/*`
- [x] fresh venv wheel smoke
  - installed `dist/gwexpy-0.1.3-py3-none-any.whl`
  - `python -c "import gwexpy; print(gwexpy.__version__)"` printed `0.1.3`

## Audit

- Skill/context: release-coordinator, multi-agent-planning-gate
- Worktree: clean release worktree from `origin/main`
- Release evidence was checked by a read-only explorer agent before changelog editing.
- Current dirty local workspace was not used for release edits.
