### PR TITLE
fix: address plot geometry, multi-source readers, and silent-failure follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,37 @@
 
 ## [Unreleased]
 
-- No unreleased changes yet.
+### Bug fixes
+
+- Fixed subplot geometry calculation in `Plot` so the expansion count always
+  matches `_expand_args`: all arguments are now counted regardless of order
+  (a leading Spectrogram or matrix no longer hides later containers), the
+  duplicated counting loops were unified into a single helper, and a leading
+  matrix keeps its grid geometry only when it is the sole argument (#440).
+- All TimeSeries readers now handle a list or tuple of paths: formats with
+  well-defined merge semantics (tdms, ats, csv, netcdf4, gbd, ndscope HDF5,
+  zarr, sdb, win, dttxml) concatenate channels along time with NaN gap
+  padding via a shared multi-source helper, while self-contained formats
+  (wav, audio) raise a clear `ValueError` instead of an opaque backend
+  `TypeError` (#441).
+- GWF alias registration no longer swallows unexpected errors silently:
+  expected missing-backend lookups return `None` as before, anything else
+  emits a warning (#442).
+- Pickling a `SeriesMatrix` now emits a warning listing any attrs entries
+  that had to be dropped because they cannot be pickled, instead of
+  dropping them silently (#442).
+- `SeriesMatrix.astype()`, `.real`, `.imag`, `.conj()`, `.transpose()`/`.T`
+  and `.reshape()` now deep-copy `attrs` like `.copy()` does, so mutating
+  the result's attrs no longer leaks into the source matrix (#442).
+
+### Tests
+
+- Added plot geometry tests for mixed-container argument orders, single
+  2D/3D/4D matrices, and parity with `_expand_args` expansion counts.
+- Added multi-source reader tests covering merge, gap padding, overlap
+  errors, empty-list rejection, and clear single-file-only errors.
+- Added regression tests for pickle attrs warnings and attrs independence
+  of derived matrices.
 
 ## [0.1.5] - 2026-06-10
 

--- a/gwexpy/plot/defaults.py
+++ b/gwexpy/plot/defaults.py
@@ -163,6 +163,40 @@ def determine_norm(data_list, current_value=None):
     return None
 
 
+def _count_expanded(item):
+    """Count the plot elements ``item`` expands to under ``separate=True``.
+
+    Mirrors ``_expand_args(separate=True)`` in ``_init_helpers``:
+    - matrices            → to_series_1Dlist() element count
+    - list/tuple/dict     → len(item)  (FrequencySeriesList/Dict inherit list/dict)
+    - SpectrogramList/Dict → len(item)  (inherit UserList/UserDict, checked by name)
+    - plain UserList/UserDict → 1        (_expand_args falls to else-branch)
+    - everything else     → 1
+    """
+    item_type = type(item).__name__
+    if item_type.endswith("Matrix"):
+        try:
+            if item_type == "SpectrogramMatrix":
+                # to_series_1Dlist(): 3-D → shape[0], 4-D → shape[0]*shape[1]
+                if item.ndim == 3:
+                    return item.shape[0]
+                if item.ndim == 4:
+                    return item.shape[0] * item.shape[1]
+                return 1
+            # to_series_1Dlist() always returns shape[0]*shape[1]
+            if item.ndim >= 2:
+                return item.shape[0] * item.shape[1]
+            return 1
+        except (AttributeError, ValueError):
+            return 1
+    if isinstance(item, (list, tuple, dict)) or item_type in (
+        "SpectrogramList",
+        "SpectrogramDict",
+    ):
+        return len(item)
+    return 1
+
+
 def determine_geometry_and_separate(data_list, separate=None, geometry=None):
     """Determine subplot separation and grid geometry for the plot data."""
     if not data_list:
@@ -171,32 +205,19 @@ def determine_geometry_and_separate(data_list, separate=None, geometry=None):
     ref = data_list[0]
     ref_type = type(ref).__name__
 
-    # Determine total elements to be plotted separately
-    total_elements = 0
-    for item in data_list:
-        item_type = type(item).__name__
-        if item_type in (
-            "SeriesMatrix",
-            "TimeSeriesMatrix",
-            "FrequencySeriesMatrix",
-        ) or item_type.endswith("Matrix"):
-            if item.ndim == 2:
-                total_elements += item.shape[0]
-            elif item.ndim == 3:
-                total_elements += item.shape[0] * item.shape[1]
-            elif item_type == "SpectrogramMatrix" and item.ndim == 4:
-                total_elements += item.shape[0] * item.shape[1]
-            else:
-                total_elements += 1
-        else:
-            total_elements += 1
+    # Total elements produced by _expand_args(separate=True), scanning ALL args
+    total_elements = sum(_count_expanded(item) for item in data_list)
+
+    # A single leading matrix keeps its own grid geometry; with extra
+    # arguments the grid cannot hold them, so fall back to a single column.
+    single_matrix = len(data_list) == 1
 
     # Recognize Spectrograms and SpectrogramMatrix for automatic separation
     if isinstance(ref, Spectrogram) or ref_type == "SpectrogramMatrix":
         if separate is None:
             separate = True
         if separate is True and geometry is None:
-            if ref_type == "SpectrogramMatrix":
+            if ref_type == "SpectrogramMatrix" and single_matrix:
                 # Check for filtered matrix which might have lost ndim or shape
                 try:
                     if ref.ndim == 3:
@@ -218,7 +239,7 @@ def determine_geometry_and_separate(data_list, separate=None, geometry=None):
         if separate is True and geometry is None:
             # Use matrix shape for geometry instead of flattening to single column
             try:
-                if ref.ndim == 3:
+                if ref.ndim == 3 and single_matrix:
                     nrows = ref.shape[0]
                     ncols = ref.shape[1]
                     return separate, (nrows, ncols)
@@ -228,55 +249,14 @@ def determine_geometry_and_separate(data_list, separate=None, geometry=None):
                 return separate, (total_elements, 1)
 
     if ref_type == "TimeSeriesDict":
-        # Compute total expanded channel count first, mirroring _expand_args(separate=True):
-        # - matrices            → to_series_1Dlist() element count
-        # - list/tuple/dict     → len(item)  (FrequencySeriesList/Dict inherit list/dict)
-        # - SpectrogramList/Dict → len(item)  (inherit UserList/UserDict, checked by name)
-        # - plain UserList/UserDict → 1        (_expand_args falls to else-branch)
-        # - everything else     → 1
-        total_channels = 0
-        for item in data_list:
-            item_type = type(item).__name__
-            if item_type in (
-                "SeriesMatrix",
-                "TimeSeriesMatrix",
-                "FrequencySeriesMatrix",
-            ) or item_type.endswith("Matrix"):
-                try:
-                    if item_type == "SpectrogramMatrix":
-                        # to_series_1Dlist(): 3-D → shape[0], 4-D → shape[0]*shape[1]
-                        if item.ndim == 3:
-                            total_channels += item.shape[0]
-                        elif item.ndim == 4:
-                            total_channels += item.shape[0] * item.shape[1]
-                        else:
-                            total_channels += 1
-                    else:
-                        # to_series_1Dlist() always returns shape[0]*shape[1]
-                        if item.ndim == 2:
-                            total_channels += item.shape[0]
-                        elif item.ndim >= 3:
-                            total_channels += item.shape[0] * item.shape[1]
-                        else:
-                            total_channels += 1
-                except (AttributeError, ValueError):
-                    total_channels += 1
-            elif isinstance(item, (list, tuple, dict)) or item_type in (
-                "SpectrogramList",
-                "SpectrogramDict",
-            ):
-                total_channels += len(item)
-            else:
-                total_channels += 1
-
         # Only default separate=True and set geometry when channels exist.
-        # An empty TimeSeriesDict (total_channels == 0) keeps the caller's
+        # An empty TimeSeriesDict (total_elements == 0) keeps the caller's
         # separate value so gwpy can produce a graceful empty plot.
-        if total_channels > 0:
+        if total_elements > 0:
             if separate is None:
                 separate = True
             if separate is True and geometry is None:
-                geometry = (total_channels, 1)
+                geometry = (total_elements, 1)
         return separate, geometry
 
     return separate, geometry

--- a/gwexpy/timeseries/_gwf_io.py
+++ b/gwexpy/timeseries/_gwf_io.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from typing import Any
 
+from astropy.io.registry import IORegistryError
 from gwpy.io.registry import default_registry as io_registry
 from gwpy.time import to_gps
 
@@ -41,14 +43,30 @@ _GWF_REGISTRY_SYNCED = False
 def _safe_get_reader(format_name: str, cls: type[Any]) -> Any | None:
     try:
         return io_registry.get_reader(format_name, cls)
-    except Exception:
+    except IORegistryError:
+        # No reader registered for this format/class (e.g. optional backend missing).
+        return None
+    except Exception as exc:
+        # This runs at import time; warn rather than crash on unexpected failures.
+        warnings.warn(
+            f"GWF alias registration skipped for {format_name!r}: {exc}",
+            stacklevel=2,
+        )
         return None
 
 
 def _safe_get_writer(format_name: str, cls: type[Any]) -> Any | None:
     try:
         return io_registry.get_writer(format_name, cls)
-    except Exception:
+    except IORegistryError:
+        # No writer registered for this format/class (e.g. optional backend missing).
+        return None
+    except Exception as exc:
+        # This runs at import time; warn rather than crash on unexpected failures.
+        warnings.warn(
+            f"GWF alias registration skipped for {format_name!r}: {exc}",
+            stacklevel=2,
+        )
         return None
 
 
@@ -66,7 +84,12 @@ def _sync_gwf_registry_aliases() -> None:
 
     try:
         from gwexpy.timeseries import TimeSeries, TimeSeriesDict, TimeSeriesMatrix
-    except Exception:
+    except ImportError as exc:
+        # Circular import during package bootstrap; warn so the skip is visible.
+        warnings.warn(
+            f"GWF alias registration skipped: {exc}",
+            stacklevel=2,
+        )
         return
 
     canonical_formats = ("gwf", "gwf.framecpp", "gwf.framel", "gwf.lalframe")

--- a/gwexpy/timeseries/io/_multi.py
+++ b/gwexpy/timeseries/io/_multi.py
@@ -1,0 +1,155 @@
+"""Shared helpers for handling list/tuple sources in TimeSeries readers.
+
+Most gwexpy readers operate on a single file. When a user passes a list
+(or tuple) of paths the behaviour should be one of:
+
+- merge the per-file results into a single container (when multi-file
+  semantics are well defined, e.g. more channels and/or contiguous time
+  segments), or
+- raise a clear ``ValueError`` early (when merging is not meaningful,
+  e.g. a single WAV file is a self-contained audio recording).
+
+The merge semantics mirror the ObsPy-based seismic reader
+(:mod:`gwexpy.timeseries.io.seismic`): channels that appear in more than
+one file are concatenated along the time axis (sorted by start time,
+gaps filled with ``pad``), while channels unique to one file are simply
+added to the result.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = [
+    "expand_multi_source",
+    "read_multi_dict",
+    "reject_multi_source",
+]
+
+
+def expand_multi_source(source):
+    """Return ``source`` as a list if it is a list or tuple, else `None`.
+
+    Parameters
+    ----------
+    source : object
+        The source argument passed to a reader.
+
+    Returns
+    -------
+    list or None
+        A list of the individual sources if ``source`` is a list or
+        tuple, otherwise `None` (single-source input).
+
+    """
+    if isinstance(source, (list, tuple)):
+        return list(source)
+    return None
+
+
+def reject_multi_source(source, format_name):
+    """Raise a clear ``ValueError`` if ``source`` is a list or tuple.
+
+    Use this in readers for formats where reading multiple files into a
+    single container has no meaningful semantics (e.g. WAV/audio files),
+    so users get an actionable error instead of an opaque backend
+    ``TypeError``.
+
+    Parameters
+    ----------
+    source : object
+        The source argument passed to a reader.
+    format_name : str
+        Format identifier used in the error message.
+
+    Raises
+    ------
+    ValueError
+        If ``source`` is a list or tuple.
+
+    """
+    if isinstance(source, (list, tuple)):
+        raise ValueError(
+            f"format '{format_name}' does not support reading multiple "
+            f"files; got {len(source)} paths"
+        )
+
+
+def read_multi_dict(reader_func, sources, format_name, *, pad=None, gap=None, **kwargs):
+    """Read several single-file sources and merge them into one dict.
+
+    Parameters
+    ----------
+    reader_func : callable
+        Single-file ``TimeSeriesDict`` reader, called as
+        ``reader_func(source, **kwargs)`` for each entry of ``sources``.
+    sources : list
+        Individual sources (paths or file-like objects).
+    format_name : str
+        Format identifier used in error messages.
+    pad : float, optional
+        Fill value for gaps between time segments of the same channel
+        (default: NaN, matching the seismic reader).
+    gap : str, optional
+        Gap handling mode forwarded to :meth:`TimeSeries.append`
+        (default: ``"pad"``).
+    **kwargs
+        Additional keyword arguments forwarded to ``reader_func``.
+
+    Returns
+    -------
+    TimeSeriesDict
+        Union of the channels found in all files; duplicate channels are
+        concatenated along the time axis (sorted by start time).
+
+    """
+    from .. import TimeSeriesDict
+
+    if not sources:
+        raise ValueError(f"no {format_name} files provided")
+    if pad is None:
+        pad = np.nan
+    if gap is None:
+        gap = "pad"
+
+    segments: dict = {}
+    order: list = []
+    first_tsd = None
+    for src in sources:
+        tsd = reader_func(src, **kwargs)
+        if first_tsd is None:
+            first_tsd = tsd
+        for key, ts in tsd.items():
+            if key not in segments:
+                segments[key] = []
+                order.append(key)
+            segments[key].append(ts)
+
+    out = TimeSeriesDict()
+    for key in order:
+        series = sorted(segments[key], key=lambda ts: float(ts.t0.value))
+        merged = series[0]
+        for ts in series[1:]:
+            try:
+                merged = merged.append(ts, inplace=False, gap=gap, pad=pad)
+            except ValueError as exc:
+                raise ValueError(
+                    f"failed to merge channel '{key}' across {format_name} files: {exc}"
+                ) from exc
+        out[key] = merged
+
+    # Propagate provenance from the first file (if any) so merged reads
+    # carry the same metadata shape as single-file reads.
+    provenance = {}
+    attrs = getattr(first_tsd, "attrs", None)
+    if isinstance(attrs, dict):
+        provenance.update(attrs)
+    else:
+        provenance.update(getattr(first_tsd, "_gwexpy_io", None) or {})
+    if provenance:
+        from gwexpy.io.utils import set_provenance
+
+        provenance["n_sources"] = len(sources)
+        set_provenance(out, provenance)
+
+    return out

--- a/gwexpy/timeseries/io/ats.py
+++ b/gwexpy/timeseries/io/ats.py
@@ -21,6 +21,7 @@ from gwexpy.io.utils import (
 )
 
 from .. import TimeSeries, TimeSeriesDict
+from ._multi import expand_multi_source, read_multi_dict
 from ._registration import register_timeseries_format
 
 _ATS_HEADER_MIN_SIZE = 1024
@@ -154,7 +155,15 @@ def _read_ats_header(fh) -> dict[str, Any]:
 
 
 def read_timeseriesdict_ats(source, **kwargs):
-    """Read a Metronix ATS file into a ``TimeSeriesDict``."""
+    """Read one or more Metronix ATS files into a ``TimeSeriesDict``.
+
+    Each ATS file holds a single channel; a list of paths therefore
+    yields one entry per distinct channel, with files for the same
+    channel concatenated along the time axis.
+    """
+    multi = expand_multi_source(source)
+    if multi is not None:
+        return read_multi_dict(read_timeseriesdict_ats, multi, "ats", **kwargs)
     ts = read_timeseries_ats(source, **kwargs)
     return TimeSeriesDict({ts.name: ts})
 
@@ -170,8 +179,9 @@ def read_timeseries_ats(
 
     Parameters
     ----------
-    source : str or Path
-        Path to the ATS file, or an open file object.
+    source : str, Path, or list of str/Path
+        Path to the ATS file, an open file object, or a list of paths
+        (segments of the same channel are concatenated along time).
     unit : str or Unit, optional
         Physical unit override (default: V).
     epoch : float or datetime, optional
@@ -181,6 +191,13 @@ def read_timeseries_ats(
         Additional keyword arguments.
 
     """
+    multi = expand_multi_source(source)
+    if multi is not None:
+        tsd = read_timeseriesdict_ats(multi, unit=unit, epoch=epoch, **kwargs)
+        if not tsd:
+            raise ValueError("No data found in ATS files")
+        return tsd[next(iter(tsd.keys()))]
+
     if hasattr(source, "read"):
         return _read_timeseries_ats_file(source, unit=unit, epoch=epoch, **kwargs)
 

--- a/gwexpy/timeseries/io/audio.py
+++ b/gwexpy/timeseries/io/audio.py
@@ -22,6 +22,7 @@ from gwexpy.io.utils import (
 )
 
 from .. import TimeSeries, TimeSeriesDict, TimeSeriesMatrix
+from ._multi import reject_multi_source
 from ._registration import register_timeseries_format
 
 
@@ -82,6 +83,11 @@ def read_timeseriesdict_audio(
         Additional keyword arguments accepted for reader compatibility.
 
     """
+    # An audio file is a self-contained (possibly multi-channel) recording
+    # without absolute timestamps, so merging multiple files is not
+    # meaningful; fail early with a clear error.
+    reject_multi_source(source, format_hint or "audio")
+
     AudioSegment = _import_pydub()
 
     seg_kwargs = {}

--- a/gwexpy/timeseries/io/csv_enhanced.py
+++ b/gwexpy/timeseries/io/csv_enhanced.py
@@ -216,8 +216,10 @@ def read_timeseriesdict_csv(
 
     Parameters
     ----------
-    source : str or Path
-        Path to a CSV file.
+    source : str, Path, or list of str/Path
+        Path to a CSV file, or a list of paths.  When a list is given,
+        channels found in several files are concatenated along the time
+        axis and channels unique to one file are merged in.
     config : CSVFormatConfig, str, Path, dict, or None
         Column mapping configuration. Can be:
 
@@ -240,6 +242,21 @@ def read_timeseriesdict_csv(
 
     """
     from .. import TimeSeriesDict
+    from ._multi import expand_multi_source, read_multi_dict
+
+    multi = expand_multi_source(source)
+    if multi is not None:
+        return read_multi_dict(
+            read_timeseriesdict_csv,
+            multi,
+            "csv",
+            config=config,
+            channels=channels,
+            timezone=timezone,
+            resample=resample,
+            resample_method=resample_method,
+            **kwargs,
+        )
 
     # --- Resolve config ---
     if config is None:

--- a/gwexpy/timeseries/io/dttxml.py
+++ b/gwexpy/timeseries/io/dttxml.py
@@ -23,6 +23,7 @@ from gwexpy.io.utils import (
 )
 
 from .. import TimeSeries, TimeSeriesDict, TimeSeriesMatrix
+from ._multi import expand_multi_source, read_multi_dict
 
 _DTTXML_FORMATS = ("xml.diaggui", "dttxml")
 
@@ -58,7 +59,27 @@ def read_timeseriesdict_dttxml(
     pad=np.nan,
     **kwargs,
 ) -> TimeSeriesDict:
-    """Read one DiagGUI XML product into a ``TimeSeriesDict``."""
+    """Read one DiagGUI XML product into a ``TimeSeriesDict``.
+
+    A list of paths is also accepted; channels found in several files
+    are concatenated along the time axis (gaps padded with ``pad``) and
+    channels unique to one file are merged in.
+    """
+    multi = expand_multi_source(source)
+    if multi is not None:
+        return read_multi_dict(
+            read_timeseriesdict_dttxml,
+            multi,
+            "xml.diaggui",
+            pad=pad,
+            products=products,
+            channels=channels,
+            unit=unit,
+            epoch=epoch,
+            timezone=timezone,
+            **kwargs,
+        )
+
     if products is None:
         raise ValueError("products must be specified for xml.diaggui")
     prod = str(products).upper()

--- a/gwexpy/timeseries/io/gbd.py
+++ b/gwexpy/timeseries/io/gbd.py
@@ -25,6 +25,7 @@ from gwexpy.io.utils import (
 )
 
 from .. import TimeSeries, TimeSeriesDict, TimeSeriesMatrix
+from ._multi import expand_multi_source, read_multi_dict
 from ._registration import register_timeseries_format
 
 HEADER_SIZE_PATTERN = re.compile(r"HeaderSiz[e]?\s*[:=]\s*(\d+)", re.IGNORECASE)
@@ -98,8 +99,10 @@ def read_timeseriesdict_gbd(
 
     Parameters
     ----------
-    source : str or file-like
-        Path or open file object to the GBD file.
+    source : str, file-like, or list of str
+        Path or open file object to the GBD file, or a list of paths.
+        When a list is given, channels found in several files are
+        concatenated along the time axis (gaps padded with ``pad``).
     timezone : str or tzinfo, required
         Local timezone of the logger (IANA name or UTC offset).
     channels : iterable, optional
@@ -116,6 +119,21 @@ def read_timeseriesdict_gbd(
         Additional compatibility arguments accepted and ignored.
 
     """
+    multi = expand_multi_source(source)
+    if multi is not None:
+        return read_multi_dict(
+            read_timeseriesdict_gbd,
+            multi,
+            "gbd",
+            pad=pad,
+            timezone=timezone,
+            channels=channels,
+            digital_channels=digital_channels,
+            unit=unit,
+            epoch=epoch,
+            **kwargs,
+        )
+
     if timezone is None:
         raise ValueError("timezone is required for GBD files")
     tzinfo = parse_timezone(timezone)

--- a/gwexpy/timeseries/io/ndscope_hdf5.py
+++ b/gwexpy/timeseries/io/ndscope_hdf5.py
@@ -27,6 +27,7 @@ import h5py
 import numpy as np
 
 from .. import TimeSeries, TimeSeriesDict
+from ._multi import expand_multi_source, read_multi_dict
 from ._registration import register_timeseries_format
 
 # Dataset names recognised as ndscope data fields.
@@ -104,8 +105,10 @@ def read_timeseriesdict_ndscope_hdf5(
 
     Parameters
     ----------
-    source : str or Path
-        Path to the HDF5 file.
+    source : str, Path, or list of str/Path
+        Path to the HDF5 file, or a list of paths.  When a list is
+        given, channels found in several files are concatenated along
+        the time axis and channels unique to one file are merged in.
     channels : iterable of str, optional
         Channel names to read.  If ``None``, all channels are read.
     start : float, optional
@@ -120,6 +123,18 @@ def read_timeseriesdict_ndscope_hdf5(
     TimeSeriesDict
 
     """
+    multi = expand_multi_source(source)
+    if multi is not None:
+        return read_multi_dict(
+            read_timeseriesdict_ndscope_hdf5,
+            multi,
+            "hdf.ndscope",
+            channels=channels,
+            start=start,
+            end=end,
+            **kwargs,
+        )
+
     wanted = set(channels) if channels is not None else None
     out = TimeSeriesDict()
 

--- a/gwexpy/timeseries/io/netcdf4_.py
+++ b/gwexpy/timeseries/io/netcdf4_.py
@@ -20,6 +20,7 @@ from gwexpy.io.utils import (
 )
 
 from .. import TimeSeries, TimeSeriesDict, TimeSeriesMatrix
+from ._multi import expand_multi_source, read_multi_dict
 from ._registration import register_timeseries_format
 
 logger = logging.getLogger(__name__)
@@ -106,8 +107,10 @@ def read_timeseriesdict_netcdf4(
 
     Parameters
     ----------
-    source : str or path-like
-        Path to a ``.nc`` file.
+    source : str, path-like, or list of str/path-like
+        Path to a ``.nc`` file, or a list of paths.  When a list is
+        given, variables found in several files are concatenated along
+        the time axis and variables unique to one file are merged in.
     channels : iterable of str, optional
         Variable names to read.  If *None*, all variables with a time
         dimension are loaded.
@@ -119,6 +122,18 @@ def read_timeseriesdict_netcdf4(
         Additional keyword arguments forwarded to ``xarray.open_dataset``.
 
     """
+    multi = expand_multi_source(source)
+    if multi is not None:
+        return read_multi_dict(
+            read_timeseriesdict_netcdf4,
+            multi,
+            "nc",
+            channels=channels,
+            unit=unit,
+            time_coord=time_coord,
+            **kwargs,
+        )
+
     xr = _import_xarray()
 
     # gwpy's registry may pass a file-like object; extract the path.
@@ -245,6 +260,9 @@ def read_timeseries_netcdf4(source, **kwargs) -> TimeSeries:
 
 def read_timeseriesmatrix_netcdf4(source, **kwargs) -> TimeSeriesMatrix:
     """Read a NetCDF4 file and convert its channels to a matrix."""
+    if isinstance(source, (list, tuple)):
+        return read_timeseriesdict_netcdf4(source, **kwargs).to_matrix()
+
     xr = _import_xarray()
 
     if hasattr(source, "name"):

--- a/gwexpy/timeseries/io/netcdf4_.py
+++ b/gwexpy/timeseries/io/netcdf4_.py
@@ -261,7 +261,14 @@ def read_timeseries_netcdf4(source, **kwargs) -> TimeSeries:
 def read_timeseriesmatrix_netcdf4(source, **kwargs) -> TimeSeriesMatrix:
     """Read a NetCDF4 file and convert its channels to a matrix."""
     if isinstance(source, (list, tuple)):
-        return read_timeseriesdict_netcdf4(source, **kwargs).to_matrix()
+        sources = list(source)
+        if not sources:
+            raise ValueError("no NetCDF4 files provided")
+        matrices = [read_timeseriesmatrix_netcdf4(s, **kwargs) for s in sources]
+        merged = matrices[0]
+        for mat in matrices[1:]:
+            merged = merged.append(mat, inplace=False, gap="pad")
+        return merged
 
     xr = _import_xarray()
 
@@ -413,6 +420,34 @@ def write_timeseries_netcdf4(ts, target, **kwargs):
     )
 
 
+def write_timeseriesmatrix_netcdf4(tsm, target, **kwargs):
+    """Write a TimeSeriesMatrix to a NetCDF4 file preserving row/col keys.
+
+    Each matrix cell is written as a variable keyed by a ``(row_key, col_key)``
+    tuple so that ``gwexpy_row_key``/``gwexpy_col_key`` attributes are encoded
+    and the full matrix structure survives a write→read roundtrip.
+    """
+    from gwexpy.timeseries import TimeSeries, TimeSeriesDict
+
+    row_keys = list(tsm.row_keys())
+    col_keys = list(tsm.col_keys())
+    n_rows, n_cols, n_samples = tsm.shape
+
+    tsd: TimeSeriesDict = TimeSeriesDict()
+    for i, rk in enumerate(row_keys):
+        for j, ck in enumerate(col_keys):
+            cell_data = np.asarray(tsm[i, j], dtype=np.float64)
+            ts = TimeSeries(
+                cell_data,
+                t0=tsm.t0,
+                dt=tsm.dt,
+                unit=tsm.unit if hasattr(tsm, "unit") else None,
+            )
+            tsd[(rk, ck)] = ts
+
+    write_timeseriesdict_netcdf4(tsd, target, **kwargs)
+
+
 # -- Registration --------------------------------------------------------------
 
 register_timeseries_format(
@@ -423,5 +458,6 @@ register_timeseries_format(
     reader_matrix=read_timeseriesmatrix_netcdf4,
     writer_dict=write_timeseriesdict_netcdf4,
     writer_single=write_timeseries_netcdf4,
+    writer_matrix=write_timeseriesmatrix_netcdf4,
     extension="nc",
 )

--- a/gwexpy/timeseries/io/netcdf4_.py
+++ b/gwexpy/timeseries/io/netcdf4_.py
@@ -267,7 +267,7 @@ def read_timeseriesmatrix_netcdf4(source, **kwargs) -> TimeSeriesMatrix:
         matrices = [read_timeseriesmatrix_netcdf4(s, **kwargs) for s in sources]
         merged = matrices[0]
         for mat in matrices[1:]:
-            merged = merged.append(mat, inplace=False, gap="pad")
+            merged = merged.append(mat, inplace=False, gap="pad", pad=np.nan)
         return merged
 
     xr = _import_xarray()

--- a/gwexpy/timeseries/io/sdb.py
+++ b/gwexpy/timeseries/io/sdb.py
@@ -10,6 +10,7 @@ import pandas as pd
 from astropy.time import Time
 
 from .. import TimeSeries, TimeSeriesDict
+from ._multi import expand_multi_source, read_multi_dict
 from ._registration import register_timeseries_format
 
 # Unit extraction factors (Imperial to Metric)
@@ -44,8 +45,11 @@ def read_timeseriesdict_sdb(
 
     Parameters
     ----------
-    source : str or Path
-        Path to SQLite database file.
+    source : str, Path, or list of str/Path
+        Path to SQLite database file, or a list of paths.  When a list
+        is given, columns found in several databases are concatenated
+        along the time axis and columns unique to one database are
+        merged in.
     table : str, optional
         Table name to read from, default 'archive'.
     columns : list, optional
@@ -54,6 +58,17 @@ def read_timeseriesdict_sdb(
         Additional compatibility arguments accepted and ignored.
 
     """
+    multi = expand_multi_source(source)
+    if multi is not None:
+        return read_multi_dict(
+            read_timeseriesdict_sdb,
+            multi,
+            "sdb",
+            table=table,
+            columns=columns,
+            **kwargs,
+        )
+
     # gwpy's registry may pass an already-open file object for explicit
     # ``.read(..., format="sdb")`` calls; sqlite3 needs the underlying path.
     if hasattr(source, "name"):

--- a/gwexpy/timeseries/io/tdms.py
+++ b/gwexpy/timeseries/io/tdms.py
@@ -15,6 +15,7 @@ from gwexpy.io.utils import (
 )
 
 from .. import TimeSeries, TimeSeriesDict, TimeSeriesMatrix
+from ._multi import expand_multi_source, read_multi_dict
 from ._registration import register_timeseries_format
 
 
@@ -41,8 +42,10 @@ def read_timeseriesdict_tdms(
 
     Parameters
     ----------
-    source : str or Path
-        Path to the TDMS file.
+    source : str, Path, or list of str/Path
+        Path to the TDMS file, or a list of paths.  When a list is
+        given, channels found in several files are concatenated along
+        the time axis and channels unique to one file are merged in.
     channels : iterable of str, optional
         Channel names to keep.
     unit : str or Unit, optional
@@ -54,6 +57,18 @@ def read_timeseriesdict_tdms(
         Additional keyword arguments forwarded to the TDMS reader.
 
     """
+    multi = expand_multi_source(source)
+    if multi is not None:
+        return read_multi_dict(
+            read_timeseriesdict_tdms,
+            multi,
+            "tdms",
+            channels=channels,
+            unit=unit,
+            epoch=epoch,
+            **kwargs,
+        )
+
     TdmsFile = _import_nptdms()
     tdms_file = TdmsFile.read(source)
 

--- a/gwexpy/timeseries/io/wav.py
+++ b/gwexpy/timeseries/io/wav.py
@@ -17,6 +17,7 @@ from gwexpy.io.utils import (
 )
 
 from .. import TimeSeries, TimeSeriesDict
+from ._multi import reject_multi_source
 from ._registration import register_timeseries_format
 
 
@@ -61,6 +62,11 @@ def read_timeseriesdict_wav(
     Channels are named 'channel_0', 'channel_1', etc.
 
     """
+    # A WAV file is a self-contained (possibly multi-channel) recording
+    # without absolute timestamps, so merging multiple files is not
+    # meaningful; fail early with a clear error.
+    reject_multi_source(source, "wav")
+
     # Filter kwargs for wavfile.read
     scipy_kwargs = {
         k: v for k, v in kwargs.items() if k not in ("start", "end", "format")

--- a/gwexpy/timeseries/io/win.py
+++ b/gwexpy/timeseries/io/win.py
@@ -28,6 +28,7 @@ from typing import Any, cast
 import numpy as np
 
 from gwexpy.io.utils import ensure_dependency
+from gwexpy.timeseries.io._multi import expand_multi_source, read_multi_dict
 from gwexpy.timeseries.io._registration import register_timeseries_format
 
 try:
@@ -199,9 +200,17 @@ def _read_win_fixed(filename: str | Path, century="20"):
 
 
 def read_win_file(source, **kwargs) -> TimeSeriesDict:
-    """Read a WIN or WIN32 file with the patched ObsPy-based reader."""
+    """Read one or more WIN or WIN32 files with the patched ObsPy-based reader.
+
+    When a list of paths is given, channels found in several files are
+    concatenated along the time axis (gaps padded with NaN).
+    """
     if not HAS_OBSPY:
         raise ImportError("obspy is required to read WIN format files")
+
+    multi = expand_multi_source(source)
+    if multi is not None:
+        return read_multi_dict(read_win_file, multi, "win", **kwargs)
 
     stream = _read_win_fixed(source, **kwargs)
 

--- a/gwexpy/timeseries/io/zarr_.py
+++ b/gwexpy/timeseries/io/zarr_.py
@@ -301,7 +301,7 @@ def read_timeseriesmatrix_zarr(
         ]
         merged = matrices[0]
         for mat in matrices[1:]:
-            merged = merged.append(mat, inplace=False, gap="pad")
+            merged = merged.append(mat, inplace=False, gap="pad", pad=np.nan)
         return merged
 
     zarr = _import_zarr()

--- a/gwexpy/timeseries/io/zarr_.py
+++ b/gwexpy/timeseries/io/zarr_.py
@@ -28,6 +28,7 @@ from gwexpy.io.utils import (
 )
 
 from .. import TimeSeries, TimeSeriesDict, TimeSeriesMatrix
+from ._multi import expand_multi_source, read_multi_dict
 from ._registration import register_timeseries_format
 
 _MATRIX_ARRAY_PREFIX = "__gwexpy_matrix__"
@@ -187,8 +188,11 @@ def read_timeseriesdict_zarr(
 
     Parameters
     ----------
-    source : str, path-like, or zarr store
-        Path to the ``.zarr`` directory (or any zarr-compatible store).
+    source : str, path-like, zarr store, or list thereof
+        Path to the ``.zarr`` directory (or any zarr-compatible store),
+        or a list of stores.  When a list is given, channels found in
+        several stores are concatenated along the time axis and
+        channels unique to one store are merged in.
     channels : iterable of str, optional
         Array names to read.  If *None*, all arrays in the root group
         are loaded.
@@ -206,6 +210,19 @@ def read_timeseriesdict_zarr(
         Additional keyword arguments forwarded to ``zarr.open_group``.
 
     """
+    multi = expand_multi_source(source)
+    if multi is not None:
+        return read_multi_dict(
+            read_timeseriesdict_zarr,
+            multi,
+            "zarr",
+            channels=channels,
+            unit=unit,
+            sample_rate_override=sample_rate_override,
+            dt_override=dt_override,
+            **kwargs,
+        )
+
     zarr = _import_zarr()
 
     # Only coerce to str for path-like objects; pass store objects through
@@ -267,6 +284,17 @@ def read_timeseriesmatrix_zarr(
     **kwargs,
 ) -> TimeSeriesMatrix:
     """Read a Zarr store and convert its channels to a matrix."""
+    if isinstance(source, (list, tuple)):
+        tsd = read_timeseriesdict_zarr(
+            source,
+            channels=channels,
+            unit=unit,
+            sample_rate_override=sample_rate_override,
+            dt_override=dt_override,
+            **kwargs,
+        )
+        return tsd.to_matrix()
+
     zarr = _import_zarr()
 
     if isinstance(source, (str, os.PathLike)):

--- a/gwexpy/timeseries/io/zarr_.py
+++ b/gwexpy/timeseries/io/zarr_.py
@@ -285,15 +285,24 @@ def read_timeseriesmatrix_zarr(
 ) -> TimeSeriesMatrix:
     """Read a Zarr store and convert its channels to a matrix."""
     if isinstance(source, (list, tuple)):
-        tsd = read_timeseriesdict_zarr(
-            source,
-            channels=channels,
-            unit=unit,
-            sample_rate_override=sample_rate_override,
-            dt_override=dt_override,
-            **kwargs,
-        )
-        return tsd.to_matrix()
+        sources = list(source)
+        if not sources:
+            raise ValueError("no Zarr stores provided")
+        matrices = [
+            read_timeseriesmatrix_zarr(
+                s,
+                channels=channels,
+                unit=unit,
+                sample_rate_override=sample_rate_override,
+                dt_override=dt_override,
+                **kwargs,
+            )
+            for s in sources
+        ]
+        merged = matrices[0]
+        for mat in matrices[1:]:
+            merged = merged.append(mat, inplace=False, gap="pad")
+        return merged
 
     zarr = _import_zarr()
 

--- a/gwexpy/types/series_matrix_structure.py
+++ b/gwexpy/types/series_matrix_structure.py
@@ -95,7 +95,7 @@ class SeriesMatrixStructureMixin:
             meta=self.meta,
             name=self.name,
             epoch=self.epoch,
-            attrs=self.attrs,
+            attrs=deepcopy(self.attrs),
         )
 
     @property
@@ -110,7 +110,7 @@ class SeriesMatrixStructureMixin:
             meta=self.meta,
             name=f"{self.name}.real" if self.name else "",
             epoch=self.epoch,
-            attrs=self.attrs,
+            attrs=deepcopy(self.attrs),
         )
 
     @real.setter
@@ -129,7 +129,7 @@ class SeriesMatrixStructureMixin:
             meta=self.meta,
             name=f"{self.name}.imag" if self.name else "",
             epoch=self.epoch,
-            attrs=self.attrs,
+            attrs=deepcopy(self.attrs),
         )
 
     @imag.setter

--- a/gwexpy/types/series_matrix_structure.py
+++ b/gwexpy/types/series_matrix_structure.py
@@ -147,7 +147,7 @@ class SeriesMatrixStructureMixin:
             meta=self.meta,
             name=f"{self.name}.conj" if self.name else "",
             epoch=self.epoch,
-            attrs=self.attrs,
+            attrs=deepcopy(self.attrs),
         )
 
     @property
@@ -170,7 +170,7 @@ class SeriesMatrixStructureMixin:
                 meta=new_meta,
                 name=f"{self.name}.T" if self.name else "",
                 epoch=self.epoch,
-                attrs=self.attrs,
+                attrs=deepcopy(self.attrs),
             )
         else:
             # Custom axes transpose
@@ -218,5 +218,5 @@ class SeriesMatrixStructureMixin:
             meta=MetaDataMatrix(new_meta),
             name=self.name,
             epoch=self.epoch,
-            attrs=self.attrs,
+            attrs=deepcopy(self.attrs),
         )

--- a/gwexpy/types/seriesmatrix_base.py
+++ b/gwexpy/types/seriesmatrix_base.py
@@ -95,12 +95,19 @@ def _pickle_safe_attrs(attrs: Any, protocol: int) -> dict[str, Any]:
     if not isinstance(attrs, dict):
         return {}
     safe_attrs = {}
+    dropped = []
     for key, value in attrs.items():
         try:
             pickle.dumps((key, value), protocol=protocol)
-        except Exception:
+        except (pickle.PicklingError, TypeError, AttributeError):
+            dropped.append(key)
             continue
         safe_attrs[key] = value
+    if dropped:
+        warnings.warn(
+            f"Dropping attrs entries that cannot be pickled: {dropped}",
+            stacklevel=2,
+        )
     return safe_attrs
 
 

--- a/gwexpy/types/seriesmatrix_base.py
+++ b/gwexpy/types/seriesmatrix_base.py
@@ -99,7 +99,14 @@ def _pickle_safe_attrs(attrs: Any, protocol: int) -> dict[str, Any]:
     for key, value in attrs.items():
         try:
             pickle.dumps((key, value), protocol=protocol)
-        except (pickle.PicklingError, TypeError, AttributeError):
+        except (
+            pickle.PicklingError,
+            TypeError,
+            AttributeError,
+            ValueError,
+            RuntimeError,
+            RecursionError,
+        ):
             dropped.append(key)
             continue
         safe_attrs[key] = value

--- a/tests/io/test_multi_source.py
+++ b/tests/io/test_multi_source.py
@@ -1,0 +1,586 @@
+"""Tests for list/tuple source handling across TimeSeries readers (issue #441).
+
+Every reader must either merge a list of paths into a single result
+(when multi-file semantics are well defined) or raise a clear
+``ValueError`` instead of an opaque backend ``TypeError``.
+"""
+
+import sqlite3
+import struct
+
+import numpy as np
+import pytest
+from scipy.io import wavfile
+
+from gwexpy.timeseries import TimeSeries, TimeSeriesDict
+from gwexpy.timeseries.io._multi import (
+    expand_multi_source,
+    read_multi_dict,
+    reject_multi_source,
+)
+
+# ---------------------------------------------------------------------------
+# Helper-level tests (no optional dependencies required)
+# ---------------------------------------------------------------------------
+
+
+class TestExpandMultiSource:
+    def test_list(self):
+        assert expand_multi_source(["a", "b"]) == ["a", "b"]
+
+    def test_tuple(self):
+        assert expand_multi_source(("a", "b")) == ["a", "b"]
+
+    def test_single_path_returns_none(self):
+        assert expand_multi_source("a.wav") is None
+
+    def test_empty_list(self):
+        assert expand_multi_source([]) == []
+
+
+class TestRejectMultiSource:
+    def test_list_raises(self):
+        with pytest.raises(
+            ValueError,
+            match=r"format 'wav' does not support reading multiple files; "
+            r"got 3 paths",
+        ):
+            reject_multi_source(["a", "b", "c"], "wav")
+
+    def test_tuple_raises(self):
+        with pytest.raises(ValueError, match="got 2 paths"):
+            reject_multi_source(("a", "b"), "wav")
+
+    def test_single_path_passes(self):
+        reject_multi_source("a.wav", "wav")  # no error
+
+
+class TestReadMultiDict:
+    @staticmethod
+    def _fake_reader(files):
+        """Build a reader that maps source name -> prepared dict."""
+
+        def reader(source, **kwargs):
+            return files[source]
+
+        return reader
+
+    def test_distinct_channels_are_merged(self):
+        files = {
+            "f1": TimeSeriesDict(
+                {"ch1": TimeSeries(np.ones(10), t0=0, dt=1, name="ch1")}
+            ),
+            "f2": TimeSeriesDict(
+                {"ch2": TimeSeries(np.zeros(10), t0=0, dt=1, name="ch2")}
+            ),
+        }
+        out = read_multi_dict(self._fake_reader(files), ["f1", "f2"], "test")
+        assert set(out) == {"ch1", "ch2"}
+
+    def test_contiguous_segments_are_concatenated(self):
+        files = {
+            "f1": TimeSeriesDict(
+                {"ch": TimeSeries(np.arange(10.0), t0=0, dt=1, name="ch")}
+            ),
+            "f2": TimeSeriesDict(
+                {"ch": TimeSeries(np.arange(10.0, 20.0), t0=10, dt=1, name="ch")}
+            ),
+        }
+        out = read_multi_dict(self._fake_reader(files), ["f1", "f2"], "test")
+        assert len(out["ch"]) == 20
+        np.testing.assert_allclose(out["ch"].value, np.arange(20.0))
+
+    def test_segments_are_sorted_by_start_time(self):
+        files = {
+            "f1": TimeSeriesDict(
+                {"ch": TimeSeries(np.arange(10.0), t0=0, dt=1, name="ch")}
+            ),
+            "f2": TimeSeriesDict(
+                {"ch": TimeSeries(np.arange(10.0, 20.0), t0=10, dt=1, name="ch")}
+            ),
+        }
+        # pass the later file first
+        out = read_multi_dict(self._fake_reader(files), ["f2", "f1"], "test")
+        assert float(out["ch"].t0.value) == 0.0
+        np.testing.assert_allclose(out["ch"].value, np.arange(20.0))
+
+    def test_gap_is_padded_with_nan(self):
+        files = {
+            "f1": TimeSeriesDict(
+                {"ch": TimeSeries(np.ones(10), t0=0, dt=1, name="ch")}
+            ),
+            "f2": TimeSeriesDict(
+                {"ch": TimeSeries(np.ones(10), t0=15, dt=1, name="ch")}
+            ),
+        }
+        out = read_multi_dict(self._fake_reader(files), ["f1", "f2"], "test")
+        assert len(out["ch"]) == 25
+        assert np.all(np.isnan(out["ch"].value[10:15]))
+
+    def test_empty_list_raises(self):
+        with pytest.raises(ValueError, match="no test files provided"):
+            read_multi_dict(self._fake_reader({}), [], "test")
+
+    def test_overlap_raises_clear_error(self):
+        files = {
+            "f1": TimeSeriesDict(
+                {"ch": TimeSeries(np.ones(10), t0=0, dt=1, name="ch")}
+            ),
+            "f2": TimeSeriesDict(
+                {"ch": TimeSeries(np.ones(10), t0=0, dt=1, name="ch")}
+            ),
+        }
+        with pytest.raises(ValueError, match="failed to merge channel 'ch'"):
+            read_multi_dict(self._fake_reader(files), ["f1", "f2"], "test")
+
+
+# ---------------------------------------------------------------------------
+# WAV: multiple files are not meaningful -> clear error
+# ---------------------------------------------------------------------------
+
+
+class TestWavMultiSource:
+    def _write_wav(self, path):
+        wavfile.write(str(path), 1000, np.zeros(10, dtype=np.int16))
+
+    @pytest.mark.parametrize("container", (list, tuple))
+    def test_dict_reader_rejects_multiple_paths(self, tmp_path, container):
+        from gwexpy.timeseries.io.wav import read_timeseriesdict_wav
+
+        paths = []
+        for i in range(2):
+            p = tmp_path / f"f{i}.wav"
+            self._write_wav(p)
+            paths.append(str(p))
+        with pytest.raises(
+            ValueError,
+            match=r"format 'wav' does not support reading multiple files; "
+            r"got 2 paths",
+        ):
+            read_timeseriesdict_wav(container(paths))
+
+    def test_single_reader_rejects_multiple_paths(self, tmp_path):
+        from gwexpy.timeseries.io.wav import read_timeseries_wav
+
+        p = tmp_path / "f.wav"
+        self._write_wav(p)
+        with pytest.raises(ValueError, match="does not support reading multiple"):
+            read_timeseries_wav([str(p), str(p)])
+
+
+# ---------------------------------------------------------------------------
+# Audio (pydub): multiple files are not meaningful -> clear error
+# (the error is raised before pydub is imported, so no skip needed)
+# ---------------------------------------------------------------------------
+
+
+class TestAudioMultiSource:
+    @pytest.mark.parametrize("fmt", ("mp3", "flac", "ogg", "m4a"))
+    def test_dict_reader_rejects_multiple_paths(self, fmt):
+        from gwexpy.timeseries.io.audio import read_timeseriesdict_audio
+
+        with pytest.raises(
+            ValueError,
+            match=rf"format '{fmt}' does not support reading multiple files; "
+            r"got 2 paths",
+        ):
+            read_timeseriesdict_audio([f"a.{fmt}", f"b.{fmt}"], format_hint=fmt)
+
+    def test_default_format_name(self):
+        from gwexpy.timeseries.io.audio import read_timeseriesdict_audio
+
+        with pytest.raises(ValueError, match="format 'audio' does not support"):
+            read_timeseriesdict_audio(["a.mp3", "b.mp3"])
+
+
+# ---------------------------------------------------------------------------
+# TDMS: list of files merges channels / concatenates segments
+# ---------------------------------------------------------------------------
+
+
+class TestTdmsMultiSource:
+    @staticmethod
+    def _write_tdms(path, channel_name, data, dt, start):
+        nptdms = pytest.importorskip("nptdms")
+        from nptdms import ChannelObject, GroupObject, RootObject, TdmsWriter
+
+        del nptdms
+        root = RootObject()
+        group = GroupObject("Group")
+        props = {"wf_increment": dt, "wf_start_time": start}
+        channel = ChannelObject("Group", channel_name, data, properties=props)
+        with TdmsWriter(str(path)) as writer:
+            writer.write_segment([root, group, channel])
+
+    def test_list_concatenates_same_channel(self, tmp_path):
+        pytest.importorskip("nptdms")
+        dt = 0.1
+        p1 = tmp_path / "seg1.tdms"
+        p2 = tmp_path / "seg2.tdms"
+        self._write_tdms(
+            p1, "Sig", np.arange(10.0), dt, np.datetime64("2024-01-01T00:00:00")
+        )
+        self._write_tdms(
+            p2, "Sig", np.arange(10.0, 20.0), dt, np.datetime64("2024-01-01T00:00:01")
+        )
+
+        tsd = TimeSeriesDict.read([str(p1), str(p2)], format="tdms")
+        assert len(tsd) == 1
+        ts = tsd["Group/Sig"]
+        assert len(ts) == 20
+        np.testing.assert_allclose(ts.value, np.arange(20.0))
+
+    def test_list_merges_distinct_channels(self, tmp_path):
+        pytest.importorskip("nptdms")
+        start = np.datetime64("2024-01-01T00:00:00")
+        p1 = tmp_path / "a.tdms"
+        p2 = tmp_path / "b.tdms"
+        self._write_tdms(p1, "A", np.ones(5), 0.5, start)
+        self._write_tdms(p2, "B", np.zeros(5), 0.5, start)
+
+        tsd = TimeSeriesDict.read([str(p1), str(p2)], format="tdms")
+        assert set(tsd) == {"Group/A", "Group/B"}
+
+    def test_empty_list_raises(self):
+        pytest.importorskip("nptdms")
+        from gwexpy.timeseries.io.tdms import read_timeseriesdict_tdms
+
+        with pytest.raises(ValueError, match="no tdms files provided"):
+            read_timeseriesdict_tdms([])
+
+
+# ---------------------------------------------------------------------------
+# ATS: one channel per file; lists merge channels / concatenate segments
+# ---------------------------------------------------------------------------
+
+
+def _write_ats(
+    path, *, n_samples=8, sample_freq=8.0, start_unix=1704067200, values=None
+):
+    """Write a minimal Metronix ATS file (header version 80)."""
+    header_size = 1024
+    header = bytearray(header_size)
+    struct.pack_into("<H", header, 0x00, header_size)
+    struct.pack_into("<h", header, 0x02, 80)  # header version
+    struct.pack_into("<I", header, 0x04, n_samples)
+    struct.pack_into("<f", header, 0x08, sample_freq)
+    struct.pack_into("<I", header, 0x0C, start_unix)
+    struct.pack_into("<d", header, 0x10, 1000.0)  # lsb_mV -> 1 V/count
+    struct.pack_into("<h", header, 0xAA, 0)  # 32-bit data
+
+    if values is None:
+        values = np.arange(n_samples)
+    data = np.asarray(values, dtype="<i4")
+
+    with open(path, "wb") as f:
+        f.write(header)
+        f.write(data.tobytes())
+
+
+class TestAtsMultiSource:
+    def test_list_concatenates_segments(self, tmp_path):
+        p1 = tmp_path / "seg1.ats"
+        p2 = tmp_path / "seg2.ats"
+        # 8 samples at 8 Hz = 1 second per file, contiguous
+        _write_ats(p1, start_unix=1704067200, values=np.arange(8))
+        _write_ats(p2, start_unix=1704067201, values=np.arange(8, 16))
+
+        tsd = TimeSeriesDict.read([str(p1), str(p2)], format="ats")
+        assert len(tsd) == 1
+        ts = next(iter(tsd.values()))
+        assert len(ts) == 16
+        np.testing.assert_allclose(ts.value, np.arange(16.0))
+
+    def test_timeseries_read_list(self, tmp_path):
+        p1 = tmp_path / "seg1.ats"
+        p2 = tmp_path / "seg2.ats"
+        _write_ats(p1, start_unix=1704067200, values=np.arange(8))
+        _write_ats(p2, start_unix=1704067201, values=np.arange(8, 16))
+
+        ts = TimeSeries.read([str(p1), str(p2)], format="ats")
+        assert len(ts) == 16
+
+    def test_empty_list_raises(self):
+        from gwexpy.timeseries.io.ats import read_timeseriesdict_ats
+
+        with pytest.raises(ValueError, match="no ats files provided"):
+            read_timeseriesdict_ats([])
+
+
+# ---------------------------------------------------------------------------
+# CSV: lists concatenate segments along the time axis
+# ---------------------------------------------------------------------------
+
+
+class TestCsvMultiSource:
+    @staticmethod
+    def _write_csv(path, t0, n=10, dt=0.25):
+        # dt=0.25 is exactly representable in binary, so the sample
+        # spacing inferred from each file matches exactly.
+        lines = [f"{t0 + i * dt},{t0 + i * dt}" for i in range(n)]
+        path.write_text("\n".join(lines) + "\n")
+
+    def test_dict_reader_list(self, tmp_path):
+        from gwexpy.timeseries.io.csv_enhanced import read_timeseriesdict_csv
+
+        p1 = tmp_path / "seg1.csv"
+        p2 = tmp_path / "seg2.csv"
+        self._write_csv(p1, 0.0)
+        self._write_csv(p2, 2.5)
+
+        tsd = read_timeseriesdict_csv([str(p1), str(p2)])
+        assert len(tsd) == 1
+        ts = next(iter(tsd.values()))
+        assert len(ts) == 20
+        np.testing.assert_allclose(ts.value, np.arange(20) * 0.25, atol=1e-9)
+
+    def test_timeseries_read_list(self, tmp_path):
+        p1 = tmp_path / "seg1.csv"
+        p2 = tmp_path / "seg2.csv"
+        self._write_csv(p1, 0.0)
+        self._write_csv(p2, 2.5)
+
+        ts = TimeSeries.read([str(p1), str(p2)], format="csv")
+        assert len(ts) == 20
+
+    def test_empty_list_raises(self):
+        from gwexpy.timeseries.io.csv_enhanced import read_timeseriesdict_csv
+
+        with pytest.raises(ValueError, match="no csv files provided"):
+            read_timeseriesdict_csv([])
+
+
+# ---------------------------------------------------------------------------
+# NetCDF4: lists merge variables / concatenate segments
+# ---------------------------------------------------------------------------
+
+
+class TestNetcdf4MultiSource:
+    def test_list_concatenates_and_merges(self, tmp_path):
+        pytest.importorskip("xarray")
+        pytest.importorskip("netCDF4")
+        from gwexpy.timeseries.io.netcdf4_ import (
+            read_timeseriesdict_netcdf4,
+            write_timeseriesdict_netcdf4,
+        )
+
+        p1 = tmp_path / "seg1.nc"
+        p2 = tmp_path / "seg2.nc"
+        t0 = 1000000000
+        write_timeseriesdict_netcdf4(
+            TimeSeriesDict({"a": TimeSeries(np.arange(10.0), t0=t0, dt=1.0, name="a")}),
+            str(p1),
+        )
+        write_timeseriesdict_netcdf4(
+            TimeSeriesDict(
+                {
+                    "a": TimeSeries(
+                        np.arange(10.0, 20.0), t0=t0 + 10, dt=1.0, name="a"
+                    ),
+                    "b": TimeSeries(np.ones(10), t0=t0 + 10, dt=1.0, name="b"),
+                }
+            ),
+            str(p2),
+        )
+
+        tsd = read_timeseriesdict_netcdf4([str(p1), str(p2)])
+        assert set(tsd) == {"a", "b"}
+        assert len(tsd["a"]) == 20
+        np.testing.assert_allclose(tsd["a"].value, np.arange(20.0))
+
+    def test_empty_list_raises(self):
+        from gwexpy.timeseries.io.netcdf4_ import read_timeseriesdict_netcdf4
+
+        with pytest.raises(ValueError, match="no nc files provided"):
+            read_timeseriesdict_netcdf4([])
+
+
+# ---------------------------------------------------------------------------
+# GBD: lists concatenate segments along the time axis
+# ---------------------------------------------------------------------------
+
+
+def _write_gbd(path, start_str, values):
+    """Write a minimal single-channel GRAPHTEC GBD file."""
+    size = len(values)
+    header_lines = [
+        "HeaderSiz=0",
+        f"$$Time Start={start_str}",
+        "$$Data Sample=1",
+        "$$Data Type=Little,Int16",
+        "$$Data Order=CH1",
+        f"$$Data Counts={size}",
+    ]
+    while True:
+        header = "\r\n".join(header_lines) + "\r\n"
+        sz = len(header.encode("ascii"))
+        new_line = f"HeaderSiz={sz}"
+        if header_lines[0] == new_line:
+            break
+        header_lines[0] = new_line
+
+    data = np.asarray(values, dtype="<i2")
+    with open(path, "wb") as f:
+        f.write(header.encode("ascii"))
+        f.write(data.tobytes())
+
+
+class TestGbdMultiSource:
+    def test_list_concatenates_segments(self, tmp_path):
+        from gwexpy.timeseries.io.gbd import read_timeseriesdict_gbd
+
+        p1 = tmp_path / "seg1.gbd"
+        p2 = tmp_path / "seg2.gbd"
+        _write_gbd(p1, "2024/01/01 00:00:00", np.arange(10))
+        _write_gbd(p2, "2024/01/01 00:00:10", np.arange(10, 20))
+
+        tsd = read_timeseriesdict_gbd([str(p1), str(p2)], timezone="UTC")
+        assert "CH1" in tsd
+        assert len(tsd["CH1"]) == 20
+        np.testing.assert_allclose(tsd["CH1"].value, np.arange(20.0))
+
+    def test_dict_read_dispatch(self, tmp_path):
+        p1 = tmp_path / "seg1.gbd"
+        p2 = tmp_path / "seg2.gbd"
+        _write_gbd(p1, "2024/01/01 00:00:00", np.arange(10))
+        _write_gbd(p2, "2024/01/01 00:00:10", np.arange(10, 20))
+
+        tsd = TimeSeriesDict.read([str(p1), str(p2)], format="gbd", timezone="UTC")
+        assert len(tsd["CH1"]) == 20
+
+    def test_empty_list_raises(self):
+        from gwexpy.timeseries.io.gbd import read_timeseriesdict_gbd
+
+        with pytest.raises(ValueError, match="no gbd files provided"):
+            read_timeseriesdict_gbd([], timezone="UTC")
+
+
+# ---------------------------------------------------------------------------
+# ndscope HDF5: lists merge channels / concatenate segments
+# ---------------------------------------------------------------------------
+
+
+class TestNdscopeHdf5MultiSource:
+    def test_list_concatenates_segments(self, tmp_path):
+        pytest.importorskip("h5py")
+        from gwexpy.timeseries.io.ndscope_hdf5 import (
+            read_timeseriesdict_ndscope_hdf5,
+            write_timeseriesdict_ndscope_hdf5,
+        )
+
+        p1 = tmp_path / "seg1.hdf5"
+        p2 = tmp_path / "seg2.hdf5"
+        t0 = 1300000000
+        write_timeseriesdict_ndscope_hdf5(
+            TimeSeriesDict({"X1:TEST": TimeSeries(np.arange(10.0), t0=t0, dt=1.0)}),
+            str(p1),
+        )
+        write_timeseriesdict_ndscope_hdf5(
+            TimeSeriesDict(
+                {"X1:TEST": TimeSeries(np.arange(10.0, 20.0), t0=t0 + 10, dt=1.0)}
+            ),
+            str(p2),
+        )
+
+        tsd = read_timeseriesdict_ndscope_hdf5([str(p1), str(p2)])
+        assert len(tsd["X1:TEST"]) == 20
+        np.testing.assert_allclose(tsd["X1:TEST"].value, np.arange(20.0))
+
+    def test_empty_list_raises(self):
+        from gwexpy.timeseries.io.ndscope_hdf5 import (
+            read_timeseriesdict_ndscope_hdf5,
+        )
+
+        with pytest.raises(ValueError, match="no hdf.ndscope files provided"):
+            read_timeseriesdict_ndscope_hdf5([])
+
+
+# ---------------------------------------------------------------------------
+# Zarr: lists merge channels / concatenate segments
+# ---------------------------------------------------------------------------
+
+
+class TestZarrMultiSource:
+    def test_list_concatenates_segments(self, tmp_path):
+        pytest.importorskip("zarr")
+        from gwexpy.timeseries.io.zarr_ import (
+            read_timeseriesdict_zarr,
+            write_timeseriesdict_zarr,
+        )
+
+        p1 = tmp_path / "seg1.zarr"
+        p2 = tmp_path / "seg2.zarr"
+        write_timeseriesdict_zarr(
+            TimeSeriesDict(
+                {"ch": TimeSeries(np.arange(10.0), t0=0, dt=1.0, name="ch")}
+            ),
+            str(p1),
+        )
+        write_timeseriesdict_zarr(
+            TimeSeriesDict(
+                {"ch": TimeSeries(np.arange(10.0, 20.0), t0=10, dt=1.0, name="ch")}
+            ),
+            str(p2),
+        )
+
+        tsd = read_timeseriesdict_zarr([str(p1), str(p2)])
+        assert len(tsd["ch"]) == 20
+        np.testing.assert_allclose(tsd["ch"].value, np.arange(20.0))
+
+    def test_empty_list_raises(self):
+        pytest.importorskip("zarr")
+        from gwexpy.timeseries.io.zarr_ import read_timeseriesdict_zarr
+
+        with pytest.raises(ValueError, match="no zarr files provided"):
+            read_timeseriesdict_zarr([])
+
+
+# ---------------------------------------------------------------------------
+# SDB: lists concatenate archive databases along the time axis
+# ---------------------------------------------------------------------------
+
+
+def _write_sdb(path, start_unix, n_records=10, interval=1, offset=0.0):
+    conn = sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE archive (dateTime INTEGER, barometer REAL)")
+    for i in range(n_records):
+        conn.execute(
+            "INSERT INTO archive VALUES (?, ?)",
+            (start_unix + i * interval, 29.92 + offset),
+        )
+    conn.commit()
+    conn.close()
+
+
+class TestSdbMultiSource:
+    def test_list_concatenates_segments(self, tmp_path):
+        from gwexpy.timeseries.io.sdb import read_timeseriesdict_sdb
+
+        p1 = tmp_path / "seg1.sdb"
+        p2 = tmp_path / "seg2.sdb"
+        _write_sdb(p1, 1700000000)
+        _write_sdb(p2, 1700000010, offset=1.0)
+
+        tsd = read_timeseriesdict_sdb([str(p1), str(p2)])
+        assert "barometer" in tsd
+        assert len(tsd["barometer"]) == 20
+
+    def test_empty_list_raises(self):
+        from gwexpy.timeseries.io.sdb import read_timeseriesdict_sdb
+
+        with pytest.raises(ValueError, match="no sdb files provided"):
+            read_timeseriesdict_sdb([])
+
+
+# ---------------------------------------------------------------------------
+# WIN: list handling goes through the shared helper (requires obspy)
+# ---------------------------------------------------------------------------
+
+
+class TestWinMultiSource:
+    def test_empty_list_raises(self):
+        pytest.importorskip("obspy")
+        from gwexpy.timeseries.io.win import read_win_file
+
+        with pytest.raises(ValueError, match="no win files provided"):
+            read_win_file([])

--- a/tests/io/test_netcdf4_reader.py
+++ b/tests/io/test_netcdf4_reader.py
@@ -188,3 +188,38 @@ class TestNetCDF4Roundtrip:
         assert all(isinstance(k, int) for k in row_keys), "Row keys should be int"
         assert all(isinstance(k, int) for k in col_keys), "Col keys should be int"
         np.testing.assert_allclose(loaded.value, data)
+
+    def test_matrix_multi_file_preserves_row_col_keys(self, tmp_path):
+        """Reading a list of NetCDF4 matrix files must preserve gwexpy_row/col_key (#443)."""
+        from collections import OrderedDict
+
+        from gwexpy.types.metadata import MetaData, MetaDataDict
+
+        seg1 = TimeSeriesMatrix(
+            np.arange(12, dtype=np.float64).reshape(2, 1, 6),
+            t0=1000000000.0,
+            dt=0.25,
+        )
+        seg2 = TimeSeriesMatrix(
+            np.arange(12, 24, dtype=np.float64).reshape(2, 1, 6),
+            t0=1000000000.0 + 6 * 0.25,
+            dt=0.25,
+        )
+        for seg in (seg1, seg2):
+            seg.rows = MetaDataDict(
+                OrderedDict({"H1": MetaData(), "L1": MetaData()}),
+                expected_size=2,
+                key_prefix="row",
+            )
+
+        path1 = tmp_path / "seg1.nc"
+        path2 = tmp_path / "seg2.nc"
+        seg1.write(str(path1), format="nc")
+        seg2.write(str(path2), format="nc")
+
+        merged = TimeSeriesMatrix.read([str(path1), str(path2)], format="nc")
+
+        assert list(merged.row_keys()) == ["H1", "L1"], (
+            f"row keys lost after multi-file read: {list(merged.row_keys())}"
+        )
+        assert merged.shape[-1] == 12

--- a/tests/io/test_zarr_reader.py
+++ b/tests/io/test_zarr_reader.py
@@ -432,3 +432,38 @@ class TestZarrRoundtrip:
         assert list(loaded.row_keys()) == [0, 1]
         assert list(loaded.col_keys()) == [10, 20]
         np.testing.assert_allclose(loaded.value, data)
+
+    def test_matrix_multi_store_preserves_row_col_keys(self, tmp_path):
+        """Reading a list of Zarr matrix stores must preserve gwexpy_row/col_key (#443)."""
+        from collections import OrderedDict
+
+        from gwexpy.types.metadata import MetaData, MetaDataDict
+
+        seg1 = TimeSeriesMatrix(
+            np.arange(12, dtype=np.float64).reshape(2, 1, 6),
+            t0=1000000000.0,
+            sample_rate=16.0,
+        )
+        seg2 = TimeSeriesMatrix(
+            np.arange(12, 24, dtype=np.float64).reshape(2, 1, 6),
+            t0=1000000000.0 + 6 / 16.0,
+            sample_rate=16.0,
+        )
+        for seg in (seg1, seg2):
+            seg.rows = MetaDataDict(
+                OrderedDict({"H1": MetaData(), "L1": MetaData()}),
+                expected_size=2,
+                key_prefix="row",
+            )
+
+        path1 = tmp_path / "seg1.zarr"
+        path2 = tmp_path / "seg2.zarr"
+        seg1.write(str(path1), format="zarr")
+        seg2.write(str(path2), format="zarr")
+
+        merged = TimeSeriesMatrix.read([str(path1), str(path2)], format="zarr")
+
+        assert list(merged.row_keys()) == ["H1", "L1"], (
+            f"row keys lost after multi-store read: {list(merged.row_keys())}"
+        )
+        assert merged.shape[-1] == 12

--- a/tests/plot/test_defaults.py
+++ b/tests/plot/test_defaults.py
@@ -338,6 +338,95 @@ class TestDetermineGeometryAndSeparate:
         assert sep is True
         assert geom == (4, 1)
 
+    def test_spectrogram_first_then_timeseriesdict_geometry(self):
+        from gwpy.spectrogram import Spectrogram
+        from gwpy.timeseries import TimeSeries
+
+        from gwexpy.timeseries import TimeSeriesDict
+
+        ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
+        sg = Spectrogram(np.ones((16, 8)), t0=0, dt=1, f0=0, df=1)
+        tsd = TimeSeriesDict({"A": ts, "B": ts.copy()})
+        # Spectrogram first must still count the trailing dict channels
+        sep, geom = determine_geometry_and_separate([sg, tsd])
+        assert sep is True
+        assert geom == (3, 1)
+
+    def test_spectrogrammatrix_first_then_timeseriesdict_geometry(self):
+        from gwpy.timeseries import TimeSeries
+
+        from gwexpy.spectrogram import SpectrogramMatrix
+        from gwexpy.timeseries import TimeSeriesDict
+
+        ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
+        sg_mat = SpectrogramMatrix(np.ones((2, 16, 8)), t0=0, dt=1, f0=0, df=1)
+        tsd = TimeSeriesDict({"A": ts, "B": ts.copy()})
+        # Matrix-first must match the dict-first result (order independence)
+        sep, geom = determine_geometry_and_separate([sg_mat, tsd])
+        assert sep is True
+        assert geom == (4, 1)
+        sep2, geom2 = determine_geometry_and_separate([tsd, sg_mat])
+        assert (sep, geom) == (sep2, geom2)
+
+    def test_single_3d_timeseriesmatrix_keeps_grid_geometry(self):
+        from gwexpy.timeseries import TimeSeriesMatrix
+
+        mat = TimeSeriesMatrix(np.ones((2, 3, 16)), dt=1 / 16)
+        sep, geom = determine_geometry_and_separate([mat])
+        assert sep is True
+        assert geom == (2, 3)
+
+    def test_single_4d_spectrogrammatrix_keeps_grid_geometry(self):
+        from gwexpy.spectrogram import SpectrogramMatrix
+
+        sg_mat = SpectrogramMatrix(np.ones((2, 3, 16, 8)), t0=0, dt=1, f0=0, df=1)
+        sep, geom = determine_geometry_and_separate([sg_mat])
+        assert sep is True
+        assert geom == (2, 3)
+
+    def test_matrix_first_then_timeseriesdict_flattens_to_total(self):
+        from gwpy.timeseries import TimeSeries
+
+        from gwexpy.timeseries import TimeSeriesDict, TimeSeriesMatrix
+
+        ts = TimeSeries(np.ones(16), t0=0, dt=1 / 16)
+        tsd = TimeSeriesDict({"A": ts, "B": ts.copy()})
+        mat = TimeSeriesMatrix(np.ones((2, 3, 16)), dt=1 / 16)
+        # With extra args the (2, 3) grid cannot hold them: 6 + 2 → one column
+        sep, geom = determine_geometry_and_separate([mat, tsd])
+        assert sep is True
+        assert geom == (8, 1)
+
+    def test_2d_matrix_geometry_matches_expand_args(self):
+        from gwexpy.frequencyseries import FrequencySeriesDict, FrequencySeriesList
+        from gwexpy.plot._init_helpers import _expand_args
+        from gwexpy.spectrogram import (
+            SpectrogramDict,
+            SpectrogramList,
+            SpectrogramMatrix,
+        )
+        from gwexpy.timeseries import TimeSeriesMatrix
+        from gwexpy.types import SeriesMatrix
+
+        # 2D input is normalized to shape (2, 1, 16) → expands to 2 elements
+        mat = TimeSeriesMatrix(np.ones((2, 16)), dt=1 / 16)
+        expanded: list = []
+        _expand_args(
+            [mat],
+            True,
+            expanded,
+            SeriesMatrix=SeriesMatrix,
+            SpectrogramMatrix=SpectrogramMatrix,
+            FrequencySeriesList=FrequencySeriesList,
+            FrequencySeriesDict=FrequencySeriesDict,
+            SpectrogramList=SpectrogramList,
+            SpectrogramDict=SpectrogramDict,
+        )
+        sep, geom = determine_geometry_and_separate([mat])
+        assert sep is True
+        assert geom == (len(expanded), 1)
+        assert geom == (2, 1)
+
 
 # ---------------------------------------------------------------------------
 # determine_xlabel

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,4 +6,4 @@ import gwexpy
 
 
 def test_package_version_matches_latest_local_release_lineage() -> None:
-    assert gwexpy.__version__ == "0.1.4"
+    assert gwexpy.__version__ == "0.1.5"

--- a/tests/timeseries/test_io_gwf_timeseriesdict.py
+++ b/tests/timeseries/test_io_gwf_timeseriesdict.py
@@ -715,3 +715,28 @@ def test_read_gwf_timeseries_with_single_channel_by_format_gwf():
     assert ts.name == CHANNEL
     if expected:
         assert ts.name in expected
+
+
+def test_safe_get_reader_missing_format_returns_none_without_warning():
+    import warnings
+
+    from gwexpy.timeseries._gwf_io import _safe_get_reader, _safe_get_writer
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert _safe_get_reader("gwexpy-no-such-format", TimeSeries) is None
+        assert _safe_get_writer("gwexpy-no-such-format", TimeSeries) is None
+
+
+def test_safe_get_reader_unexpected_error_warns(monkeypatch):
+    from gwexpy.timeseries import _gwf_io
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("registry broken")
+
+    monkeypatch.setattr(_gwf_io.io_registry, "get_reader", boom)
+    monkeypatch.setattr(_gwf_io.io_registry, "get_writer", boom)
+    with pytest.warns(UserWarning, match="GWF alias registration skipped for 'gwf'"):
+        assert _gwf_io._safe_get_reader("gwf", TimeSeries) is None
+    with pytest.warns(UserWarning, match="GWF alias registration skipped for 'gwf'"):
+        assert _gwf_io._safe_get_writer("gwf", TimeSeries) is None

--- a/tests/types/test_series_matrix_roundtrip_contracts.py
+++ b/tests/types/test_series_matrix_roundtrip_contracts.py
@@ -218,6 +218,24 @@ def test_pickle_warns_once_listing_all_dropped_attrs_keys(matrix_cls):
 
 
 @pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)
+def test_pickle_filters_attrs_with_custom_reduce_raising(matrix_cls):
+    matrix = _make_matrix(matrix_cls)
+
+    class BadReduce:
+        def __reduce__(self):
+            raise ValueError("cannot pickle this")
+
+    matrix.attrs["bad_reduce"] = BadReduce()
+    matrix.attrs["good"] = "kept"
+
+    with pytest.warns(UserWarning, match="bad_reduce"):
+        restored = pickle.loads(pickle.dumps(matrix))
+
+    assert "bad_reduce" not in restored.attrs
+    assert restored.attrs["good"] == "kept"
+
+
+@pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)
 def test_setstate_backward_compat_without_metadata_dict(matrix_cls):
     matrix = _make_matrix(matrix_cls)
     reconstruct, args, state = matrix.__reduce__()

--- a/tests/types/test_series_matrix_roundtrip_contracts.py
+++ b/tests/types/test_series_matrix_roundtrip_contracts.py
@@ -166,7 +166,8 @@ def test_pickle_roundtrip_filters_non_picklable_attrs_entries(matrix_cls):
     expected = matrix.copy()
     del expected.attrs["runtime_callback"]
 
-    restored = pickle.loads(pickle.dumps(matrix))
+    with pytest.warns(UserWarning, match="runtime_callback"):
+        restored = pickle.loads(pickle.dumps(matrix))
 
     assert matrix.attrs["runtime_callback"] is callback
     assert isinstance(restored, matrix_cls)
@@ -181,11 +182,39 @@ def test_default_pickle_filters_attrs_unsafe_for_default_protocol(matrix_cls):
     matrix.attrs["default_protocol_unsafe"] = Protocol5Only()
     matrix.attrs["default_protocol_safe"] = "kept"
 
-    restored = pickle.loads(pickle.dumps(matrix))
+    with pytest.warns(UserWarning, match="default_protocol_unsafe"):
+        restored = pickle.loads(pickle.dumps(matrix))
 
     assert "default_protocol_unsafe" in matrix.attrs
     assert "default_protocol_unsafe" not in restored.attrs
     assert restored.attrs["default_protocol_safe"] == "kept"
+
+
+@pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)
+def test_pickle_warns_once_listing_all_dropped_attrs_keys(matrix_cls):
+    matrix = _make_matrix(matrix_cls)
+
+    def callback() -> None:
+        return None
+
+    matrix.attrs["bad_one"] = callback
+    matrix.attrs["bad_two"] = Protocol5Only()
+    matrix.attrs["good"] = "kept"
+
+    with pytest.warns(UserWarning) as record:
+        restored = pickle.loads(pickle.dumps(matrix))
+
+    dropped_warnings = [
+        w for w in record if "cannot be pickled" in str(w.message)
+    ]
+    assert len(dropped_warnings) == 1
+    message = str(dropped_warnings[0].message)
+    assert "bad_one" in message
+    assert "bad_two" in message
+    assert "bad_one" not in restored.attrs
+    assert "bad_two" not in restored.attrs
+    assert restored.attrs["good"] == "kept"
+    assert restored.attrs["pipeline"] == "wave1"
 
 
 @pytest.mark.parametrize("matrix_cls", MATRIX_CLASSES)

--- a/tests/types/test_series_matrix_structure.py
+++ b/tests/types/test_series_matrix_structure.py
@@ -77,6 +77,16 @@ class TestAstype:
         assert result.dtype == np.float32
         assert result is not tsm
 
+    def test_astype_attrs_independent(self):
+        # Mutating the result's attrs must not affect the source matrix
+        tsm = _make_tsm()
+        tsm.attrs["tag"] = {"nested": 1}
+        result = tsm.astype(np.float32)
+        result.attrs["tag"]["nested"] = 999
+        result.attrs["extra"] = "added"
+        assert tsm.attrs["tag"]["nested"] == 1
+        assert "extra" not in tsm.attrs
+
 
 # ---------------------------------------------------------------------------
 # real / imag properties
@@ -118,6 +128,16 @@ class TestRealImag:
         # name=None → empty string
         result = tsm.imag
         assert result is not None
+
+    def test_real_imag_attrs_independent(self):
+        # Mutating result attrs must not affect the source matrix
+        tsm = _make_tsm(complex_=True)
+        tsm.attrs["tag"] = "orig"
+        for result in (tsm.real, tsm.imag):
+            result.attrs["tag"] = "mutated"
+            result.attrs["extra"] = "added"
+            assert tsm.attrs["tag"] == "orig"
+            assert "extra" not in tsm.attrs
 
 
 # ---------------------------------------------------------------------------

--- a/tests/types/test_series_matrix_structure.py
+++ b/tests/types/test_series_matrix_structure.py
@@ -161,6 +161,14 @@ class TestConj:
         result = tsm.conj()
         assert result is not None
 
+    def test_conj_attrs_independent(self):
+        # Mutating the result's attrs must not affect the source matrix
+        tsm = _make_tsm(complex_=True)
+        tsm.attrs["tag"] = {"nested": 1}
+        result = tsm.conj()
+        result.attrs["tag"]["nested"] = 999
+        assert tsm.attrs["tag"]["nested"] == 1
+
 
 # ---------------------------------------------------------------------------
 # transpose / T
@@ -183,6 +191,14 @@ class TestTranspose:
         result = tsm.transpose(2, 0, 1)
         # Returns plain ndarray for custom axes
         assert result.shape == (8, 2, 3)
+
+    def test_transpose_attrs_independent(self):
+        # Mutating the result's attrs must not affect the source matrix
+        tsm = _make_tsm()
+        tsm.attrs["tag"] = {"nested": 1}
+        result = tsm.T
+        result.attrs["tag"]["nested"] = 999
+        assert tsm.attrs["tag"]["nested"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -213,6 +229,14 @@ class TestReshape:
         tsm = _make_tsm()
         with pytest.raises(ValueError, match="2D or 3D"):
             tsm.reshape(2, 3, 8, 1)
+
+    def test_reshape_attrs_independent(self):
+        # Mutating the result's attrs must not affect the source matrix
+        tsm = _make_tsm(n_rows=2, n_cols=3, n_t=8)
+        tsm.attrs["tag"] = {"nested": 1}
+        result = tsm.reshape(6, 1)
+        result.attrs["tag"]["nested"] = 999
+        assert tsm.attrs["tag"]["nested"] == 1
 
     def test_reshape_with_copy_true(self):
         # Lines 208-210 — copy=True path


### PR DESCRIPTION
## Summary

This PR fixes three follow-up bug patterns found after the v0.1.5 release audit, as a **v0.1.6 candidate bugfix PR**:

- Fix plot geometry counting so it matches `_expand_args(separate=True)` (#440)
- Add shared list/tuple multi-source handling for TimeSeries readers (#441)
- Clean up silent failures and attrs-sharing bugs in GWF alias registration and SeriesMatrix metadata handling (#442)

## Fixes

### #440: plot geometry counting

- Added a shared `_count_expanded()` helper.
- Removed order-dependent early-return behavior.
- Ensured geometry counting matches actual argument expansion.
- Added regression tests for mixed containers and matrix expansion geometry.

### #441: list/tuple input for readers

- Added a shared multi-source helper in `gwexpy/timeseries/io/_multi.py`.
- Applied explicit list/tuple handling across TimeSeries readers.
- Supported timestamp-based merge behavior where semantics are well-defined.
- Added clear `ValueError` failures for formats where multi-file semantics are not supported, such as wav/audio.
- Added parameterized regression tests.

### #442: silent-failure cleanup

- Narrowed exception handling in GWF alias registration.
- Added warnings for unexpected registry/lookup failures.
- Avoided silently dropping pickle attrs without diagnostics.
- Fixed attrs-sharing bugs for `astype`, `real`, `imag`, `conj`, `transpose`, and `reshape`.
- Added regression tests for reviewer-found edge cases.

## Validation

- Impacted suites passed:

  ```text
  1684 passed / 246 skipped / 0 failed
  ```

- Ruff passed on changed files.
- Known collection errors involving missing PyQt5 are unrelated to this PR.

## Scope

This PR does not implement #438. A related astropy fallback pattern was noted there, but the registry-unification fix remains deferred pending the #438 design decision.

## Related issues

Closes #440. Closes #441. Closes #442. Refs #438.

https://claude.ai/code/session_011FXmAZEtt7NHiN7xywgFwF

---
_Generated by [Claude Code](https://claude.ai/code/session_011FXmAZEtt7NHiN7xywgFwF)_