### PR TITLE
fix(io): regenerate test.nc with explicit time coordinate (closes #393)

### DIFF
--- a/tests/fixtures/generate_fixtures.py
+++ b/tests/fixtures/generate_fixtures.py
@@ -251,12 +251,20 @@ def generate_zarr(filename):
 
 def generate_netcdf4(filename):
     if netCDF4 is None: return
+    t0 = 1704067200.0
+    dt = 0.1
+    n = 100
     with netCDF4.Dataset(filename, 'w', format='NETCDF4') as ds:
-        ds.createDimension('time', 100)
+        ds.createDimension('time', n)
+        tc = ds.createVariable('time', 'f8', ('time',))
+        tc[:] = t0 + np.arange(n) * dt
+        tc.long_name = 'GPS time'
+        tc.units = 's'
         v = ds.createVariable('ch1', 'f4', ('time',))
-        v[:] = np.random.randn(100)
-        v.setncattr('t0', 1704067200.0)
-        v.setncattr('dt', 0.1)
+        rng = np.random.default_rng(0)
+        v[:] = rng.normal(size=n)
+        v.setncattr('t0', t0)
+        v.setncattr('dt', dt)
 
 def generate_tdms(filename):
     if nptdms is None: return

--- a/tests/io/test_netcdf4_reader.py
+++ b/tests/io/test_netcdf4_reader.py
@@ -1,5 +1,7 @@
 """Tests for NetCDF4 reader/writer roundtrip."""
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -165,3 +167,31 @@ class TestNetCDF4Roundtrip:
         assert all(isinstance(k, int) for k in row_keys), "Row keys should be int"
         assert all(isinstance(k, int) for k in col_keys), "Col keys should be int"
         np.testing.assert_allclose(loaded.value, data)
+
+
+class TestNetCDF4FixtureContract:
+    """Verify that the generated test.nc fixture satisfies the reader contract.
+
+    These tests exist to prevent fixture-contract drift: if generate_netcdf4()
+    is ever modified to drop the time coordinate variable, these will fail fast.
+    """
+
+    @pytest.fixture(scope="class")
+    def fixture_path(self):
+        p = Path(__file__).resolve().parents[1] / "fixtures" / "data" / "test.nc"
+        if not p.exists():
+            pytest.skip("test.nc fixture not generated")
+        return p
+
+    def test_timeseriesdict_reads_fixture(self, fixture_path):
+        tsd = TimeSeriesDict.read(str(fixture_path), format="nc")
+        assert "ch1" in tsd
+        assert len(tsd["ch1"]) == 100
+
+    def test_timeseries_reads_fixture(self, fixture_path):
+        ts = TimeSeries.read(str(fixture_path), format="nc")
+        assert len(ts) == 100
+
+    def test_timeseriesmatrix_reads_fixture(self, fixture_path):
+        m = TimeSeriesMatrix.read(str(fixture_path), format="nc")
+        assert len(m) > 0


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix NetCDF4 fixture to include explicit time coordinate and add contract tests
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

tests/fixtures/data/test.nc was written with t0/dt only as variable
attributes, so xarray never exposed a time coordinate in ds.coords and
the NetCDF4 reader raised ValueError for all three TimeSeries-family
classes.

Fix generate_netcdf4() to create a proper 'time' coordinate variable
(GPS-second uniform grid) alongside the existing ch1 data variable.
Switched to a deterministic RNG (default_rng(0)) for reproducibility.

Added TestNetCDF4FixtureContract regression tests to lock in the
reader/fixture contract and prevent future drift.

https://claude.ai/code/session_01TLg6W3yNyqzmkdcCiV7Dy1

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Regenerate NetCDF4 fixture with a real <b><i>time</i></b> coordinate variable for xarray compatibility.
• Make fixture signal data deterministic by using a seeded NumPy RNG.
• Add regression tests to prevent fixture/reader contract drift for TimeSeries readers.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["generate_netcdf4()"] --> B[("test.nc fixture")] --> C["xarray/netCDF4 read"] --> D["TimeSeries* .read()"]
  E["Fixture contract tests"] --> B

  subgraph Legend
    direction LR
    _proc["Process/Code"] ~~~ _db[("Data file")]
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Rely only on `t0`/`dt` variable attributes (status quo)</b></summary>

- ➕ Minimal fixture size/complexity
- ➕ Keeps all timing metadata colocated with the data variable
- ➖ xarray does not expose a coordinate from ad-hoc attributes
- ➖ Reader becomes brittle across engines/backends and fails for TimeSeries readers

</details>

<details>
<summary><b>2. Write CF-style time coordinate (e.g., `units = seconds since ...`)</b></summary>

- ➕ Maximizes interoperability with xarray/CF tooling
- ➕ Encodes an absolute epoch in a standard way
- ➖ Slightly more metadata/format decisions (calendar/epoch) for a test fixture
- ➖ May require aligning reader expectations to CF conventions

</details>

**Recommendation:** Keep the PR’s approach: adding an explicit `time` coordinate variable is the most robust and backend-compatible fix for xarray exposure and prevents the NetCDF4 reader from failing. The added contract tests are a good guardrail against future fixture drift; if broader interoperability is desired later, consider moving toward CF-style `units`/`calendar` metadata.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>generate_fixtures.py</strong> <code>Generate NetCDF4 fixture with explicit &#x27;time&#x27; coordinate and seeded RNG</code> <code>+12/-4</code></summary>

<br/>

>Generate NetCDF4 fixture with explicit &#x27;time&#x27; coordinate and seeded RNG
>
><pre>
>• Creates a dedicated &#x27;time&#x27; coordinate variable (uniform grid from &#x27;t0&#x27;/&#x27;dt&#x27;) instead of storing timing only as attributes on &#x27;ch1&#x27;. Switches random data generation to &#x27;default_rng(0)&#x27; for deterministic fixture content while preserving &#x27;t0&#x27;/&#x27;dt&#x27; attributes for backward compatibility.
></pre>
>
><a href='https://github.com/tatsuki-washimi/gwexpy/pull/434/files#diff-2d98973130daae6035808b3ab1c61f33063c1bb5654be2429eeb56f71e8c40da'>tests/fixtures/generate_fixtures.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>test_netcdf4_reader.py</strong> <code>Add regression tests for the &#x27;test.nc&#x27; fixture/reader contract</code> <code>+30/-0</code></summary>

<br/>

>Add regression tests for the &#x27;test.nc&#x27; fixture/reader contract
>
><pre>
>• Introduces &#x27;TestNetCDF4FixtureContract&#x27; to assert that &#x27;TimeSeriesDict&#x27;, &#x27;TimeSeries&#x27;, and &#x27;TimeSeriesMatrix&#x27; can read the shipped &#x27;test.nc&#x27; fixture and produce expected lengths. Uses a class-scoped fixture to locate the fixture file and skips if it has not been generated.
></pre>
>
><a href='https://github.com/tatsuki-washimi/gwexpy/pull/434/files#diff-24dfd9b1a6c9ab7ad1d1b28766f728b4b493137571d01bef76a4491c58c571af'>tests/io/test_netcdf4_reader.py</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>