### PR TITLE
fix(seismic): support list/tuple of paths in TimeSeriesDict.read(format="mseed")

### DIFF
--- a/gwexpy/timeseries/io/seismic.py
+++ b/gwexpy/timeseries/io/seismic.py
@@ -56,18 +56,34 @@ def _trace_to_timeseries(trace, *, unit, timezone, epoch_override):
 
 def _read_obspy_stream(format_name, source, *, pad=np.nan, gap="pad", **kwargs):
     obspy = _import_obspy()
-    if (
-        not isinstance(source, (str, bytes))
-        and not hasattr(source, "__fspath__")
-        and hasattr(source, "name")
-    ):
-        source = source.name
-    try:
-        stream = obspy.read(source, format=format_name, **kwargs)
-    except (OSError, TypeError, ValueError) as exc:
-        # Fallback: try reading without format specifier if specifically WIN/KNET fails obscurely
-        # but usually we want to respect the format_name.
-        raise ValueError(f"Failed to read {format_name} file: {exc}") from exc
+
+    def _normalise_source(item):
+        if (
+            not isinstance(item, (str, bytes))
+            and not hasattr(item, "__fspath__")
+            and hasattr(item, "name")
+        ):
+            return item.name
+        return item
+
+    if isinstance(source, (list, tuple)):
+        if not source:
+            raise ValueError(f"No {format_name} files provided")
+        stream = obspy.Stream()
+        for item in source:
+            item = _normalise_source(item)
+            try:
+                stream += obspy.read(item, format=format_name, **kwargs)
+            except (OSError, TypeError, ValueError, AttributeError) as exc:
+                raise ValueError(
+                    f"Failed to read {format_name} file '{item}': {exc}"
+                ) from exc
+    else:
+        source = _normalise_source(source)
+        try:
+            stream = obspy.read(source, format=format_name, **kwargs)
+        except (OSError, TypeError, ValueError, AttributeError) as exc:
+            raise ValueError(f"Failed to read {format_name} file: {exc}") from exc
 
     gaps = stream.get_gaps()
     if gaps and gap == "raise":

--- a/tests/io/test_seismic_public_io.py
+++ b/tests/io/test_seismic_public_io.py
@@ -45,6 +45,32 @@ def test_mseed_public_dict_roundtrip_and_alias(tmp_path, fmt):
     assert len(back[key]) == len(tsd["SIG"])
 
 
+def test_mseed_list_of_paths(tmp_path):
+    """TimeSeriesDict.read() should accept a list of miniSEED paths (issue #428)."""
+    pytest.importorskip("obspy")
+
+    # Two contiguous segments of the same channel in separate files
+    ts1 = TimeSeries(np.arange(8, dtype=float), sample_rate=4, name="SIG", t0=0)
+    ts2 = TimeSeries(np.arange(8, dtype=float), sample_rate=4, name="SIG", t0=2)
+    path1 = tmp_path / "a.mseed"
+    path2 = tmp_path / "b.mseed"
+    TimeSeriesDict({"SIG": ts1}).write(path1, format="mseed")
+    TimeSeriesDict({"SIG": ts2}).write(path2, format="mseed")
+
+    result = TimeSeriesDict.read([str(path1), str(path2)], format="mseed")
+
+    assert len(result) == 1
+    assert len(next(iter(result.values()))) == 16
+
+
+def test_mseed_empty_list_raises():
+    """TimeSeriesDict.read() should reject an empty list."""
+    pytest.importorskip("obspy")
+
+    with pytest.raises(ValueError, match="No MSEED files provided"):
+        TimeSeriesDict.read([], format="mseed")
+
+
 @pytest.mark.parametrize("fmt", ["sac", "gse2"])
 def test_obsby_backed_public_dict_roundtrip(tmp_path, fmt):
     pytest.importorskip("obspy")


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

fix(seismic): support list/tuple of paths in TimeSeriesDict.read(format=&quot;mseed&quot;)
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 Less than 10 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

Fixes #428. When a list or tuple of file paths is passed as source,
_read_obspy_stream now reads each item individually and concatenates the
resulting ObsPy streams before merging, instead of forwarding the list
unchanged to obspy.read() which does not accept list input.

Also:
- Extracts _normalise_source() helper so file-like objects inside a list
  are handled consistently with the single-source branch.
- Adds AttributeError to the caught exception types (surfaces in some
  ObsPy versions for list input).
- Raises an explicit ValueError for an empty list input.

https://claude.ai/code/session_018roaodxJiUwXqDsCnb9618

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Fixes #428: <b><i>_read_obspy_stream</i></b> now iterates over list/tuple sources and concatenates ObsPy
  streams, since <b><i>obspy.read()</i></b> does not accept list input.
• Extracts <b><i>_normalise_source()</i></b> helper to consistently handle file-like objects (with <b><i>.name</i></b>) for
  both single and multi-source paths.
• Adds <b><i>AttributeError</i></b> to caught exception types (triggered in some ObsPy versions on list input)
  and raises explicit <b><i>ValueError</i></b> for empty list input.
• Adds two new tests: one verifying multi-file read and merge, one verifying empty-list rejection.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
    A(["TimeSeriesDict.read()"])
    B["_read_obspy_stream()"]
    C{"source type?"}
    D["_normalise_source()"]
    E["list / tuple"]
    F["single source"]
    G["obspy.read() per item"]
    H["obspy.read() once"]
    I[("obspy.Stream (merged)")]
    J(["TimeSeriesDict"])

    A --> B --> C
    C --> E --> D --> G --> I
    C --> F --> D --> H --> I
    I --> J

    subgraph Legend
        direction LR
        _proc(["Function"]) ~~~ _dec{"Decision"} ~~~ _db[("Data")]
    end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The PR&#x27;s approach is optimal: iterating over the list and concatenating ObsPy Streams is the idiomatic ObsPy pattern (Stream supports `+=`), and extracting `_normalise_source` avoids duplication. Alternatives like pre-reading all bytes or using a temporary concatenated file would add unnecessary complexity with no benefit.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>seismic.py</strong> <code>Support list/tuple of file paths in _read_obspy_stream</code> <code>+28/-12</code></summary>

<br/>

>Support list/tuple of file paths in _read_obspy_stream
>
><pre>
>• Refactors &#x27;_read_obspy_stream&#x27; to detect list/tuple sources and iterate over them, calling &#x27;obspy.read()&#x27; per item and accumulating results into a single &#x27;obspy.Stream&#x27;. Extracts &#x27;_normalise_source()&#x27; as an inner helper to handle file-like objects uniformly. Adds &#x27;AttributeError&#x27; to the caught exception set and raises &#x27;ValueError&#x27; for empty list input.
></pre>
>
><a href='https://github.com/tatsuki-washimi/gwexpy/pull/433/files#diff-8530a00c8205d7c7db987a9061c1596dbcf6248779baa5d7ecbbcbf09eb4faa1'>gwexpy/timeseries/io/seismic.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>test_seismic_public_io.py</strong> <code>Add tests for multi-file and empty-list mseed reads</code> <code>+26/-0</code></summary>

<br/>

>Add tests for multi-file and empty-list mseed reads
>
><pre>
>• Adds &#x27;test_mseed_list_of_paths&#x27; which writes two contiguous segments to separate files and verifies they are read and merged correctly into a single 16-sample channel. Adds &#x27;test_mseed_empty_list_raises&#x27; which asserts a &#x27;ValueError&#x27; is raised with the expected message when an empty list is passed.
></pre>
>
><a href='https://github.com/tatsuki-washimi/gwexpy/pull/433/files#diff-2aa5b6d5275f850ae7d092fb089578cc15abde196e74bb46e7699730da76cd2d'>tests/io/test_seismic_public_io.py</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>