### PR TITLE
Release v0.1.5: plotting and I/O hotfixes

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,8 +2,8 @@
   "title": "GWexpy: Extending GWpy with metadata-preserving multidimensional abstractions for detector commissioning",
   "description": "GWexpy is an open-source Python library that extends the GWpy ecosystem with workflow-level abstractions and I/O adapters tailored for detector commissioning and laboratory-scale experimental diagnostics. GWexpy provides TimeSeriesMatrix containers, commissioning-oriented analysis primitives including transfer-function estimators and coherence-ranking utilities, and lossless format adapters for common experimental data formats.",
   "upload_type": "software",
-  "publication_date": "2026-05-20",
-  "version": "0.1.4",
+  "publication_date": "2026-06-10",
+  "version": "0.1.5",
   "license": {
     "id": "MIT"
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@
 
 - No unreleased changes yet.
 
+## [0.1.5] - 2026-06-10
+
+This is a patch release focused on plotting and I/O hotfixes.
+
+### Bug fixes
+
+- Fixed `TimeSeriesDict.plot()` so multi-channel dictionaries are expanded into
+  separate subplots instead of producing a blank or invalid figure (#432).
+- Fixed ObsPy-backed seismic readers so `TimeSeriesDict` keys are stable string
+  trace names (e.g. `"IU.ANMO.00.BHZ"`), enabling reliable string-based lookup
+  (#435).
+- Added support for passing a list or tuple of miniSEED paths to
+  `TimeSeriesDict.read(..., format="mseed")` (#433).
+- Fixed `gwexpy.frequencyseries` import-time I/O registration so FrequencySeries
+  read formats are visible through the GWpy default I/O registry (#437).
+
+### Tests
+
+- Added regression tests for `TimeSeriesDict.plot()`.
+- Added seismic I/O tests for string keys, list-of-path miniSEED input, and
+  empty-list rejection.
+- Added subprocess-isolated FrequencySeries I/O registration tests.
+
+### Documentation
+
+- Clarified that GWexpy is an independent package built on top of GWpy and is
+  not an official component of the GWpy project.
+- Updated the README installation notes to reflect that the conda-forge
+  feedstock is available, while conda-forge packages may lag the latest PyPI
+  release.
+
+### Deferred
+
+- Broad FrequencySeries collection read/write registry-backend migration is
+  deferred to #438.
+- Dependency sweep (#431) is deferred to the v0.2.0-prep lane.
+
 ## [0.1.4] - 2026-05-20
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,8 +4,8 @@ authors:
 - family-names: "Washimi"
   given-names: "Tatsuki"
 title: "GWexpy: Extended Analysis Utilities for Gravitational Wave Data"
-version: 0.1.4
-date-released: 2026-05-20
+version: 0.1.5
+date-released: 2026-06-10
 url: "https://github.com/tatsuki-washimi/gwexpy"
 repository-code: "https://github.com/tatsuki-washimi/gwexpy"
 license: MIT

--- a/README.md
+++ b/README.md
@@ -14,17 +14,24 @@
 
 **gwexpy** is an extension library for [GWpy](https://gwpy.github.io/) for experimental physics and gravitational-wave data analysis. It adds matrix-aware containers, field operations, fitting workflows, expanded I/O, and interoperability layers while staying close to GWpy-style analysis.
 
+GWexpy is an independent package built on top of GWpy. It is not an official component of the GWpy project.
+
 ## Install
 
 ```bash
 python -m pip install gwexpy
 ```
 
-GWexpy is published on PyPI. The experimental GUI app is not part of the
-supported package surface. You can install the PyPI package inside a
-Conda-managed environment. A native conda-forge package is under review at
-<https://github.com/conda-forge/staged-recipes/pull/33169> and is not yet
-available on the conda-forge channel.
+GWexpy is published on PyPI. A conda-forge feedstock is also available, though
+the conda-forge package may lag the latest PyPI release.
+
+```bash
+python -m pip install gwexpy
+# or, once the desired version is available on conda-forge:
+conda install -c conda-forge gwexpy
+```
+
+The experimental GUI app is not part of the supported package surface.
 
 For optional extras, external dependencies, and environment-specific setup, use the official installation guides:
 

--- a/docs/web/en/user_guide/installation.md
+++ b/docs/web/en/user_guide/installation.md
@@ -27,11 +27,11 @@ myst:
 - [Next to Read](#next-to-read)
 
 :::{note}
-GWexpy is published on PyPI (current release: v0.1.3). A native conda-forge
-package is under review in staged-recipes
-(<https://github.com/conda-forge/staged-recipes/pull/33169>) and is not yet
-available on the conda-forge channel. Install `gwexpy` from PyPI — including
-inside Conda-managed environments — until the conda-forge package is live.
+GWexpy is published on PyPI (current release: v0.1.5). A conda-forge feedstock
+is also available, though the conda-forge package may lag the latest PyPI
+release. Install from PyPI for the latest version, or use
+`conda install -c conda-forge gwexpy` once the desired version is available on
+the conda-forge channel.
 :::
 
 GWexpy supports **Python 3.11 or later**. You can choose from several installation options (extras) depending on your analysis goals.
@@ -67,8 +67,8 @@ pip install gwexpy
 For gravitational-wave analysis (requiring NDS2 or FrameLIB), we strongly recommend using Conda (e.g., Miniforge) to resolve binary dependencies first.
 
 This workflow uses Conda for the environment and binary dependencies, then uses
-PyPI for GWexpy itself. It is different from a future native conda-forge
-`gwexpy` package.
+PyPI for GWexpy itself. A conda-forge feedstock for `gwexpy` is also available,
+but may lag the latest PyPI release.
 
 :::{warning}
 If you use Conda, avoid running `pip install` directly in `base` or in a shared environment for unrelated work. Create a **dedicated environment for GWexpy** first, then install both the Conda-managed binary dependencies and the `pip` packages there. This keeps binary dependency resolution isolated and reduces the risk of breaking the environment.

--- a/docs/web/ja/user_guide/installation.md
+++ b/docs/web/ja/user_guide/installation.md
@@ -27,12 +27,12 @@ myst:
 - [次に読む](#next-to-read)
 
 :::{note}
-GWexpy は PyPI に公開されています（最新リリース: v0.1.3）。
-conda-forge パッケージは staged-recipes でレビュー中
-（<https://github.com/conda-forge/staged-recipes/pull/33169>）であり、
-conda-forge チャンネルにはまだ公開されていません。
-conda-forge が利用可能になるまでは、Conda 管理の環境内でも PyPI から
-インストールしてください。
+GWexpy は PyPI に公開されています（最新リリース: v0.1.5）。
+conda-forge フィードストックも利用可能ですが、conda-forge パッケージは
+最新の PyPI リリースより遅れる場合があります。
+最新バージョンが必要な場合は PyPI からインストールしてください。
+希望のバージョンが conda-forge チャンネルで利用可能になり次第、
+`conda install -c conda-forge gwexpy` でもインストールできます。
 :::
 
 GWexpy は **Python 3.11 以上** をサポートしています。解析の目的に合わせて、いくつかのインストールオプション（extras）を選択できます。
@@ -68,8 +68,8 @@ pip install gwexpy
 重力波解析（NDS2 や FrameLIB 等）を行う場合は、Conda (Miniforge 等) を使用してバイナリ依存関係を先に解決することを強く推奨します。
 
 この手順は、環境とバイナリ依存関係を Conda で管理し、GWexpy 本体は PyPI
-から入れる方法です。将来の conda-forge native package としての `gwexpy`
-とは別の扱いです。
+から入れる方法です。`gwexpy` の conda-forge フィードストックも利用可能ですが、
+最新の PyPI リリースより遅れる場合があります。
 
 :::{warning}
 Conda 環境を使う場合は、`base` や別用途の既存環境に直接 `pip install` せず、**GWexpy 専用の新しい環境** を作成してから導入してください。Conda が管理するバイナリ依存関係と `pip` で追加する Python パッケージを同じ専用環境に閉じ込めることで、環境破損のリスクを下げられます。

--- a/gwexpy/_version.py
+++ b/gwexpy/_version.py
@@ -1,3 +1,3 @@
 from __future__ import annotations
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"


### PR DESCRIPTION
## Summary

This release addresses critical bugs in plotting and I/O functionality, along with documentation clarifications. Key fixes include:

- **TimeSeriesDict.plot()**: Fixed multi-channel dictionary expansion into separate subplots
- **ObsPy seismic readers**: Stabilized TimeSeriesDict keys as string trace names for reliable lookup
- **miniSEED I/O**: Added support for list/tuple of paths in `TimeSeriesDict.read(..., format="mseed")`
- **FrequencySeries I/O**: Fixed import-time registration visibility in GWpy's default I/O registry
- **Documentation**: Clarified GWexpy's independent status and updated conda-forge installation notes

## Acceptance Criteria

- [x] Code follows the project's style guidelines
- [x] Tests have been added for regressions and new functionality
- [x] Documentation has been updated (README clarifications and CHANGELOG)

## Documentation Checklist

- [x] **README**: Updated installation instructions to reflect conda-forge availability
- [x] **CHANGELOG**: Comprehensive release notes with bug fixes, tests, and deferred items
- [x] **Metadata**: Version bumped in `_version.py`, `.zenodo.json`, and `CITATION.cff`

## Impact

This is a patch release (v0.1.5) with no breaking changes. All fixes are backward-compatible improvements to existing functionality.

## Related Issues

- #432: TimeSeriesDict.plot() multi-channel expansion
- #433: miniSEED list/tuple path support
- #435: ObsPy seismic reader string key stability
- #437: FrequencySeries I/O registration visibility
- #438: Deferred FrequencySeries collection registry migration
- #431: Deferred dependency sweep to v0.2.0-prep

https://claude.ai/code/session_01YYvRfnRaQgdNCrYKVZZP7F