### PR TITLE
fix(frequencyseries): auto-register I/O formats on import

### DIFF
--- a/gwexpy/frequencyseries/__init__.py
+++ b/gwexpy/frequencyseries/__init__.py
@@ -30,3 +30,6 @@ _CR.register_constructor("FrequencySeriesList", FrequencySeriesList)
 _CR.register_constructor("FrequencySeriesMatrix", FrequencySeriesMatrix)
 _CR.register_constructor("BifrequencyMap", BifrequencyMap)
 del _CR
+
+# Register I/O readers on import
+from . import io as _io  # noqa: F401

--- a/gwexpy/frequencyseries/io/dttxml.py
+++ b/gwexpy/frequencyseries/io/dttxml.py
@@ -245,8 +245,19 @@ def read_frequencyseriesmatrix_dttxml(
     return fsm
 
 
+def read_frequencyseries_dttxml(*args, **kwargs) -> FrequencySeries:
+    """Read one DTT XML product and return its first channel."""
+    fsd = read_frequencyseriesdict_dttxml(*args, **kwargs)
+    if len(fsd) == 0:
+        raise ValueError("No channels found in xml.diaggui")
+    return fsd[next(iter(fsd.keys()))]
+
+
 # -- registration
 for _fmt in _DTTXML_FORMATS:
+    io_registry.register_reader(
+        _fmt, FrequencySeries, read_frequencyseries_dttxml, force=True
+    )
     io_registry.register_reader(
         _fmt, FrequencySeriesDict, read_frequencyseriesdict_dttxml, force=True
     )
@@ -263,5 +274,10 @@ io_registry.register_identifier(
 io_registry.register_identifier(
     "xml.diaggui",
     FrequencySeriesDict,
+    lambda *args, **kwargs: _looks_like_dttxml(args[1] if len(args) > 1 else None),
+)
+io_registry.register_identifier(
+    "xml.diaggui",
+    FrequencySeriesMatrix,
     lambda *args, **kwargs: _looks_like_dttxml(args[1] if len(args) > 1 else None),
 )

--- a/gwexpy/frequencyseries/io/stubs.py
+++ b/gwexpy/frequencyseries/io/stubs.py
@@ -1,7 +1,7 @@
 """Placeholder readers for unsupported frequency-domain formats."""
 from __future__ import annotations
 
-from astropy.io import registry as io_registry
+from gwpy.io.registry import default_registry as io_registry
 
 from ..collections import FrequencySeriesDict
 from ..frequencyseries import FrequencySeries

--- a/tests/io/test_frequencyseries_registration.py
+++ b/tests/io/test_frequencyseries_registration.py
@@ -1,0 +1,81 @@
+"""Subprocess-isolated tests for FrequencySeries I/O auto-registration.
+
+Verifies that ``import gwexpy.frequencyseries`` alone populates the GWpy
+default I/O registry with the expected read/write formats, matching the
+``gwexpy.timeseries`` bootstrap behaviour.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def _run_isolated(code: str) -> subprocess.CompletedProcess[str]:
+    """Run *code* in a fresh Python subprocess and return the result."""
+    return subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+
+class TestFrequencySeriesIORegistration:
+    """Verify that importing gwexpy.frequencyseries registers I/O formats."""
+
+    def test_dttxml_registered_for_frequencyseries(self):
+        result = _run_isolated("""\
+            from gwpy.io.registry import default_registry as reg
+            from gwexpy.frequencyseries import FrequencySeries
+            fmt_names = list(reg.get_formats(FrequencySeries, "Read")["Format"])
+            assert "xml.diaggui" in fmt_names, f"xml.diaggui not in {fmt_names}"
+            assert "dttxml" in fmt_names, f"dttxml not in {fmt_names}"
+        """)
+        assert result.returncode == 0, result.stderr
+
+    def test_dttxml_registered_for_frequencyseriesdict(self):
+        result = _run_isolated("""\
+            from gwpy.io.registry import default_registry as reg
+            from gwexpy.frequencyseries import FrequencySeriesDict
+            fmt_names = list(reg.get_formats(FrequencySeriesDict, "Read")["Format"])
+            assert "xml.diaggui" in fmt_names, f"xml.diaggui not in {fmt_names}"
+            assert "dttxml" in fmt_names, f"dttxml not in {fmt_names}"
+        """)
+        assert result.returncode == 0, result.stderr
+
+    def test_dttxml_registered_for_frequencyseriesmatrix(self):
+        result = _run_isolated("""\
+            from gwpy.io.registry import default_registry as reg
+            from gwexpy.frequencyseries import FrequencySeriesMatrix
+            fmt_names = list(reg.get_formats(FrequencySeriesMatrix, "Read")["Format"])
+            assert "xml.diaggui" in fmt_names, f"xml.diaggui not in {fmt_names}"
+            assert "dttxml" in fmt_names, f"dttxml not in {fmt_names}"
+        """)
+        assert result.returncode == 0, result.stderr
+
+    def test_stub_formats_in_gwpy_registry(self):
+        result = _run_isolated("""\
+            from gwpy.io.registry import default_registry as reg
+            from gwexpy.frequencyseries import FrequencySeries
+            fmt_names = list(reg.get_formats(FrequencySeries, "Read")["Format"])
+            for stub in ("win", "sdb", "orf", "mem"):
+                assert stub in fmt_names, f"{stub} not in {fmt_names}"
+        """)
+        assert result.returncode == 0, result.stderr
+
+    def test_xml_diaggui_auto_identify_for_all_types(self):
+        result = _run_isolated("""\
+            from gwpy.io.registry import default_registry as reg
+            from gwexpy.frequencyseries import (
+                FrequencySeries, FrequencySeriesDict, FrequencySeriesMatrix,
+            )
+            for cls in (FrequencySeries, FrequencySeriesDict, FrequencySeriesMatrix):
+                fmts = reg.get_formats(cls, "Read")
+                row = fmts[fmts["Format"] == "xml.diaggui"]
+                assert len(row) == 1, f"xml.diaggui not found for {cls.__name__}"
+                assert row["Auto-identify"][0] == "Yes", (
+                    f"xml.diaggui Auto-identify not Yes for {cls.__name__}"
+                )
+        """)
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Fixes #417.

This PR makes `import gwexpy.frequencyseries` automatically register the frequency-domain I/O surface, matching the existing `gwexpy.timeseries` behavior.

Changes:

- import `gwexpy.frequencyseries.io` from `gwexpy.frequencyseries.__init__`;
- register frequencyseries stub formats with `gwpy.io.registry.default_registry` instead of `astropy.io.registry`;
- add a registry-visible `FrequencySeries` DTT XML reader;
- add the missing `FrequencySeriesMatrix` DTT XML identifier;
- add subprocess-isolated registration tests.

## Scope

This intentionally does **not** change `frequencyseries/collections.py` read/write fallback dispatch. That broader registry-backend migration is deferred to a follow-up issue because it could affect collection read/write behavior.

## Validation

```text
pytest -xvs tests/io/test_frequencyseries_registration.py -p no:cacheprovider
5 passed

pytest -xvs tests/io/test_frequencyseries_io.py -p no:cacheprovider
20 passed

ruff check --no-cache gwexpy/frequencyseries/ tests/io/test_frequencyseries_registration.py
All checks passed
```

## Notes

Investigation confirmed that `gwpy.io.registry.default_registry` (`UnifiedIORegistry` instance) and `astropy.io.registry` (module) are separate registry objects. Registering frequencyseries stubs only with Astropy made them invisible when querying the GWpy registry surface — the stubs were effectively broken in practice.

## Agent Audit Manifest

```yaml
issue: "#417"
scope: "#417-A low-risk v0.1.5 patch"
excluded: "frequencyseries/collections.py read/write dispatch migration (follow-up issue)"
changed_files_count: 4
commits:
  - 3c9d07d fix(frequencyseries): auto-register I/O formats on subpackage import (#417)
tests_run:
  - "tests/io/test_frequencyseries_registration.py: 5 passed"
  - "tests/io/test_frequencyseries_io.py: 20 passed"
lint: "ruff check: all checks passed"
```

---
_Generated by [Claude Code](https://claude.ai/code/session_01Myun2NcWK1zGxphj4qqXTQ)_