### PR TITLE
chore(release): sync v0.1.4 citation metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,8 +2,8 @@
   "title": "GWexpy: Extending GWpy with metadata-preserving multidimensional abstractions for detector commissioning",
   "description": "GWexpy is an open-source Python library that extends the GWpy ecosystem with workflow-level abstractions and I/O adapters tailored for detector commissioning and laboratory-scale experimental diagnostics. GWexpy provides TimeSeriesMatrix containers, commissioning-oriented analysis primitives including transfer-function estimators and coherence-ranking utilities, and lossless format adapters for common experimental data formats.",
   "upload_type": "software",
-  "publication_date": "2026-05-12",
-  "version": "0.1.3",
+  "publication_date": "2026-05-20",
+  "version": "0.1.4",
   "license": {
     "id": "MIT"
   },

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ authors:
 - family-names: "Washimi"
   given-names: "Tatsuki"
 title: "GWexpy: Extended Analysis Utilities for Gravitational Wave Data"
-version: 0.1.3
-date-released: 2026-05-12
+version: 0.1.4
+date-released: 2026-05-20
 url: "https://github.com/tatsuki-washimi/gwexpy"
 repository-code: "https://github.com/tatsuki-washimi/gwexpy"
 license: MIT


### PR DESCRIPTION
## Summary
- sync CITATION.cff version/date to v0.1.4 / 2026-05-20
- sync .zenodo.json version/publication_date to v0.1.4 / 2026-05-20
- unblock release metadata consistency checks before tagging v0.1.4

## Validation
- rtk conda run -n gwexpy python scripts/check_release_metadata.py
- rtk conda run -n gwexpy python -m build . --outdir /tmp/gwexpy-v0.1.4-artifacts-final --no-isolation
- rtk conda run -n gwexpy python scripts/check_release_artifacts.py /tmp/gwexpy-v0.1.4-artifacts-final
- wheel smoke install in /tmp/gwexpy-v0.1.4-smoke-venv and import gwexpy -> 0.1.4
- rtk git diff --check