### PR TITLE
test(io): add IO conformance baseline and fix DTTXML TS parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ gwexpy/gui/test-data/*:Zone.Identifier
 
 # Publications (confidential until publication)
 docs_internal/publications/
+docs/publications
 
 # Sphinx autosummary targets
 **/_autosummary/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+- **docs/io**: Added `io-conformance` gate guidance and documented the v3 public I/O contract policy fields.
+
 ## [0.1.3] - 2026-05-12
 
 ### Fixed

--- a/docs/developers/contracts/public_io_contract.json
+++ b/docs/developers/contracts/public_io_contract.json
@@ -1,5 +1,35 @@
 {
     "schema_version": 2,
+    "io_conformance_v3": {
+        "target_release": "v0.1.4",
+        "ci_jobs": [
+            "base",
+            "io-audio",
+            "io-seismic",
+            "io-netcdf4",
+            "io-zarr",
+            "io-tdms",
+            "io-root",
+            "nightly"
+        ],
+        "base_gate": "io-conformance",
+        "blocking_formats": [
+            "gwf",
+            "hdf.ndscope",
+            "hdf5",
+            "csv",
+            "txt",
+            "wav"
+        ],
+        "fixture_generator_by_format": {
+            "gwf": "gwf",
+            "hdf.ndscope": "hdf_ndscope",
+            "hdf5": "hdf5",
+            "csv": "csv_txt",
+            "txt": "csv_txt",
+            "wav": "audio"
+        }
+    },
     "formats": [
         {
             "name": "gwf",

--- a/docs/developers/contracts/public_io_contract.md
+++ b/docs/developers/contracts/public_io_contract.md
@@ -17,8 +17,8 @@ implementation surface.
 
 ## Schema
 
-The top-level `io_conformance_v3` policy block defines the public I/O gate shape.
-Each format entry contains these fields:
+The raw JSON contract includes a top-level `io_conformance_v3` policy block.
+Each on-disk format entry contains these fields:
 
 - `name`: human-facing label used in docs and reviews
 - `canonical`: canonical format token
@@ -29,10 +29,6 @@ Each format entry contains these fields:
 - `registry_api`: classes that are currently registered in the astropy/gwpy I/O registry
 - `public_auto_identify`: whether published usage may rely on `format=None`
 - `registry_auto_identify`: whether the current implementation can identify the format automatically
-- `fixture_generator`: normalized v3 fixture-generation policy for the published route
-- `coverage_status`: normalized v3 coverage status for the published route
-- `ci_jobs`: normalized v3 CI gate mapping used to enforce the published route
-- `missing_dependency_policy`: normalized v3 policy for unavailable optional dependencies
 - `required_args`: operation-specific required keyword arguments
 - `trusted_only`: whether the format must be restricted to trusted data
 - `optional_dependencies`: optional import/package names used by the published
@@ -43,6 +39,18 @@ Each format entry contains these fields:
   is unavailable
 - `metadata_requirements`: extra metadata rules that are part of the public contract
 - `notes`: short rationale and boundary notes
+
+### Normalized v3 Fields
+
+The conformance loader derives additional v3 policy fields in memory from each
+on-disk format entry plus the top-level `io_conformance_v3` policy block. These
+values are exposed under each normalized entry's `v3` surface; they are not
+required as top-level fields in each JSON format entry.
+
+- `fixture_generator`: normalized fixture-generation policy for the published route
+- `coverage_status`: normalized coverage status for the published route
+- `ci_jobs`: normalized CI gate mapping used to enforce the published route
+- `missing_dependency_policy`: normalized per-operation policy for unavailable optional dependencies
 
 Rules:
 

--- a/docs/developers/contracts/public_io_contract.md
+++ b/docs/developers/contracts/public_io_contract.md
@@ -17,6 +17,7 @@ implementation surface.
 
 ## Schema
 
+The top-level `io_conformance_v3` policy block defines the public I/O gate shape.
 Each format entry contains these fields:
 
 - `name`: human-facing label used in docs and reviews
@@ -28,6 +29,10 @@ Each format entry contains these fields:
 - `registry_api`: classes that are currently registered in the astropy/gwpy I/O registry
 - `public_auto_identify`: whether published usage may rely on `format=None`
 - `registry_auto_identify`: whether the current implementation can identify the format automatically
+- `fixture_generator`: normalized v3 fixture-generation policy for the published route
+- `coverage_status`: normalized v3 coverage status for the published route
+- `ci_jobs`: normalized v3 CI gate mapping used to enforce the published route
+- `missing_dependency_policy`: normalized v3 policy for unavailable optional dependencies
 - `required_args`: operation-specific required keyword arguments
 - `trusted_only`: whether the format must be restricted to trusted data
 - `optional_dependencies`: optional import/package names used by the published

--- a/docs/developers/guides/testing.md
+++ b/docs/developers/guides/testing.md
@@ -50,10 +50,12 @@ python -m pytest
 ## Reproducing CI Gates Locally
 
 Gate-equivalent commands are centralized in `scripts/ci/run_gate.py` and are kept in sync with CI jobs.
+The `ci_jobs=base` contract mapping currently points to `python scripts/ci/run_gate.py io-conformance`; optional logical jobs stay as separate future mappings unless they are already documented elsewhere.
 
 ```bash
 python scripts/ci/run_gate.py pr-fast
 python scripts/ci/run_gate.py io-contract
+python scripts/ci/run_gate.py io-conformance
 python scripts/ci/run_gate.py io-optional
 python scripts/ci/run_gate.py io-network-backend
 python scripts/ci/run_gate.py docs-notebook

--- a/docs/developers/plans/active/2026-05-18-io-conformance-v0.1.4-plan.md
+++ b/docs/developers/plans/active/2026-05-18-io-conformance-v0.1.4-plan.md
@@ -1383,7 +1383,7 @@ v0.1.4 can ship when all of the following are true.
   `missing_dependency_policy` entries.
 - No format with public read or write classes lacks a `fixture_generator` reference.
 
-**Quantitative blocking test targets** (CI must report `blocking_pass / blocking_total`
+**Quantitative blocking test targets** (CI must report `blocked / total`
 ≥ 100% for the base gate):
 
 | Format | Min blocking rows |
@@ -1413,4 +1413,4 @@ only for `read_alias_format` / `write_alias_format` rows, not the full matrix.
   green.
 - Docs and changelog describe the conformance baseline accurately as the first
   systematic baseline, not full exhaustive enforcement.
-- CI outputs a `blocking_pass / blocking_total` summary line per job.
+- CI outputs a `blocked / total` summary line per job.

--- a/docs/developers/plans/active/2026-05-18-io-conformance-v0.1.4-plan.md
+++ b/docs/developers/plans/active/2026-05-18-io-conformance-v0.1.4-plan.md
@@ -1,0 +1,1391 @@
+# File I/O Conformance Plan for v0.1.4+
+
+Date: 2026-05-18
+Target release: v0.1.4 for the first conformance harness baseline
+Current released/runtime version in repository metadata: v0.1.3
+
+## Authoritative Source Policy
+
+When this plan and `docs/developers/contracts/public_io_contract.json` diverge:
+- **JSON contract** is authoritative for machine-readable fields (aliases, class lists,
+  tolerances, scenario status values).
+- **This plan** is authoritative for prose policy, CI gate definitions, migration
+  timelines, and acceptance criteria.
+- Discrepancies must be resolved before v0.1.4 ships by updating the JSON contract to
+  match the agreed policy.
+
+## Purpose
+
+GWexpy v0.1.1-v0.1.3 exposed repeated regressions in file I/O behavior. The
+current test suite has many useful format-specific tests, but it does not yet
+provide one systematic, contract-driven path that validates every public file
+format through generation, read, write, and external readback.
+
+This plan turns `docs/developers/contracts/public_io_contract.json` into an
+executable conformance specification.
+
+The required flow for every covered scenario is:
+
+1. Generate mock data without importing or using GWexpy.
+2. Read the mock file with GWexpy through all public read classes and required
+   registry/direct convenience classes.
+3. Cover the declared channel/file layout patterns for that format.
+4. If public write exists, write to a local temporary file with GWexpy.
+5. Read the written file back with GWexpy and, where applicable, with GWpy or
+   the native third-party library.
+6. Compare values and metadata under explicit per-format tolerances.
+
+## Schema Migration (v2 → v3)
+
+The public I/O contract is currently at schema-v2. Schema v3 introduces new fields
+required by this conformance plan. The migration policy is:
+
+- v2 is canonical until the v3 JSON schema validator lands in the repository.
+- v3 is **additive-only** for v0.1.4: no existing v2 field is renamed or removed.
+- The v3 validator must accept both v2 and v3 documents during the v0.1.4 cycle.
+- Field removal and breaking changes to v2 are deferred to v0.1.6.
+- Every new v3 field listed in "Contract Schema v3 Additions" must have a default
+  value that does not break the v2 validator, or a separate v3-only schema file must
+  be introduced alongside the v2 file.
+
+## Non-Goals for v0.1.4
+
+- v0.1.4 will not make every public format a blocking full-matrix gate.
+- v0.1.4 will not promise stricter metadata preservation than the existing
+  public contract.
+- v0.1.4 will not remove existing targeted tests.
+- v0.1.4 will not remove `gwexpy.register_all()`.
+- v0.1.4 will not require all optional backends in the base CI job.
+
+## Target Classes
+
+The conformance harness must know every class referenced by the public I/O
+contract. The classes are grouped by family.
+
+### Time-Series Family
+
+- `TimeSeries`
+- `TimeSeriesDict`
+- `TimeSeriesList`
+- `TimeSeriesMatrix`
+
+### Frequency-Series Family
+
+- `FrequencySeries`
+- `FrequencySeriesDict`
+- `FrequencySeriesList`
+- `FrequencySeriesMatrix`
+
+### Spectrogram Family
+
+- `Spectrogram`
+- `SpectrogramDict`
+- `SpectrogramList`
+
+### Tracked but Out-of-Scope for v0.1.4
+
+The following classes are known to GWexpy but are not referenced by the schema-v2
+public I/O contract. They must not appear in blocking acceptance criteria until the
+JSON contract explicitly includes them.
+
+- `SpectrogramMatrix`: exclude from blocking scenarios; add to the conformance matrix
+  only after the JSON contract references it.
+- `FrequencySeriesMatrix`: tracked, not in any blocking HDF5 scenario for v0.1.4.
+
+### Histogram Family
+
+- `Histogram`
+- `HistogramDict`
+- `HistogramList`
+
+### Segment Family
+
+- `SegmentList`
+- `DataQualityFlag`
+- `DataQualityDict`
+
+### Table Family
+
+- `EventTable`
+
+## Scenario Vocabulary
+
+Every format entry in contract schema v3 must explicitly list supported and
+unsupported scenarios. A missing scenario policy is a schema failure.
+
+### Generation Scenarios
+
+- `generate_single_channel_single_file`: create one channel in one file.
+- `generate_multi_channel_single_file`: create multiple channels in one file.
+- `generate_single_channel_multi_file`: create one logical channel split across
+  multiple files.
+- `generate_multi_channel_multi_file`: create multiple logical channels split
+  across multiple files.
+- `generate_collection_directory`: create a manifest-backed collection
+  directory.
+- `generate_native_external`: create with the native library for the format.
+- `generate_manual_spec`: create with a documented binary/text schema and
+  standard library or NumPy only.
+- `generate_gwpy_external`: create with GWpy, allowed only where a practical
+  independent writer is not available, such as GWF.
+
+### Read Scenarios
+
+- `read_explicit_format`: call `.read(..., format=canonical)`.
+- `read_auto_identify_public`: call `.read(...)` with `format=None` when the format's
+  public contract declares `public_auto_identify: true`. This is the user-visible
+  documented behavior.
+- `read_auto_identify_registry`: call `.read(...)` with `format=None` via the internal
+  registry identifier when `public_auto_identify` is false but the registry can still
+  identify the format. This is a nightly-only scenario and is not part of the public
+  contract guarantee.
+- `read_alias_format`: call `.read(..., format=alias)` for every alias.
+- `read_required_args`: call `.read()` with required args such as `products` or
+  `timezone`.
+- `read_missing_required_args`: assert the documented error when required args
+  are missing.
+- `read_single_channel_single_file`: public single-channel read.
+- `read_multi_channel_single_file`: public multi-channel read.
+- `read_single_channel_multi_file`: public one-channel multi-file read.
+- `read_multi_channel_multi_file`: public multi-channel multi-file read.
+- `read_collection_directory`: public collection-directory read.
+- `read_optional_dependency_missing`: assert documented missing-backend behavior.
+- `read_trusted_only`: assert security policy behavior for formats that require
+  explicit user opt-in (see `security_policy` field in schema v3).
+
+### Write Scenarios
+
+- `write_single_object`: write one public object.
+- `write_collection`: write dict/list public objects.
+- `write_matrix`: write matrix public objects.
+- `write_alias_format`: write using every public write alias.
+- `write_unsupported`: assert no public writer or documented unsupported error.
+- `write_optional_dependency_missing`: assert documented missing-backend behavior.
+
+### Readback and Interop Scenarios
+
+- `readback_gwexpy`: read GWexpy-written file with GWexpy.
+- `readback_gwpy`: read GWexpy-written file with GWpy where GWpy supports it.
+- `readback_native`: read GWexpy-written file with the native library.
+- `readback_registry_import_path`: repeat read in a fresh subprocess using the
+  user-visible direct import path, without calling `register_all()`.
+- `readback_top_level_import_path`: repeat read in a fresh subprocess after
+  `import gwexpy`.
+
+### Multi-File Policy Values
+
+- `unsupported`: multi-file input is not part of the public contract.
+- `single_file_only`: the format is inherently or currently single-file.
+- `list_of_files`: `.read([file1, file2, ...])` is public behavior.
+- `collection_directory`: multi-object I/O is represented by a directory and
+  manifest, not by a list of independent format files.
+- `backend_dependent`: scenario runs only when the backend supports it.
+
+### Coverage Status Values
+
+- `blocking`: must pass in the v0.1.4 primary CI gate.
+- `optional_blocking`: must pass in the optional-backend CI job when required
+  dependencies are installed.
+- `nightly`: runs in nightly/extended CI and is not a PR blocker for v0.1.4.
+- `planned`: explicitly out of scope for v0.1.4, but required before the
+  conformance matrix is considered complete.
+- `not_public`: not a public direct I/O scenario.
+
+## Contract Schema v3 Additions
+
+Every format entry must add these fields:
+
+- `fixture_generator`: named generator under `tests/io_conformance/generators`.
+- `scenario_matrix`: structured scenario list.
+- `external_writer`: native or GWpy writer used to generate fixtures.
+- `external_reader`: native or GWpy reader used for external readback.
+- `roundtrip_policy`: exact, lossy, metadata-light, read-only, or unsupported.
+- `comparison_tolerances`: value/time/frequency tolerance policy.
+- `metadata_must_match`: metadata keys that must survive read/write/readback.
+- `multi_file_policy`: one of the values listed above.
+- `coverage_status`: default status for this format in v0.1.4.
+- `ci_jobs`: one or more of `base`, `io-audio`, `io-seismic`, `io-netcdf4`, `io-zarr`,
+  `io-tdms`, `io-root`, `nightly`. These identifiers must match the CI job names in
+  `.github/workflows/` exactly.
+- `missing_dependency_policy`: skip, xfail, or must_raise_import_error.
+- `security_policy`: object with `trusted_only: bool` and `requires_warning: bool`.
+  `trusted_only: true` means the format may only be read when the caller explicitly
+  opts in. `requires_warning: true` means GWexpy must emit a visible warning on read.
+  Default for all formats: `{trusted_only: false, requires_warning: false}`.
+
+## Generator Determinism Contract
+
+Every generator under `tests/io_conformance/generators/` must satisfy all of the
+following rules.
+
+**No GWexpy import.** Generators must not import `gwexpy` or any submodule of it.
+Enforcement: `tests/io_conformance/conftest.py` runs an import-guard check at
+session start that greps each generator module for `import gwexpy`; the session
+fails immediately if any match is found.
+
+**Seeded RNG.** All numeric payload generation must use `numpy.random.default_rng(SEED)`
+where `SEED` is a per-format integer constant defined in `generators/__init__.py`.
+No call to `random.random()`, `np.random.seed()`, or any global RNG state is allowed.
+
+**Fixed metadata.** `t0`, `gps_start`, `f0`, and `sample_rate` must be hard-coded
+per generator function, not derived from `time.time()` or any system clock.
+
+**Pure function signature.** Every public generator function must accept only
+`(tmp_path, seed=None, *, n_samples, n_channels, dtype)` or a strict subset of
+those arguments. No side effects, no filesystem reads outside `tmp_path`.
+
+**pytest-xdist safety.** All generators write exclusively under the `tmp_path`
+fixture provided by pytest. No shared global state. Conformance tests are xdist-safe
+by design.
+
+Every scenario row must be executable as a unique tuple:
+
+```text
+(format, operation, scenario, class, layout, format_token, dependency_mode, status)
+```
+
+For example, `read_multi_channel_single_file` for `TimeSeriesDict` and
+`read_multi_channel_single_file` for `TimeSeriesMatrix` are two separate rows,
+not duplicate prose bullets. `format_token` is `canonical`, a concrete alias, or
+`auto`; `dependency_mode` is `base`, `optional-present`, or `optional-missing`.
+
+## Test Tree
+
+Add a new conformance harness without replacing existing targeted tests.
+
+```text
+tests/io_conformance/
+  __init__.py
+  conftest.py
+  contract.py
+  scenarios.py
+  generators/
+    __init__.py
+    audio.py
+    ats.py
+    csv_txt.py
+    dttxml.py
+    gbd.py
+    gwf.py
+    hdf5.py
+    ndscope.py
+    netcdf.py
+    root.py
+    sdb.py
+    seismic.py
+    tdms.py
+    zarr.py
+  validators/
+    __init__.py
+    common.py
+    timeseries.py
+    frequencyseries.py
+    spectrogram.py
+    histogram.py
+    segments.py
+    table.py
+  test_contract_schema_v3.py
+  test_read_conformance.py
+  test_write_roundtrip.py
+  test_external_interop.py
+  test_registry_import_paths.py
+  test_optional_dependency_behavior.py
+```
+
+## Test Parametrization
+
+**Scenario expansion.** `tests/io_conformance/scenarios.py` reads the JSON contract
+and expands every `(format, operation, scenario, class, layout, format_token,
+dependency_mode, status)` tuple into a pytest parametrize ID. The harness must skip
+rows where `status` is `planned` or `not_public`, and xfail rows where
+`dependency_mode` is `optional-missing` and the dependency is absent.
+
+**Alias sampling policy.** Running the full scenario matrix for every alias would
+multiply test count by the number of aliases. Instead:
+- One complete scenario sweep runs under the canonical format name.
+- Alias coverage is limited to `read_alias_format` (one read roundtrip per alias)
+  and `write_alias_format` (one write roundtrip per writable alias).
+- No alias receives the full matrix in blocking CI; full alias matrix is nightly only.
+
+**Subprocess import-path sampling.** `readback_registry_import_path` and
+`readback_top_level_import_path` start fresh Python processes, which are expensive.
+Sampling rule for blocking CI:
+- Run one subprocess per `(format, import_path_type)` pair using the simplest
+  available class for that format (typically `TimeSeries` or `TimeSeriesDict`).
+- Do not multiply subprocesses across all class/layout/alias combinations in blocking
+  CI.
+- Full per-scenario subprocess expansion is nightly only.
+
+**pytest-xdist.** The full conformance suite must pass under `pytest -n auto`. Each
+test function receives an isolated `tmp_path` and must not share file handles or
+global state with other tests.
+
+Generators under `tests/io_conformance/generators` must not import `gwexpy`.
+Conformance tests should fail if a generator imports `gwexpy` accidentally.
+Legacy fixtures under `tests/fixtures` remain available for targeted tests only.
+Conformance tests must generate every file they consume in `tmp_path`; they must not
+read from `tests/fixtures` or any pre-committed binary fixture. No silent stub
+fallback is permitted: if a generator fails, the test must fail immediately with a
+clear error, not skip silently.
+
+## Complete Format Matrix
+
+The matrix below lists all 25 current contract formats. No contract format is
+omitted.
+
+### 1. `gwf`
+
+- Canonical: `gwf`
+- Aliases: `frame`, `framecpp`, `framel`, `lalframe`, `gwf.framecpp`,
+  `gwf.framel`, `gwf.lalframe`
+- Public read classes: `TimeSeries`, `TimeSeriesDict`
+- Public write classes: `TimeSeries`, `TimeSeriesDict`
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: `TimeSeries`, `TimeSeriesDict`
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: none in GWexpy contract, but runtime GWF backend
+  availability must be detected
+- Generator: `generators.gwf`
+- External writer: GWpy `TimeSeriesDict.write(format="gwf")`
+- External reader: GWpy GWF reader
+- GWpy version policy: `gwpy` must be pinned in conformance test extras as
+  `gwpy>=X.Y,<X.Z`. Version bumps require re-running the GWF scenario matrix and
+  updating tolerances if outputs change.
+- Multi-file policy: `list_of_files`
+- Scenarios:
+  - `generate_single_channel_single_file`: blocking
+  - `generate_multi_channel_single_file`: blocking
+  - `generate_single_channel_multi_file`: blocking
+  - `generate_multi_channel_multi_file`: blocking
+  - `read_explicit_format`: blocking
+  - `read_auto_identify`: blocking
+  - `read_alias_format`: blocking for every alias
+  - `read_single_channel_single_file`: blocking for `TimeSeries`
+  - `read_multi_channel_single_file`: blocking for `TimeSeriesDict`
+  - `read_single_channel_multi_file`: blocking for `TimeSeries`
+  - `read_multi_channel_multi_file`: blocking for `TimeSeriesDict`
+  - `write_single_object`: blocking for `TimeSeries`
+  - `write_collection`: blocking for `TimeSeriesDict`
+  - `write_alias_format`: blocking for every writable alias
+  - `readback_gwexpy`: blocking
+  - `readback_gwpy`: blocking
+  - `readback_registry_import_path`: blocking
+  - `readback_top_level_import_path`: blocking
+- Metadata must match: `sample_rate`, `dt`, `t0`, `duration`, `channel`,
+  `name`, `unit`, channel keys
+- Tolerances: exact sample count, exact channel keys, numeric `rtol=1e-12`,
+  `atol=1e-12` for float64 fixtures
+- v0.1.4 status: blocking
+
+### 2. `hdf.ndscope`
+
+- Canonical: `hdf.ndscope`
+- Aliases: `ndscope-hdf5`, `ndscope_hdf5`, `ndscopehdf5`
+- Public read classes: `TimeSeriesDict`
+- Public write classes: `TimeSeriesDict`
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: none beyond base HDF5 stack used by project
+- Generator: `generators.ndscope`
+- External writer: `h5py`
+- External reader: `h5py`
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: blocking
+  - `generate_multi_channel_single_file`: blocking
+  - `read_explicit_format`: blocking
+  - `read_auto_identify`: blocking
+  - `read_alias_format`: blocking for every alias
+  - `read_single_channel_single_file`: blocking for `TimeSeriesDict`
+  - `read_multi_channel_single_file`: blocking for `TimeSeriesDict`
+  - `write_collection`: blocking for `TimeSeriesDict`
+  - `write_alias_format`: blocking for every writable alias
+  - `readback_gwexpy`: blocking
+  - `readback_native`: blocking with `h5py` schema inspection
+  - `readback_registry_import_path`: blocking
+  - `readback_top_level_import_path`: blocking
+- Metadata must match: `rate_hz`, `gps_start`, `unit`, channel group names,
+  sample count
+- Tolerances: numeric `rtol=1e-7`, `atol=1e-7` for float32 fixtures
+- v0.1.4 status: blocking
+
+### 3. `hdf5`
+
+- Canonical: `hdf5`
+- Aliases: none
+- Public read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesList`,
+  `TimeSeriesMatrix`, `FrequencySeries`, `FrequencySeriesDict`,
+  `FrequencySeriesList`, `Spectrogram`, `SpectrogramDict`,
+  `SpectrogramList`, `Histogram`, `HistogramDict`, `HistogramList`,
+  `EventTable`
+- Public write classes: same as public read classes
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `FrequencySeries`,
+  `Spectrogram`, `SegmentList`, `DataQualityFlag`, `DataQualityDict`,
+  `EventTable`
+- Registry write classes: `TimeSeries`, `TimeSeriesDict`, `FrequencySeries`,
+  `Spectrogram`, `SegmentList`, `DataQualityFlag`, `DataQualityDict`,
+  `EventTable`
+- Direct read classes: `TimeSeriesDict`, `TimeSeriesList`,
+  `TimeSeriesMatrix`, `FrequencySeriesDict`, `FrequencySeriesList`,
+  `SpectrogramDict`, `SpectrogramList`, `Histogram`, `HistogramDict`,
+  `HistogramList`
+- Direct write classes: same as direct read classes
+- Required read args: none
+- Required write args: none
+- Optional dependencies: none beyond base HDF5 stack used by project
+- Generator: `generators.hdf5`
+- External writer: `h5py` for raw layout fixtures, GWpy for GWpy-native HDF5
+  fixtures where applicable
+- External reader: `h5py`, GWpy where applicable
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: blocking for time/frequency series
+  - `generate_multi_channel_single_file`: blocking for dict/list/matrix families
+  - `read_explicit_format`: blocking
+  - `read_auto_identify_public`: not_public — the public contract requires explicit
+    `format="hdf5"`; auto-identification is not a documented user-facing guarantee
+  - `read_auto_identify_registry`: nightly — the registry can identify HDF5 files
+    but this is not exposed as a public contract
+  - `read_single_channel_single_file`: blocking for `TimeSeries`,
+    `FrequencySeries`, `Spectrogram`, `Histogram`, `EventTable`
+  - `read_multi_channel_single_file`: blocking for `TimeSeriesDict`,
+    `TimeSeriesList`, `TimeSeriesMatrix`, `FrequencySeriesDict`,
+    `FrequencySeriesList`, `SpectrogramDict`, `SpectrogramList`,
+    `HistogramDict`, `HistogramList`
+  - `write_single_object`: blocking for `TimeSeries`, `FrequencySeries`,
+    `Spectrogram`, `Histogram`, `EventTable`
+  - `write_collection`: blocking for dict/list classes
+  - `write_matrix`: blocking for `TimeSeriesMatrix`; planned for
+    `FrequencySeriesMatrix` and `SpectrogramMatrix` unless they become public
+  - `readback_gwexpy`: blocking
+  - `readback_gwpy`: blocking where GWpy supports the class
+  - `readback_native`: blocking with `h5py` structure inspection
+  - `readback_registry_import_path`: blocking for registry-backed classes
+  - `readback_top_level_import_path`: blocking
+- Metadata must match: family-specific axes, `sample_rate`/`dt`, `df`, `f0`,
+  `frequencies`, `times`, `unit`, `name`, `channel`, collection keys,
+  histogram edges, table columns
+- Tolerances: exact shapes and keys; numeric `rtol=1e-12`, `atol=1e-12` for
+  float64; family-specific relaxed tolerance only where existing writer stores
+  float32
+- v0.1.4 status: blocking for public classes listed above, except matrix classes
+  not in public HDF5 contract remain not_public/planned
+
+### 4. `xml.diaggui`
+
+- Canonical: `xml.diaggui`
+- Aliases: `dttxml`
+- Public read classes: `TimeSeriesDict`
+- Public write classes: none
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`,
+  `FrequencySeriesDict`, `FrequencySeriesMatrix`
+- Registry write classes: none
+- Direct read classes: `FrequencySeries`, `FrequencySeriesDict`
+- Direct write classes: none
+- Required read args: `products`
+- Required write args: none
+- Optional dependencies: none; native parser fallback behavior must be checked
+- Generator: `generators.dttxml`
+- External writer: manual XML/LIGO_LW generation with standard library and NumPy
+- External reader: optional `dttxml` package where installed, otherwise native
+  parser expectations
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking
+  - `generate_multi_channel_single_file`: optional_blocking
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify_public`: not_public — not a documented user-facing guarantee
+    despite the registry identifier
+  - `read_alias_format`: optional_blocking for `dttxml`
+  - `read_required_args`: optional_blocking with `products`
+  - `read_missing_required_args`: optional_blocking
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
+  - `write_unsupported`: blocking
+  - `readback_registry_import_path`: optional_blocking
+  - `readback_top_level_import_path`: optional_blocking
+- Metadata must match: product name, channel names, `dt`/`df`, `t0`/epoch,
+  unit, sample/bin count
+- Tolerances: XML float32 payload `rtol=1e-6`, `atol=1e-8`
+- v0.1.4 status: planned or optional_blocking; not a core blocking gate
+
+### 5. `csv`
+
+- Canonical: `csv`
+- Aliases: none
+- Public read classes: `TimeSeries`, `TimeSeriesDict`
+- Public write classes: `TimeSeries`, `TimeSeriesDict`
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`,
+  `FrequencySeries`, `Spectrogram`, `EventTable`
+- Registry write classes: `TimeSeries`, `FrequencySeries`, `Spectrogram`,
+  `EventTable`
+- Direct read classes: `TimeSeriesDict`, `TimeSeriesList`,
+  `FrequencySeriesDict`, `FrequencySeriesList`
+- Direct write classes: same as direct read classes
+- Required read args: none
+- Required write args: none
+- Optional dependencies: none
+- Generator: `generators.csv_txt`
+- External writer: Python `csv` module / pandas-free text generation
+- External reader: Python `csv` module / NumPy text loading for structure
+- Multi-file policy: `collection_directory`
+- Scenarios:
+  - `generate_single_channel_single_file`: blocking
+  - `generate_multi_channel_single_file`: blocking for single CSV where supported
+  - `generate_collection_directory`: blocking for `TimeSeriesDict`
+  - `read_explicit_format`: blocking
+  - `read_auto_identify`: blocking
+  - `read_single_channel_single_file`: blocking for `TimeSeries`
+  - `read_multi_channel_single_file`: blocking for `TimeSeriesDict`
+  - `read_collection_directory`: blocking for `TimeSeriesDict`
+  - `write_single_object`: blocking for `TimeSeries`
+  - `write_collection`: blocking for `TimeSeriesDict`
+  - `readback_gwexpy`: blocking
+  - `readback_native`: blocking with CSV structural checks
+  - `readback_registry_import_path`: blocking
+  - `readback_top_level_import_path`: blocking
+- Metadata must match: sample count, values, time column where present,
+  collection keys for manifest layout
+- Metadata not guaranteed: complete unit/name/channel preservation across every
+  GWpy-compatible CSV route
+- Tolerances: numeric `rtol=1e-12`, `atol=1e-12`
+- v0.1.4 status: blocking
+
+### 6. `txt`
+
+- Canonical: `txt`
+- Aliases: none
+- Public read classes: `TimeSeries`, `TimeSeriesDict`
+- Public write classes: `TimeSeries`, `TimeSeriesDict`
+- Registry read classes: `TimeSeries`, `FrequencySeries`
+- Registry write classes: `TimeSeries`, `FrequencySeries`
+- Direct read classes: `TimeSeriesDict`, `TimeSeriesList`,
+  `FrequencySeriesDict`, `FrequencySeriesList`
+- Direct write classes: same as direct read classes
+- Required read args: none
+- Required write args: none
+- Optional dependencies: none
+- Generator: `generators.csv_txt`
+- External writer: plain text generation with NumPy arrays
+- External reader: NumPy text loading for structure
+- Multi-file policy: `collection_directory`
+- Scenarios:
+  - `generate_single_channel_single_file`: blocking
+  - `generate_collection_directory`: blocking for `TimeSeriesDict`
+  - `read_explicit_format`: blocking
+  - `read_auto_identify`: not_public
+  - `read_single_channel_single_file`: blocking for `TimeSeries`
+  - `read_collection_directory`: blocking for `TimeSeriesDict`
+  - `write_single_object`: blocking for `TimeSeries`
+  - `write_collection`: blocking for `TimeSeriesDict`
+  - `readback_gwexpy`: blocking
+  - `readback_native`: blocking with text structural checks
+  - `readback_registry_import_path`: blocking
+  - `readback_top_level_import_path`: blocking
+- Metadata must match: sample count, values, time column where present,
+  collection manifest keys
+- Metadata not guaranteed: full name/channel/unit preservation for basic text
+- Tolerances: numeric `rtol=1e-12`, `atol=1e-12`
+- v0.1.4 status: blocking
+
+### 7. `pickle`
+
+- Canonical: `pickle`
+- Aliases: none
+- Public read classes: none
+- Public write classes: none
+- Registry read classes: none
+- Registry write classes: none
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: none
+- Security policy: `{trusted_only: true, requires_warning: true}`
+- Generator: none for public direct I/O
+- External writer: Python `pickle` only for serialization compatibility tests
+- External reader: Python `pickle`
+- Multi-file policy: `unsupported`
+- Scenarios:
+  - `read_trusted_only`: blocking for security policy documentation tests
+  - `write_unsupported`: blocking for direct I/O contract boundary
+  - all public direct read/write scenarios: not_public
+- Metadata must match: not applicable
+- Tolerances: not applicable
+- v0.1.4 status: not_public for direct I/O, blocking for boundary/security
+  assertions
+
+### 8. `root`
+
+- Canonical: `root`
+- Aliases: none
+- Public read classes: `EventTable`
+- Public write classes: `EventTable`
+- Registry read classes: `EventTable`
+- Registry write classes: `EventTable`
+- Direct read classes: none
+- Direct write classes: `TimeSeriesDict`, `TimeSeriesList`,
+  `FrequencySeriesDict`, `FrequencySeriesList`, `SpectrogramDict`,
+  `SpectrogramList`, `HistogramDict`, `HistogramList`
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `uproot`
+- Generator: `generators.root`
+- External writer: `uproot`
+- External reader: `uproot`
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking for EventTable-like
+    tree/table fixture
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking if registry supports it
+  - `write_single_object`: optional_blocking for `EventTable`
+  - `readback_gwexpy`: optional_blocking
+  - `readback_native`: optional_blocking with `uproot`
+  - `read_optional_dependency_missing`: blocking in base CI
+  - `write_optional_dependency_missing`: blocking in base CI
+- Metadata must match: table column names, row count, numeric column values
+- Tolerances: numeric `rtol=1e-12`, `atol=1e-12`
+- v0.1.4 status: planned/optional_blocking, not base blocking
+
+### 9. `sdb`
+
+- Canonical: `sdb`
+- Aliases: `sqlite`, `sqlite3`
+- Public read classes: `TimeSeries`, `TimeSeriesDict`
+- Public write classes: none
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: none
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: none
+- Generator: `generators.sdb`
+- External writer: Python `sqlite3`
+- External reader: Python `sqlite3`
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking
+  - `generate_multi_channel_single_file`: optional_blocking
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `read_alias_format`: optional_blocking for `sqlite`, `sqlite3`
+  - `read_single_channel_single_file`: optional_blocking for `TimeSeries`
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
+  - `write_unsupported`: blocking
+  - `readback_registry_import_path`: optional_blocking
+  - `readback_top_level_import_path`: optional_blocking
+- Metadata must match: selected channel/column names, sample count, time spacing
+- Tolerances: numeric `rtol=1e-12`, `atol=1e-12`
+- v0.1.4 status: planned/optional_blocking
+
+### 10. `wav`
+
+- Canonical: `wav`
+- Aliases: none
+- Public read classes: `TimeSeries`, `TimeSeriesDict`
+- Public write classes: `TimeSeries`
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: `TimeSeries`
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `tinytag`
+- Generator: `generators.audio`
+- External writer: `scipy.io.wavfile`
+- External reader: `scipy.io.wavfile`, `tinytag` for metadata when installed
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: blocking
+  - `generate_multi_channel_single_file`: blocking if stereo/multi-channel WAV is
+    public for `TimeSeriesDict`
+  - `read_explicit_format`: blocking
+  - `read_auto_identify`: blocking
+  - `read_single_channel_single_file`: blocking for `TimeSeries`
+  - `read_multi_channel_single_file`: blocking for `TimeSeriesDict`
+  - `write_single_object`: blocking for `TimeSeries`
+  - `write_collection`: not_public
+  - `readback_gwexpy`: blocking
+  - `readback_native`: blocking with `scipy.io.wavfile`
+  - `readback_registry_import_path`: blocking
+  - `readback_top_level_import_path`: blocking
+- Metadata must match: sample rate, sample count, channel count
+- Metadata not guaranteed: absolute `t0` — WAV does not store GPS epoch. Roundtrip
+  comparisons must exclude `t0`. Post-roundtrip tests assert `t0 == 0.0` (the
+  writer default) rather than comparing against the original.
+- Tolerances: PCM quantization tolerance based on sample width; `atol=1/32767` for
+  int16 fixtures (full signed range is ±32767, not ±32768).
+- v0.1.4 status: blocking
+
+### 11. `flac`
+
+- Canonical: `flac`
+- Aliases: none
+- Public read classes: `TimeSeries`, `TimeSeriesDict`
+- Public write classes: `TimeSeries`, `TimeSeriesDict`
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `pydub`, `tinytag`, external `ffmpeg`/`libav`
+- Generator: `generators.audio`
+- External writer: `pydub`
+- External reader: `pydub`, `tinytag`
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking
+  - `generate_multi_channel_single_file`: optional_blocking
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `write_single_object`: optional_blocking
+  - `write_collection`: optional_blocking
+  - `readback_gwexpy`: optional_blocking
+  - `readback_native`: optional_blocking
+  - `read_optional_dependency_missing`: blocking in base CI
+  - `write_optional_dependency_missing`: blocking in base CI
+- Metadata must match: sample rate, sample count within codec tolerance, channel
+  count
+- Metadata not guaranteed: absolute `t0` — excluded from roundtrip comparison;
+  post-roundtrip tests assert `t0 == 0.0`.
+- Tolerances: lossless codec should match PCM within quantization tolerance;
+  fallback tolerance `atol=1/32767` for int16 fixtures.
+- v0.1.4 status: planned/optional_blocking
+
+### 12. `ogg`
+
+- Canonical: `ogg`
+- Aliases: none
+- Public read classes: `TimeSeries`, `TimeSeriesDict`
+- Public write classes: `TimeSeries`, `TimeSeriesDict`
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `pydub`, `tinytag`, external `ffmpeg`/`libav`
+- Generator: `generators.audio`
+- External writer: `pydub`
+- External reader: `pydub`, `tinytag`
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking
+  - `generate_multi_channel_single_file`: optional_blocking
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `write_single_object`: optional_blocking
+  - `write_collection`: optional_blocking
+  - `readback_gwexpy`: optional_blocking
+  - `readback_native`: optional_blocking
+  - `read_optional_dependency_missing`: blocking in base CI
+  - `write_optional_dependency_missing`: blocking in base CI
+- Metadata must match: sample rate, approximate duration, channel count
+- Metadata not guaranteed: absolute `t0` — excluded from roundtrip comparison;
+  post-roundtrip tests assert `t0 == 0.0`.
+- Tolerances: lossy codec, use duration/sample-rate checks and relaxed waveform
+  comparison only if stable in CI
+- v0.1.4 status: planned/optional_blocking
+
+### 13. `mp3`
+
+- Canonical: `mp3`
+- Aliases: none
+- Public read classes: `TimeSeries`, `TimeSeriesDict`
+- Public write classes: `TimeSeries`, `TimeSeriesDict`
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `pydub`, `tinytag`, external `ffmpeg`/`libav`
+- Generator: `generators.audio`
+- External writer: `pydub`
+- External reader: `pydub`, `tinytag`
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking
+  - `generate_multi_channel_single_file`: optional_blocking
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `write_single_object`: optional_blocking
+  - `write_collection`: optional_blocking
+  - `readback_gwexpy`: optional_blocking
+  - `readback_native`: optional_blocking
+  - `read_optional_dependency_missing`: blocking in base CI
+  - `write_optional_dependency_missing`: blocking in base CI
+- Metadata must match: sample rate, approximate duration, channel count
+- Metadata not guaranteed: absolute `t0` — excluded from roundtrip comparison;
+  post-roundtrip tests assert `t0 == 0.0`.
+- Tolerances: lossy codec, avoid strict sample-by-sample equality
+- v0.1.4 status: planned/optional_blocking
+
+### 14. `m4a`
+
+- Canonical: `m4a`
+- Aliases: none
+- Public read classes: `TimeSeries`, `TimeSeriesDict`
+- Public write classes: `TimeSeries`, `TimeSeriesDict`
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `pydub`, `tinytag`, external `ffmpeg`/`libav`
+- Generator: `generators.audio`
+- External writer: `pydub`
+- External reader: `pydub`, `tinytag`
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking
+  - `generate_multi_channel_single_file`: optional_blocking
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `write_single_object`: optional_blocking
+  - `write_collection`: optional_blocking
+  - `readback_gwexpy`: optional_blocking
+  - `readback_native`: optional_blocking
+  - `read_optional_dependency_missing`: blocking in base CI
+  - `write_optional_dependency_missing`: blocking in base CI
+- Metadata must match: sample rate, approximate duration, channel count
+- Metadata not guaranteed: absolute `t0` — excluded from roundtrip comparison;
+  post-roundtrip tests assert `t0 == 0.0`.
+- Tolerances: lossy codec, avoid strict sample-by-sample equality
+- v0.1.4 status: planned/optional_blocking
+
+### 15. `gbd`
+
+- Canonical: `gbd`
+- Aliases: none
+- Public read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Public write classes: none
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: none
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: `timezone`
+- Required write args: none
+- Optional dependencies: none
+- Generator: `generators.gbd`
+- External writer: manual Graphtec-style header/body writer
+- External reader: structural manual parser for generated fixture
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking
+  - `generate_multi_channel_single_file`: optional_blocking
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `read_required_args`: optional_blocking with `timezone`
+  - `read_missing_required_args`: blocking
+  - `read_single_channel_single_file`: optional_blocking for `TimeSeries`
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesMatrix`
+  - `write_unsupported`: blocking
+  - `readback_registry_import_path`: optional_blocking
+  - `readback_top_level_import_path`: optional_blocking
+- Metadata must match: channel names, digital/analog channel classification,
+  sample count, `dt`, timezone-resolved start time
+- Tolerances: integer raw counts exact; scaled analog values `rtol=1e-12`
+- v0.1.4 status: planned/optional_blocking
+
+### 16. `tdms`
+
+- Canonical: `tdms`
+- Aliases: none
+- Public read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Public write classes: none
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: none
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `nptdms`
+- Generator: `generators.tdms`
+- External writer: `nptdms`
+- External reader: `nptdms`
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking
+  - `generate_multi_channel_single_file`: optional_blocking
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `read_single_channel_single_file`: optional_blocking for `TimeSeries`
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesMatrix`
+  - `write_unsupported`: blocking
+  - `read_optional_dependency_missing`: blocking in base CI
+  - `readback_native`: optional_blocking
+- Metadata must match: group/channel names, `wf_increment`, `wf_start_time`,
+  sample count
+- Tolerances: numeric `rtol=1e-12`, `atol=1e-12`
+- v0.1.4 status: planned/optional_blocking
+
+### 17. `mseed`
+
+- Canonical: `mseed`
+- Aliases: `miniseed`
+- Public read classes: `TimeSeriesDict`
+- Public write classes: `TimeSeriesDict`
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: `TimeSeries`, `TimeSeriesDict`
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `obspy`
+- Generator: `generators.seismic`
+- External writer: ObsPy
+- External reader: ObsPy
+- Multi-file policy: `backend_dependent`
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking
+  - `generate_multi_channel_single_file`: optional_blocking
+  - `generate_multi_channel_multi_file`: nightly
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `read_alias_format`: optional_blocking for `miniseed`
+  - `read_single_channel_single_file`: optional_blocking for `TimeSeriesDict`
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
+  - `write_collection`: optional_blocking for `TimeSeriesDict`
+  - `write_alias_format`: optional_blocking for `miniseed`
+  - `readback_gwexpy`: optional_blocking
+  - `readback_native`: optional_blocking with ObsPy
+  - `read_optional_dependency_missing`: blocking in base CI
+- Metadata must match: network/station/channel mapping, start time, sample rate,
+  sample count
+- Tolerances: float32 seismic payload `rtol=1e-6`, `atol=1e-8`
+- v0.1.4 status: planned/optional_blocking
+
+### 18. `sac`
+
+- Canonical: `sac`
+- Aliases: none
+- Public read classes: `TimeSeriesDict`
+- Public write classes: `TimeSeriesDict`
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: `TimeSeries`, `TimeSeriesDict`
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `obspy`
+- Generator: `generators.seismic`
+- External writer: ObsPy
+- External reader: ObsPy
+- Multi-file policy: `backend_dependent`
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking
+  - `generate_multi_channel_single_file`: nightly
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `read_single_channel_single_file`: optional_blocking for `TimeSeriesDict`
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
+  - `write_collection`: optional_blocking for `TimeSeriesDict`
+  - `readback_gwexpy`: optional_blocking
+  - `readback_native`: optional_blocking with ObsPy
+  - `read_optional_dependency_missing`: blocking in base CI
+- Metadata must match: station/channel, start time, sample rate, sample count
+- Tolerances: float32 payload `rtol=1e-6`, `atol=1e-8`
+- v0.1.4 status: planned/optional_blocking
+
+### 19. `gse2`
+
+- Canonical: `gse2`
+- Aliases: none
+- Public read classes: `TimeSeriesDict`
+- Public write classes: `TimeSeriesDict`
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: `TimeSeries`, `TimeSeriesDict`
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `obspy`
+- Generator: `generators.seismic`
+- External writer: ObsPy
+- External reader: ObsPy
+- Multi-file policy: `backend_dependent`
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking
+  - `generate_multi_channel_single_file`: nightly
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `read_single_channel_single_file`: optional_blocking for `TimeSeriesDict`
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
+  - `write_collection`: optional_blocking for `TimeSeriesDict`
+  - `readback_gwexpy`: optional_blocking
+  - `readback_native`: optional_blocking with ObsPy
+  - `read_optional_dependency_missing`: blocking in base CI
+- Metadata must match: station/channel, start time, sample rate, sample count
+- Tolerances: format-dependent; prefer exact integer payload or relaxed float
+  comparison `rtol=1e-6`
+- v0.1.4 status: planned/optional_blocking
+
+### 20. `knet`
+
+- Canonical: `knet`
+- Aliases: none
+- Public read classes: `TimeSeriesDict`
+- Public write classes: none
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: none
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `obspy`
+- Generator: `generators.seismic`
+- External writer: ObsPy or manual K-NET text fixture if ObsPy writer support is
+  insufficient
+- External reader: ObsPy
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: planned
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
+  - `write_unsupported`: blocking
+  - `read_optional_dependency_missing`: blocking in base CI
+- Metadata must match: channel/station identifier, sample rate, sample count
+- Tolerances: generated numeric payload `rtol=1e-6`
+- v0.1.4 status: planned
+
+### 21. `win`
+
+- Canonical: `win`
+- Aliases: `win32`
+- Public read classes: `TimeSeriesDict`
+- Public write classes: none
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: none
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `obspy`
+- Generator: `generators.seismic`
+- External writer: manual WIN fixture or ObsPy where available
+- External reader: ObsPy where available
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: planned
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `read_alias_format`: optional_blocking for `win32`
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
+  - `write_unsupported`: blocking
+  - `read_optional_dependency_missing`: blocking or conditional registration
+    according to contract
+- Metadata must match: channel identifier, sample rate if present, sample count
+- Tolerances: generated integer payload exact where possible
+- v0.1.4 status: planned
+
+### 22. `ats`
+
+- Canonical: `ats`
+- Aliases: none
+- Public read classes: `TimeSeries`, `TimeSeriesDict`
+- Public write classes: none
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: none
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: none
+- Generator: `generators.ats`
+- External writer: manual ATS binary writer using `struct`
+- External reader: manual header/body parser for generated fixture
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `read_single_channel_single_file`: optional_blocking for `TimeSeries`
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
+    only if generated multi-channel variant exists
+  - `write_unsupported`: blocking
+  - `readback_registry_import_path`: optional_blocking
+  - `readback_top_level_import_path`: optional_blocking
+- Metadata must match: header version, sample frequency, start time, sample
+  count, integer payload scaling
+- Tolerances: integer payload exact before scaling; scaled values `rtol=1e-12`
+- v0.1.4 status: planned/optional_blocking
+
+### 23. `ats.mth5`
+
+- Canonical: `ats.mth5`
+- Aliases: none
+- Public read classes: `TimeSeries`
+- Public write classes: none
+- Registry read classes: `TimeSeries`
+- Registry write classes: none
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `mth5`
+- Generator: `generators.ats`
+- External writer: `mth5` or minimal MTH5 fixture helper
+- External reader: `mth5`
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: planned
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify_public`: not_public
+  - `read_single_channel_single_file`: optional_blocking for `TimeSeries`
+  - `write_unsupported`: blocking
+  - `read_optional_dependency_missing`: blocking in base CI
+  - `readback_native`: optional_blocking with `mth5`
+- Metadata must match: station/run/channel mapping, sample rate, start time,
+  unit where available
+- Tolerances: generated numeric payload `rtol=1e-12`
+- v0.1.4 status: planned
+
+### 24. `nc`
+
+- Canonical: `nc`
+- Aliases: `netcdf4`
+- Public read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Public write classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `xarray`, `netCDF4`
+- Generator: `generators.netcdf`
+- External writer: `netCDF4` and/or `xarray`
+- External reader: `netCDF4` and/or `xarray`
+- Multi-file policy: `single_file_only`
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking
+  - `generate_multi_channel_single_file`: optional_blocking
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `read_alias_format`: optional_blocking for `netcdf4`
+  - `read_single_channel_single_file`: optional_blocking for `TimeSeries`
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesMatrix`
+  - `write_single_object`: optional_blocking for `TimeSeries`
+  - `write_collection`: optional_blocking for `TimeSeriesDict`
+  - `write_matrix`: optional_blocking for `TimeSeriesMatrix`
+  - `write_alias_format`: optional_blocking for `netcdf4`
+  - `readback_gwexpy`: optional_blocking
+  - `readback_native`: optional_blocking
+  - `read_optional_dependency_missing`: blocking in base CI
+  - `write_optional_dependency_missing`: blocking in base CI
+- Metadata must match: explicit time coordinate, sample rate or `dt`, channel
+  variable names, units, sample count
+- Tolerances: numeric `rtol=1e-12`, `atol=1e-12`
+- v0.1.4 status: optional_blocking in netcdf4 CI, planned in base CI
+
+### 25. `zarr`
+
+- Canonical: `zarr`
+- Aliases: none
+- Public read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Public write classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry read classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Registry write classes: `TimeSeries`, `TimeSeriesDict`, `TimeSeriesMatrix`
+- Direct read classes: none
+- Direct write classes: none
+- Required read args: none
+- Required write args: none
+- Optional dependencies: `zarr`
+- Generator: `generators.zarr`
+- External writer: `zarr`
+- External reader: `zarr`
+- Multi-file policy: `single_file_only` for logical Zarr stores; directory store
+  layout is the format container, not a multi-file input list
+- Scenarios:
+  - `generate_single_channel_single_file`: optional_blocking
+  - `generate_multi_channel_single_file`: optional_blocking
+  - `read_explicit_format`: optional_blocking
+  - `read_auto_identify`: optional_blocking
+  - `read_single_channel_single_file`: optional_blocking for `TimeSeries`
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
+  - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesMatrix`
+  - `write_single_object`: optional_blocking for `TimeSeries`
+  - `write_collection`: optional_blocking for `TimeSeriesDict`
+  - `write_matrix`: optional_blocking for `TimeSeriesMatrix`
+  - `readback_gwexpy`: optional_blocking
+  - `readback_native`: optional_blocking
+  - `read_optional_dependency_missing`: blocking in base CI
+  - `write_optional_dependency_missing`: blocking in base CI
+- Metadata must match: group/array keys, `t0`, `dt` or sample rate, unit,
+  sample count, matrix channel ordering
+- Tolerances: numeric `rtol=1e-12`, `atol=1e-12`
+- v0.1.4 status: optional_blocking in zarr CI, planned in base CI
+
+## Cross-Format CI Gates
+
+### Base PR Gate for v0.1.4
+
+The base gate should run without optional heavy backends beyond what is already
+available in the default development environment.
+
+Blocking formats:
+
+- `gwf`
+- `hdf.ndscope`
+- `hdf5`
+- `csv`
+- `txt`
+- `wav`
+
+Blocking policy checks for all 25 formats:
+
+- contract schema v3 is valid
+- every format has `scenario_matrix`
+- every format has `coverage_status`
+- every public format has a generator policy, even if `coverage_status=planned`
+- unsupported writes are asserted for read-only public formats
+- missing optional dependencies follow documented behavior
+- direct import subprocess checks run for core blocking formats
+
+### Optional Backend CI Gates
+
+Separate CI jobs should run these groups. The job names below are canonical and must
+match the `ci_jobs` field values in the JSON contract.
+
+- `io-audio`: `flac`, `ogg`, `mp3`, `m4a`, extended `wav`
+- `io-seismic`: `mseed`, `sac`, `gse2`, `knet`, `win`, `ats.mth5`
+- `io-netcdf4`: `nc`, alias `netcdf4`
+- `io-zarr`: `zarr`
+- `io-tdms`: `tdms`
+- `io-root`: `root`
+
+### Nightly Gate
+
+Nightly should run all scenarios marked `nightly`, including:
+
+- lossy codec waveform comparisons
+- seismic multi-file scenarios
+- optional native readback for every optional backend
+- import-path subprocess checks for every public class/format pair
+
+## Release Milestones
+
+### v0.1.4
+
+Scope: conformance infrastructure plus core blocking baseline.
+
+Required deliverables:
+
+- contract schema v3
+- `tests/io_conformance` harness skeleton
+- scenario policies for all 25 formats
+- blocking tests for `gwf`, `hdf.ndscope`, `hdf5`, `csv`, `txt`, `wav`
+- optional dependency behavior checks for all optional formats
+- no silent stub fallback in conformance generators
+- release notes saying this is the first conformance baseline, not full
+  exhaustive enforcement
+
+### v0.1.5
+
+Scope: optional backend expansion.
+
+Required deliverables:
+
+- `tdms`
+- `mseed`
+- `sac`
+- `gse2`
+- `ats`
+- `ats.mth5`
+- `nc`
+- `zarr`
+- compressed audio formats
+- `root`
+
+### v0.1.6 or Next Minor Release
+
+Scope: full public I/O contract enforcement.
+
+Required deliverables:
+
+- eliminate or justify every `coverage_status=planned`
+- make every public format at least optional-blocking in an appropriate CI job
+- publish generated I/O conformance table in docs
+- require scenario policy updates for every new public format PR
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| GWpy GWF write backend not available in base CI | Medium | High — GWF generator falls back to `generate_gwpy_external`; if GWpy is absent, all GWF blocking generation scenarios fail | Pin GWpy in conformance extras; add a CI step that asserts the GWF backend is importable before tests run |
+| ffmpeg/libav absent in `io-audio` CI runner | Medium | Medium — FLAC/OGG/MP3/M4A generators fail silently | Require ffmpeg in `io-audio` job setup; assert `shutil.which("ffmpeg")` in audio conftest |
+| #417 (FrequencySeries registry) slips past v0.1.4 | High | Low — only affects FrequencySeries auto-identify scenarios, which are `planned`; no blocking gate is broken | Keep FrequencySeries auto-identify scenarios `planned` until #417 merges |
+| Subprocess import-path checks inflate CI time by > 5 min | Medium | Medium — may cause PR CI to time out | Apply alias + subprocess sampling policy defined in "Test Parametrization" |
+| Schema v3 validator is not ready at v0.1.4 branch cut | Medium | Medium — schema policy checks can still run against v2 contract | Gate v3 field checks behind a version field in the JSON; fail the schema test only when `schema_version == 3` |
+| GWpy silent upgrade shifts GWF tolerance behavior | Low | High — floating-point comparison at `rtol=1e-12` could flip | Pin GWpy `>=X.Y,<X.Z` in conformance extras; document the pinned version in `pyproject.toml` |
+
+## Issue Tracking
+
+Create or update tracking issues:
+
+- I/O conformance schema v3 and harness
+- core v0.1.4 blocking format coverage
+- optional backend coverage expansion
+- FrequencySeries registry auto-registration and registry normalization (#417) —
+  **prerequisite** for `read_auto_identify_public` and `read_auto_identify_registry`
+  scenarios on any FrequencySeries class; those scenarios must remain `planned` until
+  #417 lands, even if other FrequencySeries I/O scenarios are `blocking`.
+- docs generation from I/O contract (rendered as a Sphinx auto-generated table at
+  `docs/io/conformance_matrix.rst`; the source of truth is the JSON contract)
+
+## Acceptance Criteria for v0.1.4
+
+v0.1.4 can ship when all of the following are true.
+
+**Schema and policy:**
+- The schema v3 contract validates against the new v3 JSON schema.
+- Every format has explicit `scenario_matrix`, `coverage_status`, `ci_jobs`, and
+  `missing_dependency_policy` entries.
+- No format with public read or write classes lacks a `fixture_generator` reference.
+
+**Quantitative blocking test targets** (CI must report `blocking_pass / blocking_total`
+≥ 100% for the base gate):
+
+| Format | Min blocking rows |
+|---|---|
+| `gwf` | ≥ 18 |
+| `hdf.ndscope` | ≥ 13 |
+| `hdf5` | ≥ 30 |
+| `csv` | ≥ 14 |
+| `txt` | ≥ 12 |
+| `wav` | ≥ 11 |
+| Policy checks (all 25 formats) | ≥ 25 |
+
+Row counts are per-scenario-tuple as defined by the (format, operation, scenario,
+class, layout, format_token, dependency_mode, status) matrix. Aliases are counted
+only for `read_alias_format` / `write_alias_format` rows, not the full matrix.
+
+**Functional gates:**
+- GWF multi-file external-fixture reads pass for `TimeSeries` and `TimeSeriesDict`.
+- GWF GWexpy single-file write/readback passes for `TimeSeries` and `TimeSeriesDict`.
+- HDF5 public family read/write/readback passes for all v0.1.4 blocking public
+  classes.
+- Missing optional dependency behavior is asserted in base CI for every format with
+  `optional_blocking` scenarios.
+
+**Regression and documentation:**
+- All existing targeted I/O tests in `tests/` (outside `io_conformance/`) remain
+  green.
+- Docs and changelog describe the conformance baseline accurately as the first
+  systematic baseline, not full exhaustive enforcement.
+- CI outputs a `blocking_pass / blocking_total` summary line per job.

--- a/docs/developers/plans/active/2026-05-18-io-conformance-v0.1.4-plan.md
+++ b/docs/developers/plans/active/2026-05-18-io-conformance-v0.1.4-plan.md
@@ -204,10 +204,15 @@ Every format entry must add these fields:
 - `metadata_must_match`: metadata keys that must survive read/write/readback.
 - `multi_file_policy`: one of the values listed above.
 - `coverage_status`: default status for this format in v0.1.4.
-- `ci_jobs`: one or more of `base`, `io-audio`, `io-seismic`, `io-netcdf4`, `io-zarr`,
-  `io-tdms`, `io-root`, `nightly`. These identifiers must match the CI job names in
-  `.github/workflows/` exactly.
-- `missing_dependency_policy`: skip, xfail, or must_raise_import_error.
+- `ci_jobs`: one or more logical gate identifiers: `base`, `io-audio`, `io-seismic`,
+  `io-netcdf4`, `io-zarr`, `io-tdms`, `io-root`, `nightly`. These identifiers are
+  stable contract values, not GitHub Actions display names. The CI implementation
+  must provide an explicit mapping from each logical gate identifier to a workflow
+  job, workflow matrix entry, or `scripts/ci/run_gate.py` target.
+- `missing_dependency_policy`: skip, must_raise_import_error,
+  conditional_registration, or warns_and_skips_optional_metadata. Known bugs must
+  be represented with `coverage_status=planned` or `coverage_status=nightly` plus
+  an issue reference, not by weakening or skipping a blocking conformance row.
 - `security_policy`: object with `trusted_only: bool` and `requires_warning: bool`.
   `trusted_only: true` means the format may only be read when the caller explicitly
   opts in. `requires_warning: true` means GWexpy must emit a visible warning on read.
@@ -220,8 +225,16 @@ following rules.
 
 **No GWexpy import.** Generators must not import `gwexpy` or any submodule of it.
 Enforcement: `tests/io_conformance/conftest.py` runs an import-guard check at
-session start that greps each generator module for `import gwexpy`; the session
-fails immediately if any match is found.
+session start that parses every generator module with `ast` and rejects:
+
+- `ast.Import` / `ast.ImportFrom` nodes targeting `gwexpy` or `gwexpy.*`;
+- literal dynamic imports such as `__import__("gwexpy")` and
+  `importlib.import_module("gwexpy")`;
+- any generator entry point that imports `gwexpy` while executed in a subprocess
+  with an import hook that raises on `gwexpy` and `gwexpy.*`.
+
+A text grep is insufficient because it misses `from gwexpy import ...`, misses lazy
+dynamic imports, and can false-positive on comments.
 
 **Seeded RNG.** All numeric payload generation must use `numpy.random.default_rng(SEED)`
 where `SEED` is a per-format integer constant defined in `generators/__init__.py`.
@@ -297,8 +310,13 @@ tests/io_conformance/
 **Scenario expansion.** `tests/io_conformance/scenarios.py` reads the JSON contract
 and expands every `(format, operation, scenario, class, layout, format_token,
 dependency_mode, status)` tuple into a pytest parametrize ID. The harness must skip
-rows where `status` is `planned` or `not_public`, and xfail rows where
-`dependency_mode` is `optional-missing` and the dependency is absent.
+rows where `status` is `planned` or `not_public`. Rows where `dependency_mode` is
+`optional-missing` are ordinary executable tests; they must assert the documented
+missing-backend behavior, such as a clear `ImportError`, conditional registration
+absence, or a warning that optional metadata was skipped. `missing_dependency_policy=skip`
+is valid only for rows that do not represent a public optional dependency contract.
+The schema validator must reject `skip` for any format that has public read/write
+coverage and non-empty `optional_dependencies`.
 
 **Alias sampling policy.** Running the full scenario matrix for every alias would
 multiply test count by the number of aliases. Instead:
@@ -361,7 +379,7 @@ omitted.
   - `generate_single_channel_multi_file`: blocking
   - `generate_multi_channel_multi_file`: blocking
   - `read_explicit_format`: blocking
-  - `read_auto_identify`: blocking
+  - `read_auto_identify_public`: blocking
   - `read_alias_format`: blocking for every alias
   - `read_single_channel_single_file`: blocking for `TimeSeries`
   - `read_multi_channel_single_file`: blocking for `TimeSeriesDict`
@@ -401,7 +419,7 @@ omitted.
   - `generate_single_channel_single_file`: blocking
   - `generate_multi_channel_single_file`: blocking
   - `read_explicit_format`: blocking
-  - `read_auto_identify`: blocking
+  - `read_auto_identify_public`: blocking
   - `read_alias_format`: blocking for every alias
   - `read_single_channel_single_file`: blocking for `TimeSeriesDict`
   - `read_multi_channel_single_file`: blocking for `TimeSeriesDict`
@@ -451,8 +469,9 @@ omitted.
   - `read_explicit_format`: blocking
   - `read_auto_identify_public`: not_public — the public contract requires explicit
     `format="hdf5"`; auto-identification is not a documented user-facing guarantee
-  - `read_auto_identify_registry`: nightly — the registry can identify HDF5 files
-    but this is not exposed as a public contract
+  - `read_auto_identify_registry`: not_public — schema-v2 declares
+    `registry_auto_identify=false`; make this nightly only if the JSON contract
+    changes
   - `read_single_channel_single_file`: blocking for `TimeSeries`,
     `FrequencySeries`, `Spectrogram`, `Histogram`, `EventTable`
   - `read_multi_channel_single_file`: blocking for `TimeSeriesDict`,
@@ -503,6 +522,8 @@ omitted.
   - `read_explicit_format`: optional_blocking
   - `read_auto_identify_public`: not_public — not a documented user-facing guarantee
     despite the registry identifier
+  - `read_auto_identify_registry`: nightly — schema-v2 declares
+    `registry_auto_identify=true`
   - `read_alias_format`: optional_blocking for `dttxml`
   - `read_required_args`: optional_blocking with `products`
   - `read_missing_required_args`: optional_blocking
@@ -540,7 +561,7 @@ omitted.
   - `generate_multi_channel_single_file`: blocking for single CSV where supported
   - `generate_collection_directory`: blocking for `TimeSeriesDict`
   - `read_explicit_format`: blocking
-  - `read_auto_identify`: blocking
+  - `read_auto_identify_public`: blocking
   - `read_single_channel_single_file`: blocking for `TimeSeries`
   - `read_multi_channel_single_file`: blocking for `TimeSeriesDict`
   - `read_collection_directory`: blocking for `TimeSeriesDict`
@@ -579,7 +600,7 @@ omitted.
   - `generate_single_channel_single_file`: blocking
   - `generate_collection_directory`: blocking for `TimeSeriesDict`
   - `read_explicit_format`: blocking
-  - `read_auto_identify`: not_public
+  - `read_auto_identify_public`: not_public
   - `read_single_channel_single_file`: blocking for `TimeSeries`
   - `read_collection_directory`: blocking for `TimeSeriesDict`
   - `write_single_object`: blocking for `TimeSeries`
@@ -644,7 +665,8 @@ omitted.
   - `generate_single_channel_single_file`: optional_blocking for EventTable-like
     tree/table fixture
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking if registry supports it
+  - `read_auto_identify_public`: optional_blocking if public auto-identification
+    is registered
   - `write_single_object`: optional_blocking for `EventTable`
   - `readback_gwexpy`: optional_blocking
   - `readback_native`: optional_blocking with `uproot`
@@ -675,7 +697,7 @@ omitted.
   - `generate_single_channel_single_file`: optional_blocking
   - `generate_multi_channel_single_file`: optional_blocking
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `read_alias_format`: optional_blocking for `sqlite`, `sqlite3`
   - `read_single_channel_single_file`: optional_blocking for `TimeSeries`
   - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
@@ -708,7 +730,7 @@ omitted.
   - `generate_multi_channel_single_file`: blocking if stereo/multi-channel WAV is
     public for `TimeSeriesDict`
   - `read_explicit_format`: blocking
-  - `read_auto_identify`: blocking
+  - `read_auto_identify_public`: blocking
   - `read_single_channel_single_file`: blocking for `TimeSeries`
   - `read_multi_channel_single_file`: blocking for `TimeSeriesDict`
   - `write_single_object`: blocking for `TimeSeries`
@@ -746,7 +768,7 @@ omitted.
   - `generate_single_channel_single_file`: optional_blocking
   - `generate_multi_channel_single_file`: optional_blocking
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `write_single_object`: optional_blocking
   - `write_collection`: optional_blocking
   - `readback_gwexpy`: optional_blocking
@@ -782,7 +804,7 @@ omitted.
   - `generate_single_channel_single_file`: optional_blocking
   - `generate_multi_channel_single_file`: optional_blocking
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `write_single_object`: optional_blocking
   - `write_collection`: optional_blocking
   - `readback_gwexpy`: optional_blocking
@@ -817,7 +839,7 @@ omitted.
   - `generate_single_channel_single_file`: optional_blocking
   - `generate_multi_channel_single_file`: optional_blocking
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `write_single_object`: optional_blocking
   - `write_collection`: optional_blocking
   - `readback_gwexpy`: optional_blocking
@@ -851,7 +873,7 @@ omitted.
   - `generate_single_channel_single_file`: optional_blocking
   - `generate_multi_channel_single_file`: optional_blocking
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `write_single_object`: optional_blocking
   - `write_collection`: optional_blocking
   - `readback_gwexpy`: optional_blocking
@@ -885,7 +907,7 @@ omitted.
   - `generate_single_channel_single_file`: optional_blocking
   - `generate_multi_channel_single_file`: optional_blocking
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `read_required_args`: optional_blocking with `timezone`
   - `read_missing_required_args`: blocking
   - `read_single_channel_single_file`: optional_blocking for `TimeSeries`
@@ -920,7 +942,7 @@ omitted.
   - `generate_single_channel_single_file`: optional_blocking
   - `generate_multi_channel_single_file`: optional_blocking
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `read_single_channel_single_file`: optional_blocking for `TimeSeries`
   - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
   - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesMatrix`
@@ -954,7 +976,7 @@ omitted.
   - `generate_multi_channel_single_file`: optional_blocking
   - `generate_multi_channel_multi_file`: nightly
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `read_alias_format`: optional_blocking for `miniseed`
   - `read_single_channel_single_file`: optional_blocking for `TimeSeriesDict`
   - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
@@ -989,7 +1011,7 @@ omitted.
   - `generate_single_channel_single_file`: optional_blocking
   - `generate_multi_channel_single_file`: nightly
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `read_single_channel_single_file`: optional_blocking for `TimeSeriesDict`
   - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
   - `write_collection`: optional_blocking for `TimeSeriesDict`
@@ -1021,7 +1043,7 @@ omitted.
   - `generate_single_channel_single_file`: optional_blocking
   - `generate_multi_channel_single_file`: nightly
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `read_single_channel_single_file`: optional_blocking for `TimeSeriesDict`
   - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
   - `write_collection`: optional_blocking for `TimeSeriesDict`
@@ -1054,7 +1076,7 @@ omitted.
 - Scenarios:
   - `generate_single_channel_single_file`: planned
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
   - `write_unsupported`: blocking
   - `read_optional_dependency_missing`: blocking in base CI
@@ -1082,7 +1104,7 @@ omitted.
 - Scenarios:
   - `generate_single_channel_single_file`: planned
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `read_alias_format`: optional_blocking for `win32`
   - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
   - `write_unsupported`: blocking
@@ -1112,7 +1134,7 @@ omitted.
 - Scenarios:
   - `generate_single_channel_single_file`: optional_blocking
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `read_single_channel_single_file`: optional_blocking for `TimeSeries`
   - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
     only if generated multi-channel variant exists
@@ -1175,7 +1197,7 @@ omitted.
   - `generate_single_channel_single_file`: optional_blocking
   - `generate_multi_channel_single_file`: optional_blocking
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `read_alias_format`: optional_blocking for `netcdf4`
   - `read_single_channel_single_file`: optional_blocking for `TimeSeries`
   - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
@@ -1215,7 +1237,7 @@ omitted.
   - `generate_single_channel_single_file`: optional_blocking
   - `generate_multi_channel_single_file`: optional_blocking
   - `read_explicit_format`: optional_blocking
-  - `read_auto_identify`: optional_blocking
+  - `read_auto_identify_public`: optional_blocking
   - `read_single_channel_single_file`: optional_blocking for `TimeSeries`
   - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesDict`
   - `read_multi_channel_single_file`: optional_blocking for `TimeSeriesMatrix`
@@ -1259,8 +1281,11 @@ Blocking policy checks for all 25 formats:
 
 ### Optional Backend CI Gates
 
-Separate CI jobs should run these groups. The job names below are canonical and must
-match the `ci_jobs` field values in the JSON contract.
+Separate CI jobs or workflow matrix entries should run these groups. The logical
+gate identifiers below are canonical and must match the `ci_jobs` field values in
+the JSON contract. The GitHub Actions workflow may expose different display names,
+but it must document the mapping from each logical identifier to the concrete job
+or `scripts/ci/run_gate.py` target.
 
 - `io-audio`: `flac`, `ogg`, `mp3`, `m4a`, extended `wav`
 - `io-seismic`: `mseed`, `sac`, `gse2`, `knet`, `win`, `ats.mth5`

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,8 @@ name: gwexpy
 channels:
   - conda-forge
 dependencies:
+  - ldas-tools-framecpp
+  - python-framel
   - pip
   - pip:
       - -r requirements-dev.txt

--- a/gwexpy/io/dttxml_common.py
+++ b/gwexpy/io/dttxml_common.py
@@ -496,12 +496,19 @@ def load_dttxml_products(source, *, native: bool = False):
             }
 
     # 1. Time Series (TS)
+    # Return raw dicts (not TimeSeries objects) so that read_timeseriesdict_dttxml
+    # can call info.get("epoch") / info.get("dt") / info.get("data") uniformly.
+    # Returning TimeSeries objects here caused AttributeError because TimeSeries.get()
+    # is the NDS data-fetch method, not dict.get().
     if hasattr(results, "TS"):
         ts_dict = {}
         for ch, info in results.TS.items():
-            ts_dict[ch] = create_series(
-                info.timeseries, dt=info.dt, t0=info.gps_second, name=ch, type="time"
-            )
+            ts_dict[ch] = {
+                "data": info.timeseries,
+                "dt": info.dt,
+                "epoch": info.gps_second,
+                "unit": None,
+            }
         normalized["TS"] = ts_dict
 
     # 2. PSD (actually ASD)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -17,11 +17,14 @@ Run all scripts from the **repository root**.
 
 Scripts used to reproduce CI gates locally.
 
-- `scripts/ci/run_gate.py`: Run the same command sets as PR Fast and nightly gate jobs.
+- `scripts/ci/run_gate.py`: Run the same command sets as PR Fast, `io-conformance`, and nightly gate jobs.
 
 ```bash
 # I/O contract gate
 python scripts/ci/run_gate.py io-contract
+
+# I/O conformance gate
+python scripts/ci/run_gate.py io-conformance
 
 # Full PR fast validation gate
 python scripts/ci/run_gate.py pr-fast

--- a/scripts/ci/run_gate.py
+++ b/scripts/ci/run_gate.py
@@ -159,6 +159,10 @@ def run_gate(gate: str, with_fixtures: bool) -> None:
         )
         return
 
+    if gate == "io-conformance":
+        run_cmd(["pytest", "-q", "tests/io_conformance"])
+        return
+
     if gate == "io-network-backend":
         if with_fixtures:
             run_cmd(["python", "tests/fixtures/generate_fixtures.py"])
@@ -219,6 +223,7 @@ def main(argv: list[str] | None = None) -> int:
         choices=[
             "pr-fast",
             "io-contract",
+            "io-conformance",
             "io-optional",
             "io-network-backend",
             "docs-notebook",

--- a/scripts/ci/run_gate.py
+++ b/scripts/ci/run_gate.py
@@ -161,6 +161,17 @@ def run_gate(gate: str, with_fixtures: bool) -> None:
 
     if gate == "io-conformance":
         run_cmd(["pytest", "-q", "tests/io_conformance"])
+        repo_root = Path.cwd().resolve()
+        if str(repo_root) not in sys.path:
+            sys.path.insert(0, str(repo_root))
+        from tests.io_conformance.contract import load_public_io_contract
+        from tests.io_conformance.reporting import summarize_blocking_rows
+        from tests.io_conformance.scenarios import expand_contract_scenarios
+
+        contract = load_public_io_contract()
+        rows = expand_contract_scenarios(contract)
+        summary = summarize_blocking_rows(rows)
+        print(summary["blocking_display"])
         return
 
     if gate == "io-network-backend":

--- a/tests/io/test_dttxml_common.py
+++ b/tests/io/test_dttxml_common.py
@@ -8,12 +8,14 @@ import warnings
 import numpy as np
 import pytest
 
+import gwexpy.io.dttxml_common as dttxml_common
 from gwexpy.io.dttxml_common import (
     ChannelInfo,
     _decode_dtt_stream,
     extract_xml_channels,
     load_dttxml_products,
 )
+from gwexpy.timeseries import TimeSeriesDict
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -58,6 +60,43 @@ def _base64_complex128(values: list[complex]) -> str:
         flat.extend([c.real, c.imag])
     raw = struct.pack(f"<{len(flat)}d", *flat)
     return base64.b64encode(raw).decode()
+
+
+class _FakeTSInfo:
+    def __init__(self, timeseries, dt, gps_second):
+        self.timeseries = np.asarray(timeseries)
+        self.dt = dt
+        self.gps_second = gps_second
+
+
+class _FakeDTTXMLResults:
+    def __init__(self, channel: str, info: _FakeTSInfo):
+        self.TS = {channel: info}
+
+
+class _FakeDiagAccess:
+    def __init__(self, channel: str, timeseries, dt, gps_second):
+        self.results = _FakeDTTXMLResults(
+            channel,
+            _FakeTSInfo(timeseries, dt=dt, gps_second=gps_second),
+        )
+
+
+class _FakeDTTXML:
+    def __init__(self, channel: str, timeseries, dt, gps_second):
+        self._channel = channel
+        self._timeseries = timeseries
+        self._dt = dt
+        self._gps_second = gps_second
+
+    def DiagAccess(self, source):
+        del source
+        return _FakeDiagAccess(
+            self._channel,
+            self._timeseries,
+            dt=self._dt,
+            gps_second=self._gps_second,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -264,3 +303,37 @@ class TestLoadDttxmlProducts:
         ]
         assert tf["frequencies"].dtype.kind == "f"
         assert tf["data"].dtype.kind == "c"
+
+    def test_ts_entries_stay_dict_shaped_and_reader_consumes_them(self, monkeypatch):
+        channel = "H1:CAL-TEST"
+        data = np.array([1.0, -2.5, 4.25], dtype=float)
+        dt = 0.25
+        gps_second = 1234567890.0
+
+        monkeypatch.setattr(
+            dttxml_common,
+            "dttxml",
+            _FakeDTTXML(channel, data, dt=dt, gps_second=gps_second),
+        )
+
+        products = load_dttxml_products("synthetic.xml")
+        payload = products["TS"][channel]
+
+        assert isinstance(payload, dict)
+        assert {"data", "dt", "epoch", "unit"} <= set(payload)
+        assert payload.get("epoch") == gps_second
+        assert payload["dt"] == dt
+        np.testing.assert_allclose(payload["data"], data)
+
+        from gwexpy.timeseries.io.dttxml import read_timeseriesdict_dttxml
+
+        tsd = read_timeseriesdict_dttxml("synthetic.xml", products="TS")
+
+        assert isinstance(tsd, TimeSeriesDict)
+        assert list(tsd.keys()) == [channel]
+
+        series = tsd[channel]
+        np.testing.assert_allclose(series.value, data)
+        assert np.isclose(float(series.t0.value), gps_second)
+        assert np.isclose(float(series.dt.value), dt)
+        assert np.isclose(float(series.sample_rate.value), 1.0 / dt)

--- a/tests/io_conformance/__init__.py
+++ b/tests/io_conformance/__init__.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from .contract import (
+    CONTRACT_PATH,
+    LOGICAL_CI_JOB_IDS,
+    SCHEMA_VERSION_V2,
+    SCHEMA_VERSION_V3,
+    LogicalCIJobId,
+    MissingDependencyPolicy,
+    ScenarioName,
+    ScenarioStatus,
+    load_public_io_contract,
+    validate_logical_ci_job_ids,
+)
+from .scenarios import expand_contract_scenarios
+
+__all__ = [
+    "CONTRACT_PATH",
+    "LOGICAL_CI_JOB_IDS",
+    "LogicalCIJobId",
+    "MissingDependencyPolicy",
+    "SCHEMA_VERSION_V2",
+    "SCHEMA_VERSION_V3",
+    "ScenarioName",
+    "ScenarioStatus",
+    "expand_contract_scenarios",
+    "load_public_io_contract",
+    "validate_logical_ci_job_ids",
+]

--- a/tests/io_conformance/__init__.py
+++ b/tests/io_conformance/__init__.py
@@ -5,17 +5,22 @@ from .contract import (
     LOGICAL_CI_JOB_IDS,
     SCHEMA_VERSION_V2,
     SCHEMA_VERSION_V3,
+    ContractCIJobId,
+    CoverageStatus,
     LogicalCIJobId,
     MissingDependencyPolicy,
     ScenarioName,
     ScenarioStatus,
     load_public_io_contract,
+    validate_contract_ci_jobs,
     validate_logical_ci_job_ids,
 )
 from .scenarios import expand_contract_scenarios
 
 __all__ = [
     "CONTRACT_PATH",
+    "ContractCIJobId",
+    "CoverageStatus",
     "LOGICAL_CI_JOB_IDS",
     "LogicalCIJobId",
     "MissingDependencyPolicy",
@@ -25,5 +30,6 @@ __all__ = [
     "ScenarioStatus",
     "expand_contract_scenarios",
     "load_public_io_contract",
+    "validate_contract_ci_jobs",
     "validate_logical_ci_job_ids",
 ]

--- a/tests/io_conformance/conftest.py
+++ b/tests/io_conformance/conftest.py
@@ -110,6 +110,11 @@ def _run_generator_smoke(spec: GeneratorSpec) -> None:
             assert output_dir.exists()
             assert any(output_dir.iterdir())
             assert result is None or isinstance(result, dict)
+            if isinstance(result, dict):
+                for value in result.values():
+                    value_path = pathlib.Path(value)
+                    assert value_path.is_absolute()
+                    assert value_path.is_relative_to(output_dir)
         """
     )
 

--- a/tests/io_conformance/conftest.py
+++ b/tests/io_conformance/conftest.py
@@ -1,0 +1,138 @@
+"""Import guards and smoke checks for the IO conformance generator harness."""
+
+from __future__ import annotations
+
+import ast
+import os
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from .generators import GeneratorSpec, iter_generator_specs
+
+ROOT = Path(__file__).resolve().parents[2]
+GENERATORS_DIR = Path(__file__).resolve().parent / "generators"
+BLOCKED_PREFIX = "gwexpy"
+
+
+def _generator_path(spec: GeneratorSpec) -> Path:
+    return GENERATORS_DIR / f"{spec.name}.py"
+
+
+def _parse_generator_source(path: Path) -> ast.AST:
+    return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+
+def _is_literal_gwexpy_import(node: ast.AST) -> bool:
+    if not isinstance(node, ast.Call):
+        return False
+
+    if not node.args:
+        return False
+
+    first_arg = node.args[0]
+    if not isinstance(first_arg, ast.Constant) or not isinstance(first_arg.value, str):
+        return False
+
+    target = first_arg.value
+    if target != BLOCKED_PREFIX and not target.startswith(f"{BLOCKED_PREFIX}."):
+        return False
+
+    func = node.func
+    if isinstance(func, ast.Name) and func.id in {"__import__", "import_module"}:
+        return True
+    if (
+        isinstance(func, ast.Attribute)
+        and func.attr == "import_module"
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "importlib"
+    ):
+        return True
+    return False
+
+
+def _guard_generator_source(spec: GeneratorSpec) -> None:
+    path = _generator_path(spec)
+    tree = _parse_generator_source(path)
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name == "gwexpy" or alias.name.startswith("gwexpy."):
+                    raise pytest.UsageError(
+                        f"{path} imports gwexpy directly, which is not allowed"
+                    )
+        elif isinstance(node, ast.ImportFrom):
+            if node.module and (
+                node.module == "gwexpy" or node.module.startswith("gwexpy.")
+            ):
+                raise pytest.UsageError(
+                    f"{path} imports from gwexpy directly, which is not allowed"
+                )
+        elif _is_literal_gwexpy_import(node):
+            raise pytest.UsageError(
+                f"{path} uses a literal gwexpy import call, which is not allowed"
+            )
+
+
+def _run_generator_smoke(spec: GeneratorSpec) -> None:
+    env = os.environ.copy()
+    pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        str(ROOT) if not pythonpath else os.pathsep.join((str(ROOT), pythonpath))
+    )
+
+    code = textwrap.dedent(
+        f"""
+        import importlib
+        import pathlib
+        import sys
+        import tempfile
+
+        class _BlockGwexpy:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "gwexpy" or fullname.startswith("gwexpy."):
+                    raise ImportError(f"blocked import: {{fullname}}")
+                return None
+
+        sys.meta_path.insert(0, _BlockGwexpy())
+
+        module = importlib.import_module({spec.module_name!r})
+        entrypoint = getattr(module, {spec.entrypoint!r})
+        assert callable(entrypoint)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_dir = pathlib.Path(tmpdir) / "out"
+            result = entrypoint(output_dir)
+            assert output_dir.exists()
+            assert any(output_dir.iterdir())
+            assert result is None or isinstance(result, dict)
+        """
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-c", code],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise pytest.UsageError(
+            "IO conformance generator smoke check failed for "
+            f"{spec.module_name}:\nSTDOUT:\n{completed.stdout}\n"
+            f"STDERR:\n{completed.stderr}"
+        )
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """Fail fast if any IO conformance generator violates the import guard."""
+
+    del session
+    for spec in iter_generator_specs():
+        _guard_generator_source(spec)
+        _run_generator_smoke(spec)

--- a/tests/io_conformance/contract.py
+++ b/tests/io_conformance/contract.py
@@ -26,6 +26,25 @@ class ScenarioStatus(str, Enum):
     SKIP = "skip"
 
 
+class CoverageStatus(str, Enum):
+    BLOCKING = "blocking"
+    OPTIONAL_BLOCKING = "optional_blocking"
+    NIGHTLY = "nightly"
+    PLANNED = "planned"
+    NOT_PUBLIC = "not_public"
+
+
+class ContractCIJobId(str, Enum):
+    BASE = "base"
+    IO_AUDIO = "io-audio"
+    IO_SEISMIC = "io-seismic"
+    IO_NETCDF4 = "io-netcdf4"
+    IO_ZARR = "io-zarr"
+    IO_TDMS = "io-tdms"
+    IO_ROOT = "io-root"
+    NIGHTLY = "nightly"
+
+
 class LogicalCIJobId(str, Enum):
     POLICY = "io-conformance-policy"
     CHECK = "io-conformance-check"
@@ -36,7 +55,9 @@ class MissingDependencyPolicy(str, Enum):
     FAIL = "fail"
     SKIP = "skip"
     NOT_PUBLIC = "not_public"
+    MUST_RAISE_IMPORT_ERROR = "must_raise_import_error"
     CONDITIONAL_REGISTRATION = "conditional_registration"
+    WARNS_AND_SKIPS_OPTIONAL_METADATA = "warns_and_skips_optional_metadata"
 
 
 LOGICAL_CI_JOB_IDS = {
@@ -47,6 +68,47 @@ LOGICAL_CI_JOB_IDS = {
 
 _ALLOWED_SCHEMA_VERSIONS = {SCHEMA_VERSION_V2, SCHEMA_VERSION_V3}
 _ALLOWED_LOGICAL_CI_JOB_IDS = frozenset(LOGICAL_CI_JOB_IDS.values())
+_ALLOWED_CONTRACT_CI_JOB_IDS = frozenset(job.value for job in ContractCIJobId)
+
+_OPTIONAL_CI_JOB_BY_FORMAT = {
+    "root": ContractCIJobId.IO_ROOT.value,
+    "wav": ContractCIJobId.IO_AUDIO.value,
+    "flac": ContractCIJobId.IO_AUDIO.value,
+    "ogg": ContractCIJobId.IO_AUDIO.value,
+    "mp3": ContractCIJobId.IO_AUDIO.value,
+    "m4a": ContractCIJobId.IO_AUDIO.value,
+    "tdms": ContractCIJobId.IO_TDMS.value,
+    "mseed": ContractCIJobId.IO_SEISMIC.value,
+    "sac": ContractCIJobId.IO_SEISMIC.value,
+    "gse2": ContractCIJobId.IO_SEISMIC.value,
+    "knet": ContractCIJobId.IO_SEISMIC.value,
+    "win": ContractCIJobId.IO_SEISMIC.value,
+    "ats.mth5": ContractCIJobId.IO_SEISMIC.value,
+    "nc": ContractCIJobId.IO_NETCDF4.value,
+    "zarr": ContractCIJobId.IO_ZARR.value,
+}
+
+_DEFAULT_BLOCKING_FORMATS = frozenset({"gwf", "hdf.ndscope", "hdf5", "csv", "txt", "wav"})
+_DEFAULT_FIXTURE_GENERATORS = {
+    "gwf": "gwf",
+    "hdf.ndscope": "hdf_ndscope",
+    "hdf5": "hdf5",
+    "csv": "csv_txt",
+    "txt": "csv_txt",
+    "wav": "audio",
+}
+
+_MISSING_DEPENDENCY_POLICY_BY_BEHAVIOR = {
+    "available_in_base_install": MissingDependencyPolicy.SKIP.value,
+    "raises_import_error": MissingDependencyPolicy.MUST_RAISE_IMPORT_ERROR.value,
+    "warns_and_skips_optional_metadata": (
+        MissingDependencyPolicy.WARNS_AND_SKIPS_OPTIONAL_METADATA.value
+    ),
+    "conditional_registration": (
+        MissingDependencyPolicy.CONDITIONAL_REGISTRATION.value
+    ),
+    "not_public": MissingDependencyPolicy.NOT_PUBLIC.value,
+}
 
 
 def _read_json(path: Path) -> dict[str, Any]:
@@ -58,25 +120,87 @@ def _public_api_is_present(entry: dict[str, Any]) -> bool:
     return bool(public_api.get("read") or public_api.get("write"))
 
 
-def _missing_dependency_policy(entry: dict[str, Any]) -> str:
-    if not _public_api_is_present(entry):
+def _missing_dependency_policy(entry: dict[str, Any], operation: str) -> str:
+    public_api = entry.get("public_api", {})
+    if not public_api.get(operation):
         return MissingDependencyPolicy.NOT_PUBLIC.value
 
     unavailable = entry.get("unavailable_behavior", {})
-    if (
-        unavailable.get("read") == MissingDependencyPolicy.CONDITIONAL_REGISTRATION.value
-        or unavailable.get("write")
-        == MissingDependencyPolicy.CONDITIONAL_REGISTRATION.value
-    ):
-        return MissingDependencyPolicy.CONDITIONAL_REGISTRATION.value
+    behavior = unavailable.get(operation)
+    if behavior in _MISSING_DEPENDENCY_POLICY_BY_BEHAVIOR:
+        return _MISSING_DEPENDENCY_POLICY_BY_BEHAVIOR[behavior]
 
     if entry.get("optional_dependencies"):
-        return MissingDependencyPolicy.FAIL.value
+        return MissingDependencyPolicy.MUST_RAISE_IMPORT_ERROR.value
 
-    return MissingDependencyPolicy.FAIL.value
+    return MissingDependencyPolicy.SKIP.value
 
 
-def _normalize_entry(entry: dict[str, Any]) -> dict[str, Any]:
+def _io_conformance_policy(data: dict[str, Any]) -> dict[str, Any]:
+    return data.get("io_conformance_v3", {})
+
+
+def _blocking_formats(policy: dict[str, Any]) -> frozenset[str]:
+    values = policy.get("blocking_formats", _DEFAULT_BLOCKING_FORMATS)
+    return frozenset(values)
+
+
+def _fixture_generator(entry: dict[str, Any], policy: dict[str, Any]) -> str | None:
+    mapping = {
+        **_DEFAULT_FIXTURE_GENERATORS,
+        **policy.get("fixture_generator_by_format", {}),
+    }
+    return entry.get("fixture_generator") or mapping.get(entry["canonical"])
+
+
+def _coverage_status(entry: dict[str, Any], policy: dict[str, Any]) -> str:
+    canonical = entry["canonical"]
+    if not _public_api_is_present(entry):
+        return CoverageStatus.NOT_PUBLIC.value
+    if canonical in _blocking_formats(policy):
+        return CoverageStatus.BLOCKING.value
+    if canonical in _OPTIONAL_CI_JOB_BY_FORMAT and entry.get("optional_dependencies"):
+        return CoverageStatus.OPTIONAL_BLOCKING.value
+    return CoverageStatus.PLANNED.value
+
+
+def _ci_jobs(entry: dict[str, Any], coverage_status: str) -> list[str]:
+    canonical = entry["canonical"]
+    if coverage_status == CoverageStatus.NOT_PUBLIC.value:
+        return []
+    if coverage_status == CoverageStatus.BLOCKING.value:
+        return [ContractCIJobId.BASE.value]
+    if canonical in _OPTIONAL_CI_JOB_BY_FORMAT:
+        return [_OPTIONAL_CI_JOB_BY_FORMAT[canonical]]
+    return [ContractCIJobId.NIGHTLY.value]
+
+
+def _scenario_matrix(coverage_status: str) -> list[dict[str, str]]:
+    blocking_status = (
+        ScenarioStatus.BLOCKED.value
+        if coverage_status == CoverageStatus.BLOCKING.value
+        else ScenarioStatus.SKIP.value
+    )
+    return [
+        {
+            "scenario": ScenarioName.POLICY.value,
+            "status": ScenarioStatus.PASS.value,
+            "logical_ci_job_id": LogicalCIJobId.POLICY.value,
+        },
+        {
+            "scenario": ScenarioName.CHECK.value,
+            "status": ScenarioStatus.PASS.value,
+            "logical_ci_job_id": LogicalCIJobId.CHECK.value,
+        },
+        {
+            "scenario": ScenarioName.BLOCKING.value,
+            "status": blocking_status,
+            "logical_ci_job_id": LogicalCIJobId.BLOCKING.value,
+        },
+    ]
+
+
+def _normalize_entry(entry: dict[str, Any], policy: dict[str, Any]) -> dict[str, Any]:
     normalized = dict(entry)
     normalized.pop("read_auto_identify", None)
     normalized.pop("write_auto_identify", None)
@@ -96,20 +220,31 @@ def _normalize_entry(entry: dict[str, Any]) -> dict[str, Any]:
         normalized.get("registry_auto_identify", False)
     )
     normalized["trusted_only"] = bool(normalized.get("trusted_only", False))
+    coverage_status = _coverage_status(normalized, policy)
+    ci_jobs = _ci_jobs(normalized, coverage_status)
+    fixture_generator = _fixture_generator(normalized, policy)
     normalized["v3"] = {
+        "coverage_status": coverage_status,
+        "ci_jobs": ci_jobs,
+        "fixture_generator": fixture_generator,
         "logical_ci_job_ids": {
             "policy": LogicalCIJobId.POLICY.value,
             "check": LogicalCIJobId.CHECK.value,
             "blocking": LogicalCIJobId.BLOCKING.value,
         },
+        "scenario_matrix": _scenario_matrix(coverage_status),
         "scenario_statuses": {
             "policy": ScenarioStatus.PASS.value,
             "check": ScenarioStatus.PASS.value,
-            "blocking": ScenarioStatus.BLOCKED.value,
+            "blocking": (
+                ScenarioStatus.BLOCKED.value
+                if coverage_status == CoverageStatus.BLOCKING.value
+                else ScenarioStatus.SKIP.value
+            ),
         },
         "missing_dependency_policy": {
-            "read": _missing_dependency_policy(normalized),
-            "write": _missing_dependency_policy(normalized),
+            "read": _missing_dependency_policy(normalized, "read"),
+            "write": _missing_dependency_policy(normalized, "write"),
         },
     }
     return normalized
@@ -127,11 +262,26 @@ def load_public_io_contract(path: Path | str = CONTRACT_PATH) -> dict[str, Any]:
     formats = data.get("formats", [])
     if not isinstance(formats, list):
         raise TypeError("public I/O contract formats must be a list")
+    policy = _io_conformance_policy(data)
 
-    return {
+    normalized = {
         "schema_version": SCHEMA_VERSION_V3,
-        "formats": [_normalize_entry(entry) for entry in formats],
+        "io_conformance_v3": policy,
+        "formats": [_normalize_entry(entry, policy) for entry in formats],
     }
+    validate_contract_ci_jobs(normalized["formats"])
+    return normalized
+
+
+def validate_contract_ci_jobs(entries: Iterable[dict[str, Any]]) -> None:
+    bad_ids = {
+        ci_job
+        for entry in entries
+        for ci_job in entry.get("v3", {}).get("ci_jobs", [])
+        if ci_job not in _ALLOWED_CONTRACT_CI_JOB_IDS
+    }
+    if bad_ids:
+        raise ValueError(f"invalid contract ci_jobs values: {sorted(bad_ids)!r}")
 
 
 def validate_logical_ci_job_ids(rows: Iterable[dict[str, Any]]) -> None:

--- a/tests/io_conformance/contract.py
+++ b/tests/io_conformance/contract.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import json
+from enum import Enum
+from pathlib import Path
+from typing import Any, Iterable
+
+SCHEMA_VERSION_V2 = 2
+SCHEMA_VERSION_V3 = 3
+
+CONTRACT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "docs/developers/contracts/public_io_contract.json"
+)
+
+
+class ScenarioName(str, Enum):
+    POLICY = "policy"
+    CHECK = "check"
+    BLOCKING = "blocking"
+
+
+class ScenarioStatus(str, Enum):
+    PASS = "pass"
+    BLOCKED = "blocked"
+    SKIP = "skip"
+
+
+class LogicalCIJobId(str, Enum):
+    POLICY = "io-conformance-policy"
+    CHECK = "io-conformance-check"
+    BLOCKING = "io-conformance-blocking"
+
+
+class MissingDependencyPolicy(str, Enum):
+    FAIL = "fail"
+    SKIP = "skip"
+    NOT_PUBLIC = "not_public"
+    CONDITIONAL_REGISTRATION = "conditional_registration"
+
+
+LOGICAL_CI_JOB_IDS = {
+    ScenarioName.POLICY.value: LogicalCIJobId.POLICY.value,
+    ScenarioName.CHECK.value: LogicalCIJobId.CHECK.value,
+    ScenarioName.BLOCKING.value: LogicalCIJobId.BLOCKING.value,
+}
+
+_ALLOWED_SCHEMA_VERSIONS = {SCHEMA_VERSION_V2, SCHEMA_VERSION_V3}
+_ALLOWED_LOGICAL_CI_JOB_IDS = frozenset(LOGICAL_CI_JOB_IDS.values())
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _public_api_is_present(entry: dict[str, Any]) -> bool:
+    public_api = entry.get("public_api", {})
+    return bool(public_api.get("read") or public_api.get("write"))
+
+
+def _missing_dependency_policy(entry: dict[str, Any]) -> str:
+    if not _public_api_is_present(entry):
+        return MissingDependencyPolicy.NOT_PUBLIC.value
+
+    unavailable = entry.get("unavailable_behavior", {})
+    if (
+        unavailable.get("read") == MissingDependencyPolicy.CONDITIONAL_REGISTRATION.value
+        or unavailable.get("write")
+        == MissingDependencyPolicy.CONDITIONAL_REGISTRATION.value
+    ):
+        return MissingDependencyPolicy.CONDITIONAL_REGISTRATION.value
+
+    if entry.get("optional_dependencies"):
+        return MissingDependencyPolicy.FAIL.value
+
+    return MissingDependencyPolicy.FAIL.value
+
+
+def _normalize_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(entry)
+    normalized.pop("read_auto_identify", None)
+    normalized.pop("write_auto_identify", None)
+    normalized.setdefault("aliases", [])
+    normalized.setdefault("metadata_requirements", [])
+    normalized.setdefault("notes", [])
+    normalized.setdefault("optional_dependencies", [])
+    normalized.setdefault("extras", [])
+    normalized.setdefault("required_args", {"read": [], "write": []})
+    normalized.setdefault("direct_api", {"read": [], "write": []})
+    normalized.setdefault("registry_api", {"read": [], "write": []})
+    normalized.setdefault("public_api", {"read": [], "write": []})
+    normalized["public_auto_identify"] = bool(
+        normalized.get("public_auto_identify", False)
+    )
+    normalized["registry_auto_identify"] = bool(
+        normalized.get("registry_auto_identify", False)
+    )
+    normalized["trusted_only"] = bool(normalized.get("trusted_only", False))
+    normalized["v3"] = {
+        "logical_ci_job_ids": {
+            "policy": LogicalCIJobId.POLICY.value,
+            "check": LogicalCIJobId.CHECK.value,
+            "blocking": LogicalCIJobId.BLOCKING.value,
+        },
+        "scenario_statuses": {
+            "policy": ScenarioStatus.PASS.value,
+            "check": ScenarioStatus.PASS.value,
+            "blocking": ScenarioStatus.BLOCKED.value,
+        },
+        "missing_dependency_policy": {
+            "read": _missing_dependency_policy(normalized),
+            "write": _missing_dependency_policy(normalized),
+        },
+    }
+    return normalized
+
+
+def load_public_io_contract(path: Path | str = CONTRACT_PATH) -> dict[str, Any]:
+    contract_path = Path(path)
+    data = _read_json(contract_path)
+    schema_version = data.get("schema_version")
+    if schema_version not in _ALLOWED_SCHEMA_VERSIONS:
+        raise ValueError(
+            f"unsupported public I/O contract schema_version: {schema_version!r}"
+        )
+
+    formats = data.get("formats", [])
+    if not isinstance(formats, list):
+        raise TypeError("public I/O contract formats must be a list")
+
+    return {
+        "schema_version": SCHEMA_VERSION_V3,
+        "formats": [_normalize_entry(entry) for entry in formats],
+    }
+
+
+def validate_logical_ci_job_ids(rows: Iterable[dict[str, Any]]) -> None:
+    bad_ids = {
+        row.get("logical_ci_job_id")
+        for row in rows
+        if row.get("logical_ci_job_id") not in _ALLOWED_LOGICAL_CI_JOB_IDS
+    }
+    if bad_ids:
+        raise ValueError(f"invalid logical_ci_job_id values: {sorted(bad_ids)!r}")

--- a/tests/io_conformance/generators/__init__.py
+++ b/tests/io_conformance/generators/__init__.py
@@ -25,6 +25,18 @@ GENERATOR_SPECS: tuple[GeneratorSpec, ...] = (
         name="audio",
         module_name="tests.io_conformance.generators.audio",
     ),
+    GeneratorSpec(
+        name="hdf5",
+        module_name="tests.io_conformance.generators.hdf5",
+    ),
+    GeneratorSpec(
+        name="hdf_ndscope",
+        module_name="tests.io_conformance.generators.hdf_ndscope",
+    ),
+    GeneratorSpec(
+        name="gwf",
+        module_name="tests.io_conformance.generators.gwf",
+    ),
 )
 
 

--- a/tests/io_conformance/generators/__init__.py
+++ b/tests/io_conformance/generators/__init__.py
@@ -1,0 +1,34 @@
+"""Deterministic generator specs for the IO conformance harness."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["GENERATOR_SPECS", "GeneratorSpec", "iter_generator_specs"]
+
+
+@dataclass(frozen=True, slots=True)
+class GeneratorSpec:
+    """Describe one conformance generator module."""
+
+    name: str
+    module_name: str
+    entrypoint: str = "generate"
+
+
+GENERATOR_SPECS: tuple[GeneratorSpec, ...] = (
+    GeneratorSpec(
+        name="csv_txt",
+        module_name="tests.io_conformance.generators.csv_txt",
+    ),
+    GeneratorSpec(
+        name="audio",
+        module_name="tests.io_conformance.generators.audio",
+    ),
+)
+
+
+def iter_generator_specs() -> tuple[GeneratorSpec, ...]:
+    """Return the fixed generator set in a deterministic order."""
+
+    return GENERATOR_SPECS

--- a/tests/io_conformance/generators/audio.py
+++ b/tests/io_conformance/generators/audio.py
@@ -1,0 +1,64 @@
+"""Deterministic audio generator used by the IO conformance harness."""
+
+from __future__ import annotations
+
+import json
+import math
+import struct
+import wave
+from pathlib import Path
+
+__all__ = ["GENERATED_FILES", "generate"]
+
+GENERATED_FILES = ("tone.wav", "manifest.json")
+
+_SAMPLE_RATE = 8_000
+_DURATION_SECONDS = 0.05
+_FREQUENCY_HZ = 440.0
+_AMPLITUDE = 0.2
+
+
+def generate(output_dir: Path) -> dict[str, Path]:
+    """Write a tiny deterministic sine-wave WAV fixture into *output_dir*."""
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    wav_path = output_dir / "tone.wav"
+    manifest_path = output_dir / "manifest.json"
+
+    sample_count = int(_SAMPLE_RATE * _DURATION_SECONDS)
+    frames = bytearray()
+    for index in range(sample_count):
+        sample = int(
+            32767
+            * _AMPLITUDE
+            * math.sin(2.0 * math.pi * _FREQUENCY_HZ * index / _SAMPLE_RATE)
+        )
+        frames.extend(struct.pack("<h", sample))
+
+    with wave.open(str(wav_path), "wb") as handle:
+        handle.setnchannels(1)
+        handle.setsampwidth(2)
+        handle.setframerate(_SAMPLE_RATE)
+        handle.writeframes(bytes(frames))
+
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "duration_seconds": _DURATION_SECONDS,
+                "files": list(GENERATED_FILES),
+                "generator": "audio",
+                "sample_rate_hz": _SAMPLE_RATE,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return {
+        "manifest": manifest_path,
+        "wav": wav_path,
+    }

--- a/tests/io_conformance/generators/csv_txt.py
+++ b/tests/io_conformance/generators/csv_txt.py
@@ -1,0 +1,58 @@
+"""Deterministic CSV/TXT generator used by the IO conformance harness."""
+
+from __future__ import annotations
+
+import csv
+import json
+from pathlib import Path
+
+__all__ = ["GENERATED_FILES", "generate"]
+
+GENERATED_FILES = ("sample.csv", "sample.txt", "manifest.json")
+
+_CSV_ROWS: tuple[tuple[str, str], ...] = (
+    ("channel", "value"),
+    ("H1:STRAIN", "1.0"),
+    ("L1:STRAIN", "0.5"),
+)
+
+_TXT_LINES: tuple[str, ...] = (
+    "generator=csv_txt",
+    "kind=conformance",
+    "rows=3",
+)
+
+
+def generate(output_dir: Path) -> dict[str, Path]:
+    """Write a tiny deterministic CSV/TXT fixture set into *output_dir*."""
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    csv_path = output_dir / "sample.csv"
+    txt_path = output_dir / "sample.txt"
+    manifest_path = output_dir / "manifest.json"
+
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle, lineterminator="\n")
+        writer.writerows(_CSV_ROWS)
+
+    txt_path.write_text("\n".join(_TXT_LINES) + "\n", encoding="utf-8")
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "generator": "csv_txt",
+                "files": list(GENERATED_FILES),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return {
+        "csv": csv_path,
+        "txt": txt_path,
+        "manifest": manifest_path,
+    }

--- a/tests/io_conformance/generators/gwf.py
+++ b/tests/io_conformance/generators/gwf.py
@@ -1,0 +1,61 @@
+"""Deterministic GWF generator used by the IO conformance harness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+from gwpy.timeseries import TimeSeries, TimeSeriesDict
+
+__all__ = ["GENERATED_FILES", "generate"]
+
+GENERATED_FILES = ("frame.gwf", "manifest.json")
+
+_SEED = 8_183
+_CHANNEL = "K1:CONFORMANCE-GWF"
+_SAMPLE_RATE = 16.0
+_T0 = 1_000_000_000.0
+
+
+def generate(output_dir: Path) -> dict[str, Path]:
+    """Write a deterministic GWF frame into *output_dir* using GWpy."""
+
+    output_dir = Path(output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    gwf_path = output_dir / "frame.gwf"
+    manifest_path = output_dir / "manifest.json"
+
+    rng = np.random.default_rng(_SEED)
+    series = TimeSeries(
+        rng.normal(loc=0.0, scale=1.0, size=32),
+        sample_rate=_SAMPLE_RATE,
+        t0=_T0,
+        name=_CHANNEL,
+        channel=_CHANNEL,
+        unit="m",
+    )
+    TimeSeriesDict({_CHANNEL: series}).write(gwf_path, format="gwf")
+
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "channel": _CHANNEL,
+                "files": list(GENERATED_FILES),
+                "generator": "gwf",
+                "sample_rate_hz": _SAMPLE_RATE,
+                "seed": _SEED,
+                "t0": _T0,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return {
+        "gwf": gwf_path,
+        "manifest": manifest_path,
+    }

--- a/tests/io_conformance/generators/hdf5.py
+++ b/tests/io_conformance/generators/hdf5.py
@@ -1,0 +1,61 @@
+"""Deterministic HDF5 generator used by the IO conformance harness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+from gwpy.timeseries import TimeSeries
+
+__all__ = ["GENERATED_FILES", "generate"]
+
+GENERATED_FILES = ("sample.h5", "manifest.json")
+
+_SEED = 15_934
+_CHANNEL = "H1:CONFORMANCE-HDF5"
+_SAMPLE_RATE = 8.0
+_T0 = 1_000_000_000.0
+
+
+def generate(output_dir: Path) -> dict[str, Path]:
+    """Write a deterministic GWpy-readable HDF5 time series into *output_dir*."""
+
+    output_dir = Path(output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    h5_path = output_dir / "sample.h5"
+    manifest_path = output_dir / "manifest.json"
+
+    rng = np.random.default_rng(_SEED)
+    values = rng.normal(loc=0.0, scale=1.0, size=32)
+    series = TimeSeries(
+        values,
+        sample_rate=_SAMPLE_RATE,
+        t0=_T0,
+        name=_CHANNEL,
+        unit="m",
+    )
+    series.write(h5_path, format="hdf5")
+
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "channel": _CHANNEL,
+                "files": list(GENERATED_FILES),
+                "generator": "hdf5",
+                "sample_rate_hz": _SAMPLE_RATE,
+                "seed": _SEED,
+                "t0": _T0,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return {
+        "hdf5": h5_path,
+        "manifest": manifest_path,
+    }

--- a/tests/io_conformance/generators/hdf_ndscope.py
+++ b/tests/io_conformance/generators/hdf_ndscope.py
@@ -1,0 +1,62 @@
+"""Deterministic NDScope HDF5 generator used by the IO conformance harness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+__all__ = ["GENERATED_FILES", "generate"]
+
+GENERATED_FILES = ("ndscope.hdf", "manifest.json")
+
+_SEED = 20_241
+_CHANNELS = ("H1:CONFORMANCE-NDSCOPE", "L1:CONFORMANCE-NDSCOPE")
+_SAMPLE_RATE = 16.0
+_T0 = 1_000_000_000.0
+
+
+def generate(output_dir: Path) -> dict[str, Path]:
+    """Write a deterministic NDScope-style HDF5 fixture into *output_dir*."""
+
+    output_dir = Path(output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    hdf_path = output_dir / "ndscope.hdf"
+    manifest_path = output_dir / "manifest.json"
+
+    rng = np.random.default_rng(_SEED)
+    with h5py.File(hdf_path, "w") as handle:
+        for index, channel in enumerate(_CHANNELS):
+            group = handle.create_group(channel)
+            group.create_dataset(
+                "raw",
+                data=rng.normal(loc=float(index), scale=0.1, size=32),
+            )
+            group.attrs["rate_hz"] = _SAMPLE_RATE
+            group.attrs["gps_start"] = _T0
+            group.attrs["unit"] = "m"
+
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "channels": list(_CHANNELS),
+                "files": list(GENERATED_FILES),
+                "generator": "hdf_ndscope",
+                "sample_rate_hz": _SAMPLE_RATE,
+                "seed": _SEED,
+                "t0": _T0,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    return {
+        "hdf": hdf_path,
+        "manifest": manifest_path,
+    }

--- a/tests/io_conformance/reporting.py
+++ b/tests/io_conformance/reporting.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from .contract import ScenarioName, ScenarioStatus
+
+__all__ = ["summarize_blocking_rows"]
+
+
+def summarize_blocking_rows(rows: Iterable[Mapping[str, Any]]) -> dict[str, int | str]:
+    """Summarize blocking scenario rows for CI reporting."""
+
+    blocking_rows = [
+        row for row in rows if row.get("scenario") == ScenarioName.BLOCKING.value
+    ]
+    blocking_blocked = sum(
+        row.get("status") == ScenarioStatus.BLOCKED.value for row in blocking_rows
+    )
+    blocking_total = len(blocking_rows)
+    return {
+        "blocking_blocked": blocking_blocked,
+        "blocking_total": blocking_total,
+        "blocking_display": f"{blocking_blocked} blocked / {blocking_total} total",
+    }

--- a/tests/io_conformance/scenarios.py
+++ b/tests/io_conformance/scenarios.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from .contract import (
     LOGICAL_CI_JOB_IDS,
+    CoverageStatus,
     ScenarioName,
     ScenarioStatus,
     validate_logical_ci_job_ids,
@@ -11,11 +12,7 @@ from .contract import (
 
 
 def _is_core_public_format(entry: dict[str, Any]) -> bool:
-    public_api = entry.get("public_api", {})
-    return bool(
-        (public_api.get("read") or public_api.get("write"))
-        and not entry.get("optional_dependencies")
-    )
+    return entry["v3"]["coverage_status"] == CoverageStatus.BLOCKING.value
 
 
 def _scenario_row(
@@ -27,8 +24,11 @@ def _scenario_row(
         "format": entry["canonical"],
         "scenario": scenario.value,
         "status": status.value,
+        "coverage_status": entry["v3"]["coverage_status"],
         "logical_ci_job_id": LOGICAL_CI_JOB_IDS[scenario.value],
-        "missing_dependency_policy": entry["v3"]["missing_dependency_policy"]["read"],
+        "ci_jobs": entry["v3"]["ci_jobs"],
+        "fixture_generator": entry["v3"]["fixture_generator"],
+        "missing_dependency_policy": entry["v3"]["missing_dependency_policy"],
         "public_auto_identify": entry["public_auto_identify"],
         "registry_auto_identify": entry["registry_auto_identify"],
         "trusted_only": entry["trusted_only"],

--- a/tests/io_conformance/scenarios.py
+++ b/tests/io_conformance/scenarios.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .contract import (
+    LOGICAL_CI_JOB_IDS,
+    ScenarioName,
+    ScenarioStatus,
+    validate_logical_ci_job_ids,
+)
+
+
+def _is_core_public_format(entry: dict[str, Any]) -> bool:
+    public_api = entry.get("public_api", {})
+    return bool(
+        (public_api.get("read") or public_api.get("write"))
+        and not entry.get("optional_dependencies")
+    )
+
+
+def _scenario_row(
+    entry: dict[str, Any],
+    scenario: ScenarioName,
+    status: ScenarioStatus,
+) -> dict[str, Any]:
+    return {
+        "format": entry["canonical"],
+        "scenario": scenario.value,
+        "status": status.value,
+        "logical_ci_job_id": LOGICAL_CI_JOB_IDS[scenario.value],
+        "missing_dependency_policy": entry["v3"]["missing_dependency_policy"]["read"],
+        "public_auto_identify": entry["public_auto_identify"],
+        "registry_auto_identify": entry["registry_auto_identify"],
+        "trusted_only": entry["trusted_only"],
+    }
+
+
+def expand_contract_scenarios(contract: dict[str, Any]) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for entry in contract["formats"]:
+        rows.append(_scenario_row(entry, ScenarioName.POLICY, ScenarioStatus.PASS))
+        rows.append(_scenario_row(entry, ScenarioName.CHECK, ScenarioStatus.PASS))
+        if _is_core_public_format(entry):
+            rows.append(
+                _scenario_row(entry, ScenarioName.BLOCKING, ScenarioStatus.BLOCKED)
+            )
+
+    validate_logical_ci_job_ids(rows)
+    return rows

--- a/tests/io_conformance/test_contract_schema_v3.py
+++ b/tests/io_conformance/test_contract_schema_v3.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tests.io_conformance.contract import (
+    CONTRACT_PATH,
+    LOGICAL_CI_JOB_IDS,
+    MissingDependencyPolicy,
+    ScenarioName,
+    ScenarioStatus,
+    load_public_io_contract,
+    validate_logical_ci_job_ids,
+)
+from tests.io_conformance.scenarios import expand_contract_scenarios
+
+
+def _formats_by_canonical(contract: dict[str, object]) -> dict[str, dict[str, object]]:
+    return {entry["canonical"]: entry for entry in contract["formats"]}
+
+
+def test_v2_contract_loads_with_v3_defaults():
+    contract = load_public_io_contract(CONTRACT_PATH)
+
+    assert contract["schema_version"] == 3
+    assert len(contract["formats"]) == 25
+
+    formats = _formats_by_canonical(contract)
+    assert formats["hdf5"]["registry_auto_identify"] is False
+    assert formats["xml.diaggui"]["registry_auto_identify"] is True
+    assert "read_auto_identify" not in formats["hdf5"]
+    assert "read_auto_identify" not in formats["xml.diaggui"]
+
+
+def test_v2_legacy_auto_identify_keys_do_not_leak(tmp_path):
+    contract_path = tmp_path / "public_io_contract.json"
+    contract_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "formats": [
+                    {
+                        "canonical": "legacy.synthetic",
+                        "read_auto_identify": True,
+                        "write_auto_identify": True,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    contract = load_public_io_contract(contract_path)
+    [entry] = contract["formats"]
+
+    assert "read_auto_identify" not in entry
+    assert "write_auto_identify" not in entry
+    assert entry["public_auto_identify"] is False
+    assert entry["registry_auto_identify"] is False
+
+
+def test_contract_expands_all_formats_and_core_blocking_rows():
+    contract = load_public_io_contract(CONTRACT_PATH)
+    rows = expand_contract_scenarios(contract)
+    formats = _formats_by_canonical(contract)
+
+    policy_rows = [row for row in rows if row["scenario"] == ScenarioName.POLICY.value]
+    check_rows = [row for row in rows if row["scenario"] == ScenarioName.CHECK.value]
+    blocking_rows = [
+        row for row in rows if row["scenario"] == ScenarioName.BLOCKING.value
+    ]
+
+    assert {row["format"] for row in policy_rows} == set(formats)
+    assert {row["format"] for row in check_rows} == set(formats)
+    assert {row["format"] for row in blocking_rows} == {
+        canonical
+        for canonical, entry in formats.items()
+        if entry["public_api"]["read"] or entry["public_api"]["write"]
+        if not entry["optional_dependencies"]
+    }
+
+    assert all(row["status"] == ScenarioStatus.PASS.value for row in policy_rows)
+    assert all(row["status"] == ScenarioStatus.PASS.value for row in check_rows)
+    assert all(
+        row["status"] == ScenarioStatus.BLOCKED.value for row in blocking_rows
+    )
+
+
+def test_logical_ci_ids_are_validated():
+    contract = load_public_io_contract(CONTRACT_PATH)
+    rows = expand_contract_scenarios(contract)
+
+    validate_logical_ci_job_ids(rows)
+
+    bad_row = dict(rows[0], logical_ci_job_id="io-conformance-unknown")
+
+    with pytest.raises(ValueError, match="logical_ci_job_id"):
+        validate_logical_ci_job_ids([bad_row])
+
+
+def test_public_optional_dependency_formats_do_not_use_skip_policy():
+    contract = load_public_io_contract(CONTRACT_PATH)
+    rows = expand_contract_scenarios(contract)
+    formats = _formats_by_canonical(contract)
+    optional_public = {
+        canonical
+        for canonical, entry in formats.items()
+        if entry["public_api"]["read"] or entry["public_api"]["write"]
+        if entry["optional_dependencies"]
+    }
+
+    assert optional_public
+    assert all(
+        row["missing_dependency_policy"] != MissingDependencyPolicy.SKIP.value
+        for row in rows
+        if row["format"] in optional_public
+    )
+
+
+def test_registry_auto_identify_defaults_are_preserved():
+    contract = load_public_io_contract(CONTRACT_PATH)
+    formats = _formats_by_canonical(contract)
+
+    assert formats["hdf5"]["registry_auto_identify"] is False
+    assert formats["hdf5"]["public_auto_identify"] is False
+    assert formats["xml.diaggui"]["registry_auto_identify"] is True
+
+
+def test_enums_only_expose_the_supported_values():
+    assert tuple(ScenarioName) == (
+        ScenarioName.POLICY,
+        ScenarioName.CHECK,
+        ScenarioName.BLOCKING,
+    )
+    assert tuple(ScenarioStatus) == (
+        ScenarioStatus.PASS,
+        ScenarioStatus.BLOCKED,
+        ScenarioStatus.SKIP,
+    )
+    assert tuple(MissingDependencyPolicy) == (
+        MissingDependencyPolicy.FAIL,
+        MissingDependencyPolicy.SKIP,
+        MissingDependencyPolicy.NOT_PUBLIC,
+        MissingDependencyPolicy.CONDITIONAL_REGISTRATION,
+    )
+    assert LOGICAL_CI_JOB_IDS == {
+        ScenarioName.POLICY.value: "io-conformance-policy",
+        ScenarioName.CHECK.value: "io-conformance-check",
+        ScenarioName.BLOCKING.value: "io-conformance-blocking",
+    }

--- a/tests/io_conformance/test_contract_schema_v3.py
+++ b/tests/io_conformance/test_contract_schema_v3.py
@@ -7,10 +7,13 @@ import pytest
 from tests.io_conformance.contract import (
     CONTRACT_PATH,
     LOGICAL_CI_JOB_IDS,
+    ContractCIJobId,
+    CoverageStatus,
     MissingDependencyPolicy,
     ScenarioName,
     ScenarioStatus,
     load_public_io_contract,
+    validate_contract_ci_jobs,
     validate_logical_ci_job_ids,
 )
 from tests.io_conformance.scenarios import expand_contract_scenarios
@@ -31,6 +34,26 @@ def test_v2_contract_loads_with_v3_defaults():
     assert formats["xml.diaggui"]["registry_auto_identify"] is True
     assert "read_auto_identify" not in formats["hdf5"]
     assert "read_auto_identify" not in formats["xml.diaggui"]
+    assert contract["io_conformance_v3"]["base_gate"] == "io-conformance"
+
+
+def test_contract_v3_policy_fields_are_normalized_for_all_formats():
+    contract = load_public_io_contract(CONTRACT_PATH)
+
+    for entry in contract["formats"]:
+        v3 = entry["v3"]
+        assert v3["coverage_status"] in {status.value for status in CoverageStatus}
+        assert set(v3["missing_dependency_policy"]) == {"read", "write"}
+        assert isinstance(v3["ci_jobs"], list)
+        assert all(job in {ci_job.value for ci_job in ContractCIJobId} for job in v3["ci_jobs"])
+        assert isinstance(v3["scenario_matrix"], list)
+        assert {row["scenario"] for row in v3["scenario_matrix"]} == {
+            ScenarioName.POLICY.value,
+            ScenarioName.CHECK.value,
+            ScenarioName.BLOCKING.value,
+        }
+
+    validate_contract_ci_jobs(contract["formats"])
 
 
 def test_v2_legacy_auto_identify_keys_do_not_leak(tmp_path):
@@ -76,8 +99,7 @@ def test_contract_expands_all_formats_and_core_blocking_rows():
     assert {row["format"] for row in blocking_rows} == {
         canonical
         for canonical, entry in formats.items()
-        if entry["public_api"]["read"] or entry["public_api"]["write"]
-        if not entry["optional_dependencies"]
+        if entry["v3"]["coverage_status"] == CoverageStatus.BLOCKING.value
     }
 
     assert all(row["status"] == ScenarioStatus.PASS.value for row in policy_rows)
@@ -112,10 +134,52 @@ def test_public_optional_dependency_formats_do_not_use_skip_policy():
 
     assert optional_public
     assert all(
-        row["missing_dependency_policy"] != MissingDependencyPolicy.SKIP.value
+        row["missing_dependency_policy"]["read"] != MissingDependencyPolicy.SKIP.value
         for row in rows
         if row["format"] in optional_public
     )
+
+
+def test_wav_write_missing_dependency_policy_stays_base_install() -> None:
+    contract = load_public_io_contract(CONTRACT_PATH)
+    wav = _formats_by_canonical(contract)["wav"]
+
+    assert (
+        wav["v3"]["missing_dependency_policy"]["read"]
+        == MissingDependencyPolicy.WARNS_AND_SKIPS_OPTIONAL_METADATA.value
+    )
+    assert (
+        wav["v3"]["missing_dependency_policy"]["write"]
+        == MissingDependencyPolicy.SKIP.value
+    )
+
+
+def test_core_blocking_formats_have_base_ci_job_and_fixture_generators():
+    contract = load_public_io_contract(CONTRACT_PATH)
+    formats = _formats_by_canonical(contract)
+
+    expected_generators = {
+        "gwf": "gwf",
+        "hdf.ndscope": "hdf_ndscope",
+        "hdf5": "hdf5",
+        "csv": "csv_txt",
+        "txt": "csv_txt",
+        "wav": "audio",
+    }
+
+    for canonical, generator in expected_generators.items():
+        entry = formats[canonical]
+        assert entry["v3"]["coverage_status"] == CoverageStatus.BLOCKING.value
+        assert entry["v3"]["ci_jobs"] == [ContractCIJobId.BASE.value]
+        assert entry["v3"]["fixture_generator"] == generator
+
+
+def test_contract_ci_jobs_do_not_use_internal_stage_ids():
+    contract = load_public_io_contract(CONTRACT_PATH)
+    internal_stage_ids = set(LOGICAL_CI_JOB_IDS.values())
+
+    for entry in contract["formats"]:
+        assert not (set(entry["v3"]["ci_jobs"]) & internal_stage_ids)
 
 
 def test_registry_auto_identify_defaults_are_preserved():
@@ -142,7 +206,9 @@ def test_enums_only_expose_the_supported_values():
         MissingDependencyPolicy.FAIL,
         MissingDependencyPolicy.SKIP,
         MissingDependencyPolicy.NOT_PUBLIC,
+        MissingDependencyPolicy.MUST_RAISE_IMPORT_ERROR,
         MissingDependencyPolicy.CONDITIONAL_REGISTRATION,
+        MissingDependencyPolicy.WARNS_AND_SKIPS_OPTIONAL_METADATA,
     )
     assert LOGICAL_CI_JOB_IDS == {
         ScenarioName.POLICY.value: "io-conformance-policy",

--- a/tests/io_conformance/test_generators.py
+++ b/tests/io_conformance/test_generators.py
@@ -1,0 +1,78 @@
+"""Tests for deterministic IO conformance generators."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+from tests.io_conformance import conftest as guard_conftest
+from tests.io_conformance.generators import GENERATOR_SPECS, iter_generator_specs
+
+_FROZEN_GENERATOR_IDS = ("csv_txt", "audio", "hdf5", "hdf_ndscope", "gwf")
+
+
+def _file_tree(base_dir: Path) -> tuple[Path, ...]:
+    return tuple(
+        sorted(path.relative_to(base_dir) for path in base_dir.rglob("*") if path.is_file())
+    )
+
+
+def _read_tree(base_dir: Path) -> dict[Path, bytes]:
+    return {
+        path.relative_to(base_dir): path.read_bytes()
+        for path in sorted(base_dir.rglob("*"))
+        if path.is_file()
+    }
+
+
+def test_generator_registry_is_frozen_and_stable() -> None:
+    specs = iter_generator_specs()
+    assert specs == GENERATOR_SPECS
+    assert tuple(spec.name for spec in specs) == _FROZEN_GENERATOR_IDS
+    assert tuple(spec.entrypoint for spec in specs) == ("generate",) * len(specs)
+    assert tuple(spec.module_name for spec in specs) == tuple(
+        f"tests.io_conformance.generators.{generator_id}"
+        for generator_id in _FROZEN_GENERATOR_IDS
+    )
+
+
+@pytest.mark.parametrize("spec", iter_generator_specs(), ids=lambda spec: spec.name)
+def test_generators_are_deterministic_and_confined(tmp_path: Path, spec) -> None:
+    module = importlib.import_module(spec.module_name)
+    entrypoint = getattr(module, spec.entrypoint)
+
+    run_a = tmp_path / f"{spec.name}_a"
+    run_b = tmp_path / f"{spec.name}_b"
+    result_a = entrypoint(run_a)
+    result_b = entrypoint(run_b)
+
+    assert isinstance(result_a, dict)
+    assert isinstance(result_b, dict)
+    assert set(result_a) == set(result_b)
+
+    for output in (run_a, run_b):
+        assert output.exists()
+        for artifact in output.rglob("*"):
+            if artifact.is_file():
+                assert artifact.is_relative_to(output)
+
+    for result, output in ((result_a, run_a), (result_b, run_b)):
+        for value in result.values():
+            artifact_path = Path(value)
+            assert artifact_path.is_absolute()
+            assert artifact_path.is_relative_to(output)
+
+    assert _file_tree(run_a) == _file_tree(run_b)
+    if spec.name == "gwf":
+        assert (run_a / "manifest.json").read_bytes() == (
+            run_b / "manifest.json"
+        ).read_bytes()
+        return
+    assert _read_tree(run_a) == _read_tree(run_b)
+
+
+@pytest.mark.parametrize("spec", iter_generator_specs(), ids=lambda spec: spec.name)
+def test_generator_source_passes_import_guard(spec) -> None:
+    guard_conftest._guard_generator_source(spec)

--- a/tests/io_conformance/test_optional_dependency_behavior.py
+++ b/tests/io_conformance/test_optional_dependency_behavior.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from tests.io_conformance.contract import (
+    CONTRACT_PATH,
+    ContractCIJobId,
+    CoverageStatus,
+    MissingDependencyPolicy,
+    load_public_io_contract,
+)
+
+
+def _formats_by_canonical(contract: dict[str, object]) -> dict[str, dict[str, object]]:
+    return {entry["canonical"]: entry for entry in contract["formats"]}
+
+
+def test_public_optional_dependency_formats_do_not_use_skip_policy() -> None:
+    contract = load_public_io_contract(CONTRACT_PATH)
+    formats = _formats_by_canonical(contract)
+
+    for entry in formats.values():
+        if not entry["optional_dependencies"]:
+            continue
+        if entry["public_api"]["read"]:
+            assert (
+                entry["v3"]["missing_dependency_policy"]["read"]
+                != MissingDependencyPolicy.SKIP.value
+            )
+        if entry["canonical"] != "wav" and entry["public_api"]["write"]:
+            assert (
+                entry["v3"]["missing_dependency_policy"]["write"]
+                != MissingDependencyPolicy.SKIP.value
+            )
+
+
+def test_optional_dependency_formats_use_optional_ci_jobs_except_wav() -> None:
+    contract = load_public_io_contract(CONTRACT_PATH)
+    formats = _formats_by_canonical(contract)
+
+    wav = formats["wav"]
+    assert wav["v3"]["coverage_status"] == CoverageStatus.BLOCKING.value
+    assert wav["v3"]["ci_jobs"] == [ContractCIJobId.BASE.value]
+    assert (
+        wav["v3"]["missing_dependency_policy"]["read"]
+        == MissingDependencyPolicy.WARNS_AND_SKIPS_OPTIONAL_METADATA.value
+    )
+    assert (
+        wav["v3"]["missing_dependency_policy"]["write"]
+        == MissingDependencyPolicy.SKIP.value
+    )
+
+    for canonical, entry in formats.items():
+        if canonical == "wav" or not entry["optional_dependencies"]:
+            continue
+        if not (entry["public_api"]["read"] or entry["public_api"]["write"]):
+            continue
+
+        assert entry["v3"]["ci_jobs"]
+        assert ContractCIJobId.BASE.value not in entry["v3"]["ci_jobs"]

--- a/tests/io_conformance/test_read_conformance.py
+++ b/tests/io_conformance/test_read_conformance.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pytest
+from astropy.io.registry.base import IORegistryError
+from gwpy.timeseries import TimeSeries as GWpyTimeSeries
+
+import gwexpy
+
+gwexpy.register_all()
+
+from gwexpy.timeseries import TimeSeries, TimeSeriesDict
+from tests.io_conformance.contract import load_public_io_contract
+from tests.io_conformance.generators import audio, gwf, hdf5, hdf_ndscope
+from tests.io_conformance.validators import (
+    assert_timeseries_close,
+    assert_timeseriesdict_close,
+)
+
+_CONTRACT_FORMATS = {
+    entry["canonical"]: entry for entry in load_public_io_contract()["formats"]
+}
+
+_TEXT_VALUES = np.array([0.0, 1.0, 2.0, 3.0], dtype=float)
+
+
+@dataclass(frozen=True)
+class SeriesCase:
+    path: Path
+    values: np.ndarray | None
+    sample_rate: float
+    t0: float
+    name: str | None = None
+    channel: str | None = None
+    unit: str | None = None
+
+
+@dataclass(frozen=True)
+class DictCase:
+    path: Path
+    auto_path: Path | None
+    values_by_key: dict[str, np.ndarray]
+    sample_rate: float
+    t0: float
+    unit_by_key: dict[str, str] | None = None
+
+
+def _contract_aliases(canonical: str) -> tuple[str, ...]:
+    return tuple(_CONTRACT_FORMATS[canonical]["aliases"])
+
+
+def _skip_missing_gwf_backend(exc: Exception, *, alias: str | None = None) -> None:
+    message = str(exc)
+    if isinstance(exc, ImportError) or "Missing optional dependency" in message:
+        target = f"alias {alias!r}" if alias is not None else "format 'gwf'"
+        pytest.skip(f"GWF backend unavailable for {target}: {exc}")
+    if "No reader defined for format 'gwf'" in message:
+        target = f"alias {alias!r}" if alias is not None else "format 'gwf'"
+        pytest.skip(f"GWF backend unavailable for {target}: {exc}")
+    raise exc
+
+
+def _make_text_fixture(tmp_path: Path, suffix: str, fmt: str) -> SeriesCase:
+    series = GWpyTimeSeries(
+        _TEXT_VALUES,
+        sample_rate=1.0,
+        t0=123.0,
+        name="X1:TEST",
+        channel="X1:TEST",
+        unit="m",
+    )
+    path = tmp_path / f"sample.{suffix}"
+    series.write(path, format=fmt)
+    return SeriesCase(
+        path=path,
+        values=_TEXT_VALUES,
+        sample_rate=1.0,
+        t0=123.0,
+        name="ch1" if fmt == "csv" else None,
+        channel=None,
+        unit=None,
+    )
+
+
+def _gwf_expected_values() -> dict[str, np.ndarray]:
+    rng = np.random.default_rng(8_183)
+    return {"K1:CONFORMANCE-GWF": rng.normal(loc=0.0, scale=1.0, size=32)}
+
+
+def _ndscope_expected_values() -> dict[str, np.ndarray]:
+    rng = np.random.default_rng(20_241)
+    return {
+        "H1:CONFORMANCE-NDSCOPE": rng.normal(loc=0.0, scale=0.1, size=32),
+        "L1:CONFORMANCE-NDSCOPE": rng.normal(loc=1.0, scale=0.1, size=32),
+    }
+
+
+def _hdf5_expected_values() -> np.ndarray:
+    rng = np.random.default_rng(15_934)
+    return rng.normal(loc=0.0, scale=1.0, size=32)
+
+
+@pytest.fixture(scope="module")
+def gwf_case(tmp_path_factory: pytest.TempPathFactory) -> DictCase:
+    path = tmp_path_factory.mktemp("gwf-read") / "frame.gwf"
+    generated = gwf.generate(path.parent)
+    gwf_path = generated["gwf"]
+    try:
+        TimeSeriesDict.read(gwf_path, format="gwf")
+    except Exception as exc:  # pragma: no cover - depends on optional backend
+        _skip_missing_gwf_backend(exc)
+
+    return DictCase(
+        path=gwf_path,
+        auto_path=None,
+        values_by_key=_gwf_expected_values(),
+        sample_rate=16.0,
+        t0=1_000_000_000.0,
+        unit_by_key={"K1:CONFORMANCE-GWF": "m"},
+    )
+
+
+@pytest.fixture(scope="module")
+def ndscope_case(tmp_path_factory: pytest.TempPathFactory) -> DictCase:
+    path = tmp_path_factory.mktemp("ndscope-read") / "ndscope.hdf"
+    generated = hdf_ndscope.generate(path.parent)
+    auto_path = generated["hdf"].with_suffix(".hdf5")
+    shutil.copyfile(generated["hdf"], auto_path)
+    return DictCase(
+        path=generated["hdf"],
+        auto_path=auto_path,
+        values_by_key=_ndscope_expected_values(),
+        sample_rate=16.0,
+        t0=1_000_000_000.0,
+    )
+
+
+@pytest.fixture(scope="module")
+def hdf5_case(tmp_path_factory: pytest.TempPathFactory) -> SeriesCase:
+    path = tmp_path_factory.mktemp("hdf5-read") / "sample.h5"
+    generated = hdf5.generate(path.parent)
+    return SeriesCase(
+        path=generated["hdf5"],
+        values=_hdf5_expected_values(),
+        sample_rate=8.0,
+        t0=1_000_000_000.0,
+        name="H1:CONFORMANCE-HDF5",
+        channel=None,
+        unit="m",
+    )
+
+
+@pytest.fixture(scope="module")
+def csv_case(tmp_path_factory: pytest.TempPathFactory) -> SeriesCase:
+    return _make_text_fixture(tmp_path_factory.mktemp("csv-read"), "csv", "csv")
+
+
+@pytest.fixture(scope="module")
+def txt_case(tmp_path_factory: pytest.TempPathFactory) -> SeriesCase:
+    return _make_text_fixture(tmp_path_factory.mktemp("txt-read"), "txt", "txt")
+
+
+@pytest.fixture(scope="module")
+def wav_case(tmp_path_factory: pytest.TempPathFactory) -> SeriesCase:
+    path = tmp_path_factory.mktemp("wav-read") / "tone.wav"
+    generated = audio.generate(path.parent)
+    return SeriesCase(
+        path=generated["wav"],
+        values=None,
+        sample_rate=8_000.0,
+        t0=0.0,
+        name="channel_0",
+        channel="channel_0",
+        unit="",
+    )
+
+
+def test_gwf_explicit_and_auto_identify(gwf_case: DictCase) -> None:
+    explicit = TimeSeriesDict.read(gwf_case.path, format="gwf")
+    auto = TimeSeriesDict.read(gwf_case.path)
+
+    assert_timeseriesdict_close(
+        explicit,
+        gwf_case.values_by_key,
+        sample_rate=gwf_case.sample_rate,
+        t0=gwf_case.t0,
+        unit_by_key=gwf_case.unit_by_key,
+    )
+    assert_timeseriesdict_close(
+        auto,
+        gwf_case.values_by_key,
+        sample_rate=gwf_case.sample_rate,
+        t0=gwf_case.t0,
+        unit_by_key=gwf_case.unit_by_key,
+    )
+
+
+@pytest.mark.parametrize("alias", _contract_aliases("gwf"), ids=str)
+def test_gwf_alias_reads(gwf_case: DictCase, alias: str) -> None:
+    try:
+        actual = TimeSeriesDict.read(gwf_case.path, format=alias)
+    except Exception as exc:  # pragma: no cover - depends on optional backend
+        _skip_missing_gwf_backend(exc, alias=alias)
+
+    assert_timeseriesdict_close(
+        actual,
+        gwf_case.values_by_key,
+        sample_rate=gwf_case.sample_rate,
+        t0=gwf_case.t0,
+        unit_by_key=gwf_case.unit_by_key,
+        check_channel=False,
+    )
+
+
+def test_hdf_ndscope_explicit_and_auto_identify(ndscope_case: DictCase) -> None:
+    explicit = TimeSeriesDict.read(ndscope_case.path, format="hdf.ndscope")
+    assert ndscope_case.auto_path is not None
+    auto = TimeSeriesDict.read(ndscope_case.auto_path)
+
+    assert_timeseriesdict_close(
+        explicit,
+        ndscope_case.values_by_key,
+        sample_rate=ndscope_case.sample_rate,
+        t0=ndscope_case.t0,
+    )
+    assert_timeseriesdict_close(
+        auto,
+        ndscope_case.values_by_key,
+        sample_rate=ndscope_case.sample_rate,
+        t0=ndscope_case.t0,
+    )
+
+
+@pytest.mark.parametrize("alias", _contract_aliases("hdf.ndscope"), ids=str)
+def test_hdf_ndscope_alias_reads(ndscope_case: DictCase, alias: str) -> None:
+    actual = TimeSeriesDict.read(ndscope_case.path, format=alias)
+
+    assert_timeseriesdict_close(
+        actual,
+        ndscope_case.values_by_key,
+        sample_rate=ndscope_case.sample_rate,
+        t0=ndscope_case.t0,
+    )
+
+
+def test_hdf5_explicit_read(hdf5_case: SeriesCase) -> None:
+    actual = TimeSeries.read(hdf5_case.path, format="hdf5")
+
+    assert_timeseries_close(
+        actual,
+        hdf5_case.values,
+        sample_rate=hdf5_case.sample_rate,
+        t0=hdf5_case.t0,
+        name=hdf5_case.name,
+        channel=hdf5_case.channel,
+        unit=hdf5_case.unit,
+    )
+
+
+def test_hdf5_requires_explicit_format(hdf5_case: SeriesCase) -> None:
+    with pytest.raises(IORegistryError, match="Format could not be identified"):
+        TimeSeries.read(hdf5_case.path)
+
+
+def test_csv_explicit_and_auto_identify(csv_case: SeriesCase) -> None:
+    explicit = TimeSeries.read(csv_case.path, format="csv")
+    auto = TimeSeries.read(csv_case.path)
+
+    assert_timeseries_close(
+        explicit,
+        csv_case.values,
+        sample_rate=csv_case.sample_rate,
+        t0=csv_case.t0,
+        name=csv_case.name,
+        channel=csv_case.channel,
+        unit=csv_case.unit,
+    )
+    assert_timeseries_close(
+        auto,
+        csv_case.values,
+        sample_rate=csv_case.sample_rate,
+        t0=csv_case.t0,
+        name=csv_case.name,
+        channel=csv_case.channel,
+        unit=csv_case.unit,
+    )
+
+
+def test_txt_explicit_read_and_explicit_requirement(txt_case: SeriesCase) -> None:
+    actual = TimeSeries.read(txt_case.path, format="txt")
+
+    assert_timeseries_close(
+        actual,
+        txt_case.values,
+        sample_rate=txt_case.sample_rate,
+        t0=txt_case.t0,
+        name=txt_case.name,
+        channel=txt_case.channel,
+        unit=txt_case.unit,
+    )
+
+    with pytest.raises(IORegistryError, match="Format could not be identified"):
+        TimeSeries.read(txt_case.path)
+
+
+def test_wav_explicit_and_auto_identify(wav_case: SeriesCase) -> None:
+    explicit = TimeSeries.read(wav_case.path, format="wav")
+    auto = TimeSeries.read(wav_case.path)
+
+    assert_timeseries_close(
+        explicit,
+        wav_case.values,
+        sample_rate=wav_case.sample_rate,
+        t0=wav_case.t0,
+        name=wav_case.name,
+        channel=wav_case.channel,
+        unit=wav_case.unit,
+    )
+    assert_timeseries_close(
+        auto,
+        wav_case.values,
+        sample_rate=wav_case.sample_rate,
+        t0=wav_case.t0,
+        name=wav_case.name,
+        channel=wav_case.channel,
+        unit=wav_case.unit,
+    )

--- a/tests/io_conformance/test_read_conformance.py
+++ b/tests/io_conformance/test_read_conformance.py
@@ -189,6 +189,7 @@ def test_gwf_explicit_and_auto_identify(gwf_case: DictCase) -> None:
         sample_rate=gwf_case.sample_rate,
         t0=gwf_case.t0,
         unit_by_key=gwf_case.unit_by_key,
+        check_channel=False,
     )
     assert_timeseriesdict_close(
         auto,
@@ -196,6 +197,7 @@ def test_gwf_explicit_and_auto_identify(gwf_case: DictCase) -> None:
         sample_rate=gwf_case.sample_rate,
         t0=gwf_case.t0,
         unit_by_key=gwf_case.unit_by_key,
+        check_channel=False,
     )
 
 

--- a/tests/io_conformance/test_reporting.py
+++ b/tests/io_conformance/test_reporting.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from tests.io_conformance.contract import (
+    CONTRACT_PATH,
+    ScenarioName,
+    ScenarioStatus,
+    load_public_io_contract,
+)
+from tests.io_conformance.reporting import summarize_blocking_rows
+from tests.io_conformance.scenarios import expand_contract_scenarios
+
+
+def test_blocking_summary_uses_expanded_contract_rows() -> None:
+    contract = load_public_io_contract(CONTRACT_PATH)
+    rows = expand_contract_scenarios(contract)
+
+    summary = summarize_blocking_rows(rows)
+    blocking_rows = [
+        row for row in rows if row["scenario"] == ScenarioName.BLOCKING.value
+    ]
+    expected_blocked = sum(
+        row["status"] == ScenarioStatus.BLOCKED.value for row in blocking_rows
+    )
+
+    assert summary["blocking_blocked"] == expected_blocked
+    assert summary["blocking_total"] == len(blocking_rows)
+    assert summary["blocking_display"] == (
+        f"{summary['blocking_blocked']} blocked / {summary['blocking_total']} total"
+    )

--- a/tests/io_conformance/test_write_roundtrip.py
+++ b/tests/io_conformance/test_write_roundtrip.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import gwexpy
+from gwexpy.timeseries import TimeSeries, TimeSeriesDict, TimeSeriesList
+from tests.io_conformance.contract import load_public_io_contract
+
+gwexpy.register_all()
+
+
+_CONTRACT_FORMATS = {
+    entry["canonical"]: entry for entry in load_public_io_contract()["formats"]
+}
+
+
+def _contract_aliases(canonical: str) -> tuple[str, ...]:
+    return tuple(_CONTRACT_FORMATS[canonical]["aliases"])
+
+
+def _skip_missing_gwf_backend(exc: Exception, *, alias: str | None = None) -> None:
+    message = str(exc)
+    target = f"alias {alias!r}" if alias is not None else "format 'gwf'"
+    if isinstance(exc, (ImportError, ModuleNotFoundError)):
+        pytest.skip(f"GWF backend unavailable for {target}: {exc}")
+    if "Missing optional dependency" in message:
+        pytest.skip(f"GWF backend unavailable for {target}: {exc}")
+    if "No writer defined for format 'gwf'" in message:
+        pytest.skip(f"GWF backend unavailable for {target}: {exc}")
+    if "No reader defined for format 'gwf'" in message:
+        pytest.skip(f"GWF backend unavailable for {target}: {exc}")
+    raise exc
+
+
+def _make_series(
+    *,
+    name: str = "H1:ROUNDTRIP",
+    sample_rate: float = 4.0,
+    t0: float = 1_000_000_000.0,
+    values: np.ndarray | None = None,
+) -> TimeSeries:
+    data = np.arange(8.0) if values is None else values
+    return TimeSeries(data, sample_rate=sample_rate, t0=t0, unit="m", name=name)
+
+
+def _assert_series_close(actual: TimeSeries, expected: TimeSeries) -> None:
+    np.testing.assert_allclose(actual.value, expected.value)
+    np.testing.assert_allclose(actual.times.value, expected.times.value)
+    assert str(actual.unit) == str(expected.unit)
+    assert float(actual.sample_rate.value) == pytest.approx(
+        float(expected.sample_rate.value)
+    )
+    assert float(actual.t0.value) == pytest.approx(float(expected.t0.value))
+
+
+def test_csv_timeseriesdict_roundtrip(tmp_path: Path) -> None:
+    expected = TimeSeriesDict(
+        {
+            "H1:CSV": _make_series(name="H1:CSV"),
+            "L1:CSV": _make_series(name="L1:CSV", values=np.arange(8.0) * 2.0),
+        }
+    )
+    outdir = tmp_path / "csv"
+
+    expected.write(outdir, format="csv")
+    actual = TimeSeriesDict.read(outdir, format="csv")
+
+    assert list(actual.keys()) == list(expected.keys())
+    for key in expected:
+        _assert_series_close(actual[key], expected[key])
+
+
+def test_txt_timeserieslist_roundtrip(tmp_path: Path) -> None:
+    expected = TimeSeriesList(
+        _make_series(name="H1:TXT"),
+        _make_series(name="L1:TXT", values=np.arange(8.0) * 3.0),
+    )
+    outdir = tmp_path / "txt"
+
+    expected.write(outdir, format="txt")
+    actual = TimeSeriesList.read(outdir, format="txt")
+
+    assert len(actual) == len(expected)
+    for index, series in enumerate(expected):
+        _assert_series_close(actual[index], series)
+
+
+def test_hdf5_timeseries_roundtrip(tmp_path: Path) -> None:
+    expected = _make_series()
+    path = tmp_path / "series.h5"
+
+    expected.write(path, format="hdf5")
+    actual = TimeSeries.read(path, format="hdf5")
+
+    _assert_series_close(actual, expected)
+
+
+def test_hdf_ndscope_timeseriesdict_roundtrip(tmp_path: Path) -> None:
+    expected = TimeSeriesDict({"H1:NDSCOPE": _make_series(name="H1:NDSCOPE")})
+    path = tmp_path / "ndscope.hdf5"
+
+    expected.write(path, format="hdf.ndscope")
+    actual = TimeSeriesDict.read(path, format="hdf.ndscope")
+
+    assert list(actual.keys()) == list(expected.keys())
+    _assert_series_close(actual["H1:NDSCOPE"], expected["H1:NDSCOPE"])
+
+
+@pytest.mark.parametrize("alias", _contract_aliases("gwf"), ids=str)
+def test_gwf_alias_write_roundtrip(tmp_path: Path, alias: str) -> None:
+    expected = TimeSeriesDict({"K1:GWF": _make_series(name="K1:GWF")})
+    path = tmp_path / f"{alias.replace('.', '_')}.gwf"
+
+    try:
+        expected.write(path, format=alias)
+        actual = TimeSeriesDict.read(path, format="gwf")
+    except Exception as exc:  # pragma: no cover - depends on optional backend
+        _skip_missing_gwf_backend(exc, alias=alias)
+
+    assert list(actual.keys()) == list(expected.keys())
+    _assert_series_close(actual["K1:GWF"], expected["K1:GWF"])
+
+
+@pytest.mark.parametrize("alias", _contract_aliases("hdf.ndscope"), ids=str)
+def test_hdf_ndscope_alias_write_roundtrip(tmp_path: Path, alias: str) -> None:
+    expected = TimeSeriesDict(
+        {
+            "H1:NDSCOPE": _make_series(name="H1:NDSCOPE"),
+            "L1:NDSCOPE": _make_series(
+                name="L1:NDSCOPE",
+                values=np.arange(8.0) * 2.0,
+            ),
+        }
+    )
+    path = tmp_path / f"{alias.replace('.', '_')}.hdf5"
+
+    expected.write(path, format=alias)
+    actual = TimeSeriesDict.read(path, format="hdf.ndscope")
+
+    assert list(actual.keys()) == list(expected.keys())
+    for key in expected:
+        _assert_series_close(actual[key], expected[key])
+
+
+def test_wav_timeseries_roundtrip(tmp_path: Path) -> None:
+    expected = _make_series(
+        name="H1:WAV",
+        sample_rate=8_000.0,
+        t0=0.0,
+        values=np.sin(np.linspace(0.0, 4.0 * np.pi, 512)),
+    )
+    path = tmp_path / "signal.wav"
+
+    expected.write(path, format="wav")
+    actual = TimeSeries.read(path, format="wav")
+
+    assert len(actual) == len(expected)
+    assert float(actual.sample_rate.value) == pytest.approx(
+        float(expected.sample_rate.value)
+    )
+    assert float(actual.t0.value) == pytest.approx(float(expected.t0.value))
+    assert np.corrcoef(actual.value, expected.value)[0, 1] > 0.99
+
+
+def test_gwf_timeseriesdict_roundtrip(tmp_path: Path) -> None:
+    expected = TimeSeriesDict({"K1:GWF": _make_series(name="K1:GWF")})
+    path = tmp_path / "frame.gwf"
+
+    try:
+        expected.write(path, format="gwf")
+        actual = TimeSeriesDict.read(path, format="gwf")
+    except Exception as exc:  # pragma: no cover - depends on optional backend
+        _skip_missing_gwf_backend(exc)
+
+    assert list(actual.keys()) == list(expected.keys())
+    _assert_series_close(actual["K1:GWF"], expected["K1:GWF"])

--- a/tests/io_conformance/validators/__init__.py
+++ b/tests/io_conformance/validators/__init__.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from .timeseries import assert_timeseries_close, assert_timeseriesdict_close
+
+__all__ = [
+    "assert_timeseries_close",
+    "assert_timeseriesdict_close",
+]

--- a/tests/io_conformance/validators/timeseries.py
+++ b/tests/io_conformance/validators/timeseries.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+import numpy as np
+
+
+def _as_array(values: Sequence[float] | np.ndarray) -> np.ndarray:
+    return np.asarray(values, dtype=float)
+
+
+def _channel_label(channel: object) -> str | None:
+    if channel is None:
+        return None
+    return str(channel)
+
+
+def assert_timeseries_close(
+    actual,
+    expected_values: Sequence[float] | np.ndarray | None = None,
+    *,
+    sample_rate: float | None = None,
+    t0: float | None = None,
+    name: str | None = None,
+    channel: str | None = None,
+    unit: str | None = None,
+    rtol: float = 1e-12,
+    atol: float = 1e-12,
+) -> None:
+    if expected_values is not None:
+        expected = _as_array(expected_values)
+        actual_values = _as_array(actual.value)
+        assert actual_values.shape == expected.shape
+        np.testing.assert_allclose(actual_values, expected, rtol=rtol, atol=atol)
+
+    if sample_rate is not None:
+        np.testing.assert_allclose(float(actual.sample_rate.value), sample_rate)
+
+    if t0 is not None:
+        np.testing.assert_allclose(float(actual.t0.value), t0)
+
+    if name is not None:
+        assert getattr(actual, "name", None) == name
+
+    if channel is not None:
+        assert _channel_label(getattr(actual, "channel", None)) == channel
+
+    if unit is not None:
+        assert str(getattr(actual, "unit", "")) == unit
+
+
+def assert_timeseriesdict_close(
+    actual,
+    expected_values: Mapping[str, Sequence[float] | np.ndarray],
+    *,
+    sample_rate: float,
+    t0: float,
+    unit_by_key: Mapping[str, str] | None = None,
+    check_channel: bool = True,
+    rtol: float = 1e-12,
+    atol: float = 1e-12,
+) -> None:
+    assert tuple(actual.keys()) == tuple(expected_values.keys())
+
+    for key, values in expected_values.items():
+        assert_timeseries_close(
+            actual[key],
+            values,
+            sample_rate=sample_rate,
+            t0=t0,
+            name=key,
+            channel=key if check_channel else None,
+            unit=None if unit_by_key is None else unit_by_key[key],
+            rtol=rtol,
+            atol=atol,
+        )


### PR DESCRIPTION
## Summary

Title: test(io): add IO conformance baseline and fix DTTXML TS parsing

Closes #415

This branch covers two related pieces of work: the original DTTXML TS parsing fix and the broader IO conformance baseline that landed alongside it.

## Original DTTXML Fix

`load_dttxml_products()` now returns plain dicts for TS entries instead of wrapping them as `TimeSeries` objects. That keeps `read_timeseriesdict_dttxml()` on the dict path it expects and avoids dispatching `dict.get()` calls into `TimeSeries.get()`.

A focused regression test now patches the `dttxml` bridge with a minimal fake TS result, asserts the normalized payload is dict-shaped, and exercises `read_timeseriesdict_dttxml()` end to end.

## IO Conformance Baseline

The branch also adds the IO conformance release plan and review follow-ups, the public IO contract v3 metadata and docs updates, deterministic GWF/HDF5/NDScope generators, and the conformance read/write/generator/reporting tests.

The contract docs now distinguish on-disk JSON format-entry fields from normalized v3-derived fields such as `fixture_generator`, `coverage_status`, `ci_jobs`, and `missing_dependency_policy`.

It also includes the GWF channel metadata variance tolerance work needed for stable comparisons across backends.

## CI / Environment

`environment.yml` now provisions `ldas-tools-framecpp` and `python-framel` so PR Fast can exercise the GWF backend path in CI.

## Validation

- PR CI: 7/7 success for current head.
- Local gate: `rtk conda run -n gwexpy python scripts/ci/run_gate.py pr-fast` -> `5616 passed, 196 skipped, 13 deselected, 6 xfailed`.
- Local gate: `rtk conda run -n gwexpy python scripts/ci/run_gate.py io-conformance --no-fixtures` -> `52 passed, 6 skipped`, `6 blocked / 6 total`.
- Review-response focused tests: `rtk proxy pytest -q tests/io/test_dttxml_common.py tests/io/test_dttxml_reader.py tests/io/test_io_docs_contract_sync.py tests/io_conformance/test_contract_schema_v3.py -ra` -> `47 passed`.
- Review-response lint/checks: `rtk ruff check tests/io/test_dttxml_common.py` and `rtk git diff --check` -> no issues.
- Current head SHA: `efbe7dc3c50538b729d76871a71e62aa93809136`.

## Follow-up Items

- Native-parser TS product support remains a follow-up task; this PR protects the `dttxml` package bridge path that caused #415.
- Optional-dependency CI mapping lint and possible generator smoke optimization remain follow-up hardening items.

## Residual Risk

The shared conda solver surface is larger now because of `ldas-tools-framecpp` and `python-framel`. That is an operational risk for environment resolution, even though the prior CI run and local gates were green.
