### PR TITLE
chore(release): prepare v0.1.4 metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,29 @@
 
 ## [Unreleased]
 
-- **docs/io**: Added `io-conformance` gate guidance and documented the v3 public I/O contract policy fields.
+- No unreleased changes yet.
+
+## [0.1.4] - 2026-05-20
+
+### Added
+
+- **io/conformance**: Added the first contract-driven I/O conformance baseline for `gwf`, `hdf.ndscope`, `hdf5`, `csv`, `txt`, and `wav`.
+- **io/contracts**: Added v3 public I/O contract policy fields for fixture generation, coverage status, CI jobs, and missing optional dependency behavior.
+- **ci/io**: Added the `io-conformance` gate and expanded I/O gate documentation.
+
+### Fixed
+
+- **io/dttxml**: Fixed `load_dttxml_products()` so DTTXML `TS` entries remain raw dict payloads and do not collide with `TimeSeries.get()`.
+- **io/gwf**: Provisioned the GWF backend for the PR fast gate and tolerated backend-specific GWF channel metadata variance.
+
+### Tests
+
+- **io/conformance**: Added deterministic fixture generators and read/write round-trip coverage for the v0.1.4 blocking format baseline.
+- **io/dttxml**: Added regression coverage for DTTXML `TS` dict parsing through `read_timeseriesdict_dttxml()`.
+
+### Known Issues
+
+- **io/zarr**: The optional `io-zarr` gate can hang in environments where Zarr 3.1.5 stalls during basic `create_array()` fixture generation. Zarr remains outside the v0.1.4 base blocking gate and is tracked for optional-backend hardening.
 
 ## [0.1.3] - 2026-05-12
 

--- a/gwexpy/_version.py
+++ b/gwexpy/_version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"


### PR DESCRIPTION
## Summary
- bump package version metadata from 0.1.3 to 0.1.4
- add v0.1.4 changelog notes for the I/O conformance baseline and DTTXML fix
- document the optional Zarr fixture-generation hang observed with Zarr 3.1.5 as a known issue outside the v0.1.4 base gate

## Validation
- rtk conda run -n gwexpy python scripts/ci/run_gate.py io-conformance --no-fixtures: 52 passed, 6 skipped; 6 blocked / 6 total
- rtk conda run -n gwexpy python scripts/ci/run_gate.py io-contract --no-fixtures: 774 passed, 40 skipped, 1 deselected; wheel build/import smoke passed before metadata bump
- focused I/O suite: 190 passed, 10 skipped
- rtk conda run -n gwexpy python scripts/ci/run_gate.py io-optional --no-fixtures: 28 passed, 8 skipped
- rtk conda run -n gwexpy python -m build . --wheel --no-isolation: built gwexpy-0.1.4-py3-none-any.whl
- rtk git diff --check: clean

## Notes
- io-zarr optional gate was not counted as a release blocker: minimal Zarr 3.1.5 create_array fixture generation timed out in this environment, while Zarr remains planned/optional for v0.1.4 base gating.