### PR TITLE
fix: use string name as TimeSeriesDict key in seismic readers (fix #429)

### DIFF
--- a/gwexpy/timeseries/io/seismic.py
+++ b/gwexpy/timeseries/io/seismic.py
@@ -104,7 +104,7 @@ def _build_dict(stream, *, channels, unit, timezone, epoch):
             tr, unit=unit, timezone=timezone, epoch_override=epoch
         )
         # Handle duplicate channels if necessary, currently overwrites
-        tsd[ts.channel] = ts
+        tsd[ts.name] = ts
     return tsd
 
 

--- a/tests/io/test_seismic_public_io.py
+++ b/tests/io/test_seismic_public_io.py
@@ -39,7 +39,10 @@ def test_mseed_public_dict_roundtrip_and_alias(tmp_path, fmt):
     back = TimeSeriesDict.read(path, format=fmt)
 
     assert len(back) == 1
-    assert len(next(iter(back.values()))) == len(tsd["SIG"])
+    key = next(iter(back.keys()))
+    assert isinstance(key, str), f"expected str key, got {type(key)}"
+    assert back[key].name == key
+    assert len(back[key]) == len(tsd["SIG"])
 
 
 @pytest.mark.parametrize("fmt", ["sac", "gse2"])
@@ -53,7 +56,10 @@ def test_obsby_backed_public_dict_roundtrip(tmp_path, fmt):
     back = TimeSeriesDict.read(path, format=fmt)
 
     assert len(back) == 1
-    assert len(next(iter(back.values()))) == len(tsd["SIG"])
+    key = next(iter(back.keys()))
+    assert isinstance(key, str), f"expected str key, got {type(key)}"
+    assert back[key].name == key
+    assert len(back[key]) == len(tsd["SIG"])
 
 
 def test_knet_public_surface_is_dict_first(monkeypatch):
@@ -71,7 +77,10 @@ def test_knet_public_surface_is_dict_first(monkeypatch):
     monkeypatch.setattr(seismic_io, "_read_obspy_stream", lambda *a, **k: stream)
     out = TimeSeriesDict.read("dummy.knet", format="knet")
     assert len(out) == 1
-    assert str(next(iter(out.keys()))).endswith("EW")
+    key = next(iter(out.keys()))
+    assert isinstance(key, str), f"expected str key, got {type(key)}"
+    assert key.endswith("EW")
+    assert out[key].name == key
 
 
 def test_win_alias_family_public_surface_is_dict_first(monkeypatch):


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix seismic TimeSeriesDict keys to use string trace IDs
<code>🐞 Bug fix</code> <code>🧪 Tests</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

`_build_dict()` was keying the dict by `ts.channel`, which GWpy normalizes
to a `Channel` object. Switch to `ts.name` (already set to `str(trace.id)`)
so that `data["KW.COLD..HHX"]` works as expected for all ObsPy-backed formats
(mseed, sac, gse2, knet).

Tests strengthened to assert `isinstance(key, str)` and that string-based
lookup succeeds.

https://claude.ai/code/session_01TNbnQEG7Tz8eEWkTrsxrbz

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Key ObsPy-backed seismic reads by string trace ID for stable dict lookups.
• Prevent GWpy Channel normalization from changing TimeSeriesDict key types.
• Strengthen round-trip tests to assert string keys and string-based access.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["ObsPy Stream"] --> B["seismic._build_dict"] --> C["seismic._trace_to_timeseries"] --> D["TimeSeries (name=str id)"] --> E[("TimeSeriesDict")]
  B -->|"key = ts.name"| E --> F["User lookup by str key"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Cast ts.channel to str when inserting into dict</b></summary>

- ➕ Minimal change while preserving the intent of using the channel attribute
- ➕ Works even if ts.name is not populated for some TimeSeries constructors
- ➖ Still couples dictionary keys to GWpy channel normalization semantics
- ➖ Less aligned with TimeSeriesDict&#x27;s documented &#x27;indexed by name&#x27; contract

</details>

<details>
<summary><b>2. Normalize keys at TimeSeriesDict boundary (enforce str keys)</b></summary>

- ➕ Centralized policy ensures consistent key types across all ingest paths
- ➖ Broader behavioral change with higher compatibility risk
- ➖ May require auditing many readers/writers beyond seismic I/O

</details>

**Recommendation:** Use `ts.name` as the key (current PR). It matches TimeSeriesDict’s documented indexing contract, leverages the already-stable `str(trace.id)` assignment in `_trace_to_timeseries`, and avoids GWpy `Channel` object normalization leaking into public dict keys.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Bug fix</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>seismic.py</strong> <code>Key seismic TimeSeriesDict entries by ts.name (string)</code> <code>+1/-1</code></summary>

<br/>

>Key seismic TimeSeriesDict entries by ts.name (string)
>
><pre>
>• Switches &#x27;_build_dict()&#x27; to use &#x27;ts.name&#x27; instead of &#x27;ts.channel&#x27; as the dictionary key. This prevents GWpy-normalized &#x27;Channel&#x27; objects from becoming keys and ensures string-based lookups work consistently for ObsPy-backed formats.
></pre>
>
><a href='https://github.com/tatsuki-washimi/gwexpy/pull/435/files#diff-8530a00c8205d7c7db987a9061c1596dbcf6248779baa5d7ecbbcbf09eb4faa1'>gwexpy/timeseries/io/seismic.py</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Tests</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>test_seismic_public_io.py</strong> <code>Assert seismic reads return string keys and support string lookup</code> <code>+12/-3</code></summary>

<br/>

>Assert seismic reads return string keys and support string lookup
>
><pre>
>• Updates public I/O round-trip tests for mseed/sac/gse2 and the knet surface test to assert keys are &#x27;str&#x27;, that &#x27;back[key].name == key&#x27;, and that length checks use string-based indexing. This guards against regressions where keys become non-string objects.
></pre>
>
><a href='https://github.com/tatsuki-washimi/gwexpy/pull/435/files#diff-2aa5b6d5275f850ae7d092fb089578cc15abde196e74bb46e7699730da76cd2d'>tests/io/test_seismic_public_io.py</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>