### PR TITLE
fix: expand TimeSeriesDict channels to separate subplots in plot()

### DIFF
--- a/gwexpy/plot/defaults.py
+++ b/gwexpy/plot/defaults.py
@@ -233,14 +233,31 @@ def determine_geometry_and_separate(data_list, separate=None, geometry=None):
         if separate is None:
             separate = True
         if separate is True and geometry is None:
-            # Mirror _expand_args(separate=True): list/tuple/dict/UserList/UserDict
-            # are all extended element-by-element; everything else is one subplot.
-            # UserList/UserDict covers SpectrogramList and SpectrogramDict which
-            # do not inherit directly from list/dict.
-            total_channels = sum(
-                len(item) if isinstance(item, (list, tuple, dict, UserList, UserDict)) else 1
-                for item in data_list
-            )
+            # Mirror _expand_args(separate=True) expansion counts:
+            # - matrices  → shape[0] (2-D) or shape[0]*shape[1] (3-D+)
+            # - list/tuple/dict/UserList/UserDict → len(item)
+            # - everything else → 1
+            total_channels = 0
+            for item in data_list:
+                item_type = type(item).__name__
+                if item_type in (
+                    "SeriesMatrix",
+                    "TimeSeriesMatrix",
+                    "FrequencySeriesMatrix",
+                ) or item_type.endswith("Matrix"):
+                    try:
+                        if item.ndim == 2:
+                            total_channels += item.shape[0]
+                        elif item.ndim >= 3:
+                            total_channels += item.shape[0] * item.shape[1]
+                        else:
+                            total_channels += 1
+                    except (AttributeError, ValueError):
+                        total_channels += 1
+                elif isinstance(item, (list, tuple, dict, UserList, UserDict)):
+                    total_channels += len(item)
+                else:
+                    total_channels += 1
             geometry = (total_channels, 1)
         return separate, geometry
 

--- a/gwexpy/plot/defaults.py
+++ b/gwexpy/plot/defaults.py
@@ -246,12 +246,24 @@ def determine_geometry_and_separate(data_list, separate=None, geometry=None):
                     "FrequencySeriesMatrix",
                 ) or item_type.endswith("Matrix"):
                     try:
-                        if item.ndim == 2:
-                            total_channels += item.shape[0]
-                        elif item.ndim >= 3:
-                            total_channels += item.shape[0] * item.shape[1]
+                        if item_type == "SpectrogramMatrix":
+                            # to_series_1Dlist(): 3-D → shape[0] spectrograms,
+                            # 4-D → shape[0]*shape[1] spectrograms
+                            if item.ndim == 3:
+                                total_channels += item.shape[0]
+                            elif item.ndim == 4:
+                                total_channels += item.shape[0] * item.shape[1]
+                            else:
+                                total_channels += 1
                         else:
-                            total_channels += 1
+                            # SeriesMatrix/TimeSeriesMatrix/FrequencySeriesMatrix:
+                            # to_series_1Dlist() always returns shape[0]*shape[1]
+                            if item.ndim == 2:
+                                total_channels += item.shape[0]
+                            elif item.ndim >= 3:
+                                total_channels += item.shape[0] * item.shape[1]
+                            else:
+                                total_channels += 1
                     except (AttributeError, ValueError):
                         total_channels += 1
                 elif isinstance(item, (list, tuple, dict, UserList, UserDict)):

--- a/gwexpy/plot/defaults.py
+++ b/gwexpy/plot/defaults.py
@@ -231,7 +231,11 @@ def determine_geometry_and_separate(data_list, separate=None, geometry=None):
         if separate is None:
             separate = True
         if separate is True and geometry is None:
-            geometry = (len(ref), 1)
+            total_channels = sum(
+                len(item) if type(item).__name__ == "TimeSeriesDict" else 1
+                for item in data_list
+            )
+            geometry = (total_channels, 1)
         return separate, geometry
 
     return separate, geometry

--- a/gwexpy/plot/defaults.py
+++ b/gwexpy/plot/defaults.py
@@ -227,6 +227,13 @@ def determine_geometry_and_separate(data_list, separate=None, geometry=None):
             except (AttributeError, ValueError):
                 return separate, (total_elements, 1)
 
+    if ref_type == "TimeSeriesDict":
+        if separate is None:
+            separate = True
+        if separate is True and geometry is None:
+            geometry = (len(ref), 1)
+        return separate, geometry
+
     return separate, geometry
 
 

--- a/gwexpy/plot/defaults.py
+++ b/gwexpy/plot/defaults.py
@@ -258,7 +258,8 @@ def determine_geometry_and_separate(data_list, separate=None, geometry=None):
                     total_channels += len(item)
                 else:
                     total_channels += 1
-            geometry = (total_channels, 1)
+            if total_channels > 0:
+                geometry = (total_channels, 1)
         return separate, geometry
 
     return separate, geometry

--- a/gwexpy/plot/defaults.py
+++ b/gwexpy/plot/defaults.py
@@ -231,8 +231,10 @@ def determine_geometry_and_separate(data_list, separate=None, geometry=None):
         if separate is None:
             separate = True
         if separate is True and geometry is None:
+            # Mirror _expand_args(separate=True): list/tuple/dict are extended,
+            # everything else contributes one subplot.
             total_channels = sum(
-                len(item) if type(item).__name__ == "TimeSeriesDict" else 1
+                len(item) if isinstance(item, (list, tuple, dict)) else 1
                 for item in data_list
             )
             geometry = (total_channels, 1)

--- a/gwexpy/plot/defaults.py
+++ b/gwexpy/plot/defaults.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections import UserDict, UserList
+
 import numpy as np
 from astropy import units as u
 from gwpy.frequencyseries import FrequencySeries
@@ -231,10 +233,12 @@ def determine_geometry_and_separate(data_list, separate=None, geometry=None):
         if separate is None:
             separate = True
         if separate is True and geometry is None:
-            # Mirror _expand_args(separate=True): list/tuple/dict are extended,
-            # everything else contributes one subplot.
+            # Mirror _expand_args(separate=True): list/tuple/dict/UserList/UserDict
+            # are all extended element-by-element; everything else is one subplot.
+            # UserList/UserDict covers SpectrogramList and SpectrogramDict which
+            # do not inherit directly from list/dict.
             total_channels = sum(
-                len(item) if isinstance(item, (list, tuple, dict)) else 1
+                len(item) if isinstance(item, (list, tuple, dict, UserList, UserDict)) else 1
                 for item in data_list
             )
             geometry = (total_channels, 1)

--- a/gwexpy/plot/defaults.py
+++ b/gwexpy/plot/defaults.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from collections import UserDict, UserList
-
 import numpy as np
 from astropy import units as u
 from gwpy.frequencyseries import FrequencySeries
@@ -230,47 +228,54 @@ def determine_geometry_and_separate(data_list, separate=None, geometry=None):
                 return separate, (total_elements, 1)
 
     if ref_type == "TimeSeriesDict":
-        if separate is None:
-            separate = True
-        if separate is True and geometry is None:
-            # Mirror _expand_args(separate=True) expansion counts:
-            # - matrices  → shape[0] (2-D) or shape[0]*shape[1] (3-D+)
-            # - list/tuple/dict/UserList/UserDict → len(item)
-            # - everything else → 1
-            total_channels = 0
-            for item in data_list:
-                item_type = type(item).__name__
-                if item_type in (
-                    "SeriesMatrix",
-                    "TimeSeriesMatrix",
-                    "FrequencySeriesMatrix",
-                ) or item_type.endswith("Matrix"):
-                    try:
-                        if item_type == "SpectrogramMatrix":
-                            # to_series_1Dlist(): 3-D → shape[0] spectrograms,
-                            # 4-D → shape[0]*shape[1] spectrograms
-                            if item.ndim == 3:
-                                total_channels += item.shape[0]
-                            elif item.ndim == 4:
-                                total_channels += item.shape[0] * item.shape[1]
-                            else:
-                                total_channels += 1
+        # Compute total expanded channel count first, mirroring _expand_args(separate=True):
+        # - matrices            → to_series_1Dlist() element count
+        # - list/tuple/dict     → len(item)  (FrequencySeriesList/Dict inherit list/dict)
+        # - SpectrogramList/Dict → len(item)  (inherit UserList/UserDict, checked by name)
+        # - plain UserList/UserDict → 1        (_expand_args falls to else-branch)
+        # - everything else     → 1
+        total_channels = 0
+        for item in data_list:
+            item_type = type(item).__name__
+            if item_type in (
+                "SeriesMatrix",
+                "TimeSeriesMatrix",
+                "FrequencySeriesMatrix",
+            ) or item_type.endswith("Matrix"):
+                try:
+                    if item_type == "SpectrogramMatrix":
+                        # to_series_1Dlist(): 3-D → shape[0], 4-D → shape[0]*shape[1]
+                        if item.ndim == 3:
+                            total_channels += item.shape[0]
+                        elif item.ndim == 4:
+                            total_channels += item.shape[0] * item.shape[1]
                         else:
-                            # SeriesMatrix/TimeSeriesMatrix/FrequencySeriesMatrix:
-                            # to_series_1Dlist() always returns shape[0]*shape[1]
-                            if item.ndim == 2:
-                                total_channels += item.shape[0]
-                            elif item.ndim >= 3:
-                                total_channels += item.shape[0] * item.shape[1]
-                            else:
-                                total_channels += 1
-                    except (AttributeError, ValueError):
-                        total_channels += 1
-                elif isinstance(item, (list, tuple, dict, UserList, UserDict)):
-                    total_channels += len(item)
-                else:
+                            total_channels += 1
+                    else:
+                        # to_series_1Dlist() always returns shape[0]*shape[1]
+                        if item.ndim == 2:
+                            total_channels += item.shape[0]
+                        elif item.ndim >= 3:
+                            total_channels += item.shape[0] * item.shape[1]
+                        else:
+                            total_channels += 1
+                except (AttributeError, ValueError):
                     total_channels += 1
-            if total_channels > 0:
+            elif isinstance(item, (list, tuple, dict)) or item_type in (
+                "SpectrogramList",
+                "SpectrogramDict",
+            ):
+                total_channels += len(item)
+            else:
+                total_channels += 1
+
+        # Only default separate=True and set geometry when channels exist.
+        # An empty TimeSeriesDict (total_channels == 0) keeps the caller's
+        # separate value so gwpy can produce a graceful empty plot.
+        if total_channels > 0:
+            if separate is None:
+                separate = True
+            if separate is True and geometry is None:
                 geometry = (total_channels, 1)
         return separate, geometry
 

--- a/tests/plot/test_defaults.py
+++ b/tests/plot/test_defaults.py
@@ -288,6 +288,18 @@ class TestDetermineGeometryAndSeparate:
         assert sep is True
         assert geom == (4, 1)
 
+    def test_timeseriesdict_mixed_with_matrix_geometry(self):
+        from gwpy.timeseries import TimeSeries
+
+        from gwexpy.timeseries import TimeSeriesDict, TimeSeriesMatrix
+
+        ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
+        tsd = TimeSeriesDict({"A": ts, "B": ts.copy()})
+        mat = TimeSeriesMatrix(np.ones((2, 16)), dt=1 / 16)
+        sep, geom = determine_geometry_and_separate([tsd, mat])
+        assert sep is True
+        assert geom == (4, 1)
+
 
 # ---------------------------------------------------------------------------
 # determine_xlabel

--- a/tests/plot/test_defaults.py
+++ b/tests/plot/test_defaults.py
@@ -274,6 +274,20 @@ class TestDetermineGeometryAndSeparate:
         assert sep is True
         assert geom == (4, 1)
 
+    def test_timeseriesdict_mixed_with_spectrogramlist_geometry(self):
+        from gwpy.spectrogram import Spectrogram
+        from gwpy.timeseries import TimeSeries
+
+        from gwexpy.spectrogram import SpectrogramList
+        from gwexpy.timeseries import TimeSeriesDict
+
+        ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
+        sg = Spectrogram(np.ones((16, 8)), t0=0, dt=1, f0=0, df=1)
+        tsd = TimeSeriesDict({"A": ts, "B": ts.copy()})
+        sep, geom = determine_geometry_and_separate([tsd, SpectrogramList([sg, sg])])
+        assert sep is True
+        assert geom == (4, 1)
+
 
 # ---------------------------------------------------------------------------
 # determine_xlabel

--- a/tests/plot/test_defaults.py
+++ b/tests/plot/test_defaults.py
@@ -209,6 +209,40 @@ class TestDetermineGeometryAndSeparate:
         sep, geom = determine_geometry_and_separate([sg], geometry=(2, 2))
         assert geom == (2, 2)
 
+    def test_timeseriesdict_sets_separate_true(self):
+        from gwpy.timeseries import TimeSeries
+        from gwexpy.timeseries import TimeSeriesDict
+        ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
+        tsd = TimeSeriesDict({"A": ts, "B": ts.copy(), "C": ts.copy()})
+        sep, geom = determine_geometry_and_separate([tsd])
+        assert sep is True
+
+    def test_timeseriesdict_geometry_matches_channel_count(self):
+        from gwpy.timeseries import TimeSeries
+        from gwexpy.timeseries import TimeSeriesDict
+        ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
+        tsd = TimeSeriesDict({"A": ts, "B": ts.copy(), "C": ts.copy()})
+        sep, geom = determine_geometry_and_separate([tsd])
+        assert geom == (3, 1)
+
+    def test_timeseriesdict_explicit_separate_false_respected(self):
+        from gwpy.timeseries import TimeSeries
+        from gwexpy.timeseries import TimeSeriesDict
+        ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
+        tsd = TimeSeriesDict({"A": ts, "B": ts.copy()})
+        sep, geom = determine_geometry_and_separate([tsd], separate=False)
+        assert sep is False
+        assert geom is None
+
+    def test_timeseriesdict_explicit_geometry_respected(self):
+        from gwpy.timeseries import TimeSeries
+        from gwexpy.timeseries import TimeSeriesDict
+        ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
+        tsd = TimeSeriesDict({"A": ts, "B": ts.copy()})
+        sep, geom = determine_geometry_and_separate([tsd], geometry=(1, 2))
+        assert sep is True
+        assert geom == (1, 2)
+
 
 # ---------------------------------------------------------------------------
 # determine_xlabel

--- a/tests/plot/test_defaults.py
+++ b/tests/plot/test_defaults.py
@@ -300,6 +300,14 @@ class TestDetermineGeometryAndSeparate:
         assert sep is True
         assert geom == (4, 1)
 
+    def test_empty_timeseriesdict_no_geometry(self):
+        from gwexpy.timeseries import TimeSeriesDict
+
+        tsd = TimeSeriesDict()
+        sep, geom = determine_geometry_and_separate([tsd])
+        assert sep is True
+        assert geom is None
+
 
 # ---------------------------------------------------------------------------
 # determine_xlabel

--- a/tests/plot/test_defaults.py
+++ b/tests/plot/test_defaults.py
@@ -263,6 +263,17 @@ class TestDetermineGeometryAndSeparate:
         assert sep is True
         assert geom == (4, 1)
 
+    def test_timeseriesdict_mixed_with_list_geometry(self):
+        from gwpy.timeseries import TimeSeries
+
+        from gwexpy.timeseries import TimeSeriesDict
+
+        ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
+        tsd = TimeSeriesDict({"A": ts, "B": ts.copy()})
+        sep, geom = determine_geometry_and_separate([tsd, [ts, ts]])
+        assert sep is True
+        assert geom == (4, 1)
+
 
 # ---------------------------------------------------------------------------
 # determine_xlabel

--- a/tests/plot/test_defaults.py
+++ b/tests/plot/test_defaults.py
@@ -305,8 +305,24 @@ class TestDetermineGeometryAndSeparate:
 
         tsd = TimeSeriesDict()
         sep, geom = determine_geometry_and_separate([tsd])
-        assert sep is True
+        # Empty dict: separate stays None, geometry stays None
+        assert sep is None
         assert geom is None
+
+    def test_plain_userlist_counts_as_one(self):
+        from collections import UserList
+
+        from gwpy.timeseries import TimeSeries
+
+        from gwexpy.timeseries import TimeSeriesDict
+
+        ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
+        tsd = TimeSeriesDict({"A": ts, "B": ts.copy()})
+        # Plain UserList is NOT expanded by _expand_args (falls to else-branch → 1 arg)
+        ul = UserList([ts, ts])
+        sep, geom = determine_geometry_and_separate([tsd, ul])
+        assert sep is True
+        assert geom == (3, 1)
 
     def test_timeseriesdict_mixed_with_3d_spectrogrammatrix_geometry(self):
         from gwpy.timeseries import TimeSeries

--- a/tests/plot/test_defaults.py
+++ b/tests/plot/test_defaults.py
@@ -211,7 +211,9 @@ class TestDetermineGeometryAndSeparate:
 
     def test_timeseriesdict_sets_separate_true(self):
         from gwpy.timeseries import TimeSeries
+
         from gwexpy.timeseries import TimeSeriesDict
+
         ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
         tsd = TimeSeriesDict({"A": ts, "B": ts.copy(), "C": ts.copy()})
         sep, geom = determine_geometry_and_separate([tsd])
@@ -219,7 +221,9 @@ class TestDetermineGeometryAndSeparate:
 
     def test_timeseriesdict_geometry_matches_channel_count(self):
         from gwpy.timeseries import TimeSeries
+
         from gwexpy.timeseries import TimeSeriesDict
+
         ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
         tsd = TimeSeriesDict({"A": ts, "B": ts.copy(), "C": ts.copy()})
         sep, geom = determine_geometry_and_separate([tsd])
@@ -227,7 +231,9 @@ class TestDetermineGeometryAndSeparate:
 
     def test_timeseriesdict_explicit_separate_false_respected(self):
         from gwpy.timeseries import TimeSeries
+
         from gwexpy.timeseries import TimeSeriesDict
+
         ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
         tsd = TimeSeriesDict({"A": ts, "B": ts.copy()})
         sep, geom = determine_geometry_and_separate([tsd], separate=False)
@@ -236,12 +242,26 @@ class TestDetermineGeometryAndSeparate:
 
     def test_timeseriesdict_explicit_geometry_respected(self):
         from gwpy.timeseries import TimeSeries
+
         from gwexpy.timeseries import TimeSeriesDict
+
         ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
         tsd = TimeSeriesDict({"A": ts, "B": ts.copy()})
         sep, geom = determine_geometry_and_separate([tsd], geometry=(1, 2))
         assert sep is True
         assert geom == (1, 2)
+
+    def test_timeseriesdict_multiple_dicts_geometry(self):
+        from gwpy.timeseries import TimeSeries
+
+        from gwexpy.timeseries import TimeSeriesDict
+
+        ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
+        tsd1 = TimeSeriesDict({"A": ts, "B": ts.copy()})
+        tsd2 = TimeSeriesDict({"C": ts, "D": ts.copy()})
+        sep, geom = determine_geometry_and_separate([tsd1, tsd2])
+        assert sep is True
+        assert geom == (4, 1)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/plot/test_defaults.py
+++ b/tests/plot/test_defaults.py
@@ -308,6 +308,20 @@ class TestDetermineGeometryAndSeparate:
         assert sep is True
         assert geom is None
 
+    def test_timeseriesdict_mixed_with_3d_spectrogrammatrix_geometry(self):
+        from gwpy.timeseries import TimeSeries
+
+        from gwexpy.spectrogram import SpectrogramMatrix
+        from gwexpy.timeseries import TimeSeriesDict
+
+        ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
+        tsd = TimeSeriesDict({"A": ts, "B": ts.copy()})
+        # 3-D SpectrogramMatrix shape (2, 16, 8): to_series_1Dlist returns shape[0]=2
+        sg_mat = SpectrogramMatrix(np.ones((2, 16, 8)), t0=0, dt=1, f0=0, df=1)
+        sep, geom = determine_geometry_and_separate([tsd, sg_mat])
+        assert sep is True
+        assert geom == (4, 1)
+
 
 # ---------------------------------------------------------------------------
 # determine_xlabel

--- a/tests/plot/test_gwexpy_plot_smoke.py
+++ b/tests/plot/test_gwexpy_plot_smoke.py
@@ -13,3 +13,21 @@ def test_plot_timeseries_no_matrix_does_not_error():
     import matplotlib.pyplot as plt
 
     plt.close(plot)
+
+
+def test_timeseriesdict_plot_not_blank():
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    from gwpy.timeseries import TimeSeries
+    from gwexpy.timeseries import TimeSeriesDict
+
+    ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
+    tsd = TimeSeriesDict({"A": ts, "B": ts.copy()})
+
+    plot = tsd.plot()
+
+    assert len(plot.axes) >= 2
+
+    plt.close(plot)

--- a/tests/plot/test_gwexpy_plot_smoke.py
+++ b/tests/plot/test_gwexpy_plot_smoke.py
@@ -1,3 +1,7 @@
+import matplotlib
+
+matplotlib.use("Agg")
+
 import numpy as np
 
 
@@ -16,11 +20,9 @@ def test_plot_timeseries_no_matrix_does_not_error():
 
 
 def test_timeseriesdict_plot_not_blank():
-    import matplotlib
-    matplotlib.use("Agg")
     import matplotlib.pyplot as plt
-
     from gwpy.timeseries import TimeSeries
+
     from gwexpy.timeseries import TimeSeriesDict
 
     ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)


### PR DESCRIPTION
Fixes #421. `determine_geometry_and_separate` did not recognise
`TimeSeriesDict`, so `separate` stayed `None` and `_expand_args`
wrapped all channels in a single Python list that gwpy cannot render,
producing a blank plot.

Added a `TimeSeriesDict` branch (mirroring the existing
SeriesMatrix/SpectrogramMatrix pattern) that defaults `separate=True`
and sets `geometry=(n_channels, 1)`. Explicit caller values for
`separate` and `geometry` are still respected.

Also adds four unit tests to `TestDetermineGeometryAndSeparate` and a
plot-level regression smoke test asserting that the resulting figure
contains at least as many axes as channels.

https://claude.ai/code/session_01WHWUtfyBGauVok2HGmzDDr