### PR TITLE
test(io): add FrequencySeries collection registry-backend audit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
   errors, empty-list rejection, and clear single-file-only errors.
 - Added regression tests for pickle attrs warnings and attrs independence
   of derived matrices.
+- **frequencyseries/io**: Added registry-backend audit tests and a developer
+  note for FrequencySeries collection read/write fallback (#438). No
+  behaviour change.
 
 ## [0.1.5] - 2026-06-10
 

--- a/docs/developers/guides/frequencyseries_registry_backends.md
+++ b/docs/developers/guides/frequencyseries_registry_backends.md
@@ -1,0 +1,66 @@
+# FrequencySeries I/O Registry Backends
+
+> Developer note — audit-only, no behaviour change.
+> Tracked by issue #438 (this document) and issue #444 (migration decision).
+
+## Current State
+
+GWexpy exposes two distinct I/O dispatch backends within the `frequencyseries`
+package.  These backends are **intentionally separated** at present.
+
+| Class | Read/Write backend | Where formats are registered |
+|---|---|---|
+| `FrequencySeries` | `gwpy.io.registry.default_registry` | `gwexpy/frequencyseries/io/` and stubs |
+| `FrequencySeriesMatrix` | `gwpy.io.registry.default_registry` | `SeriesMatrixIOMixin` fallback |
+| `FrequencySeriesBaseDict` / `FrequencySeriesDict` | `astropy.io.registry` (module-level functions) | astropy global registry — but `xml.diaggui` / `dttxml` are handled by an inline fast path *before* the astropy fallback, and are also registered in the gwpy registry (see observation 4) |
+| `FrequencySeriesBaseList` / `FrequencySeriesList` | `astropy.io.registry` (module-level functions) | astropy global registry |
+
+### Key observations
+
+1. **`FrequencySeries` and `FrequencySeriesMatrix`** dispatch through
+   `gwpy.io.registry.default_registry`.  Formats such as `xml.diaggui` and
+   `dttxml` are registered there on import.
+
+2. **Collection containers** (`FrequencySeriesBaseDict`, `FrequencySeriesBaseList`
+   and their concrete subclasses) dispatch unknown formats through the module-level
+   `astropy.io.registry.read` / `astropy.io.registry.write` functions.
+   This means:
+
+   - A format registered **only** in `gwpy.io.registry.default_registry` is
+     **not** reachable via `FrequencySeriesDict.read()` / `FrequencySeriesList.read()`.
+   - Conversely, a format must be registered in the astropy global registry to be
+     reachable from collection read/write.
+
+3. **`FrequencySeriesList` is not registered in `gwpy.io.registry.default_registry`
+   at all** (confirmed by `get_formats` returning an empty table).
+
+4. The fast-path dispatch in `FrequencySeriesBaseDict.read` for `xml.diaggui` /
+   `dttxml` bypasses the registry entirely — these formats are handled inline
+   before the astropy fallback.
+
+## Why This Split Exists
+
+The collection containers (`FrequencySeriesBaseDict`, `FrequencySeriesBaseList`)
+pre-date the GWpy-aligned registry migration.  Their `read`/`write` methods
+were written against the standard Astropy Unified I/O API rather than the GWpy
+`default_registry` wrapper.  The two codepaths diverged organically and have not
+yet been unified.
+
+## No Behaviour Change Policy
+
+This split is **preserved as-is** until a deliberate migration decision is made.
+The audit tests in
+`tests/io/test_frequencyseries_collections_registry.py` lock in the current
+dispatch behaviour so that any future refactor can be verified against a known
+baseline.
+
+## Future Work
+
+Issue **#444** tracks the decision of whether to:
+
+- Migrate collection containers to use `gwpy.io.registry.default_registry`, or
+- Keep the astropy-registry fallback and ensure all needed formats are
+  cross-registered, or
+- Introduce an explicit public API that abstracts the difference.
+
+No action is required before #444 is resolved.

--- a/tests/io/test_frequencyseries_collections_registry.py
+++ b/tests/io/test_frequencyseries_collections_registry.py
@@ -39,7 +39,6 @@ from gwexpy.frequencyseries import (
     FrequencySeriesMatrix,
 )
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -116,8 +115,8 @@ class TestFrequencySeriesDictRegistryBackend:
     def test_gwpy_only_format_is_NOT_reachable_via_dict_read(self):
         """A format registered only in gwpy default_registry is invisible to
         the collection read fallback (which uses astropy.io.registry)."""
-        from gwpy.io.registry import default_registry as gwpy_reg
         from astropy.io.registry import IORegistryError
+        from gwpy.io.registry import default_registry as gwpy_reg
 
         gwpy_format = "gwpy-only-audit-dict"
         gwpy_reg.register_reader(gwpy_format, FrequencySeriesDict, _gwpy_registry_sentinel)
@@ -174,8 +173,8 @@ class TestFrequencySeriesListRegistryBackend:
     def test_gwpy_only_format_is_NOT_reachable_via_list_read(self):
         """A format registered only in gwpy default_registry is invisible to
         the FrequencySeriesList read fallback."""
-        from gwpy.io.registry import default_registry as gwpy_reg
         from astropy.io.registry import IORegistryError
+        from gwpy.io.registry import default_registry as gwpy_reg
 
         gwpy_format = "gwpy-only-audit-list"
         gwpy_reg.register_reader(gwpy_format, FrequencySeriesList, _gwpy_registry_sentinel)

--- a/tests/io/test_frequencyseries_collections_registry.py
+++ b/tests/io/test_frequencyseries_collections_registry.py
@@ -1,0 +1,292 @@
+"""Audit tests for FrequencySeries collection read/write registry backend.
+
+These tests fix the *current* behaviour of the registry dispatch in
+``gwexpy.frequencyseries.collections``:
+
+* ``FrequencySeriesBaseDict`` (and its subclass ``FrequencySeriesDict``)
+  dispatches unknown formats through ``astropy.io.registry`` for both
+  ``read`` and ``write``.
+* ``FrequencySeriesBaseList`` (and its subclass ``FrequencySeriesList``)
+  dispatches unknown formats through ``astropy.io.registry`` for both
+  ``read`` and ``write``.
+* A format registered **only** in ``gwpy.io.registry.default_registry``
+  is **not** reachable via the collection ``read``/``write`` fallback path.
+* ``FrequencySeriesBaseList`` (unlike ``FrequencySeriesBaseDict``) has
+  **no entries** in ``gwpy.io.registry.default_registry`` at all —
+  ``get_formats`` returns an empty table (tracked in issue #444).
+* ``FrequencySeriesMatrix.read/write`` uses ``gwpy.io.registry.default_registry``
+  (SeriesMatrixIOMixin), confirming the split between series/matrix and
+  plain collection containers.
+
+No behaviour is changed by these tests.  They exist solely to document and
+lock in the current dispatch contract so that future refactors (tracked in
+issue #444) can be verified against a known baseline.
+
+See ``docs/developers/guides/frequencyseries_registry_backends.md`` for the
+developer rationale.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from gwexpy.frequencyseries import (
+    FrequencySeriesDict,
+    FrequencySeriesList,
+    FrequencySeriesMatrix,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _SentinelReached(Exception):
+    """Raised by sentinel readers/writers to confirm dispatch path."""
+
+
+def _astropy_sentinel_reader(source, *args, **kwargs):
+    raise _SentinelReached("astropy reader reached")
+
+
+def _astropy_sentinel_writer(data, target, *args, **kwargs):
+    raise _SentinelReached("astropy writer reached")
+
+
+def _gwpy_registry_sentinel(source, *args, **kwargs):
+    raise _SentinelReached("gwpy registry was unexpectedly reached")
+
+
+def _run_isolated(code: str) -> subprocess.CompletedProcess[str]:
+    """Run *code* in a fresh Python subprocess and return the result."""
+    try:
+        return subprocess.run(
+            [sys.executable, "-c", textwrap.dedent(code)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except subprocess.TimeoutExpired as e:
+        pytest.fail(f"Subprocess timed out after 60s. stdout: {e.stdout!r}")
+
+
+# ---------------------------------------------------------------------------
+# FrequencySeriesDict  (FrequencySeriesBaseDict)
+# ---------------------------------------------------------------------------
+
+
+class TestFrequencySeriesDictRegistryBackend:
+    """FrequencySeriesDict.read/write fallback goes through astropy.io.registry."""
+
+    _FORMAT = "test-audit-dict-read"
+    _FORMAT_W = "test-audit-dict-write"
+
+    def test_read_dispatches_to_astropy_registry(self):
+        """Unknown format reaches astropy.io.registry, not gwpy default_registry."""
+        from astropy.io import registry as astropy_reg
+
+        astropy_reg.register_reader(
+            self._FORMAT, FrequencySeriesDict, _astropy_sentinel_reader
+        )
+        try:
+            with pytest.raises(_SentinelReached, match="astropy reader reached"):
+                FrequencySeriesDict.read("dummy.txt", format=self._FORMAT)
+        finally:
+            astropy_reg.unregister_reader(self._FORMAT, FrequencySeriesDict)
+
+    def test_write_dispatches_to_astropy_registry(self):
+        """Unknown format reaches astropy.io.registry for write."""
+        from astropy.io import registry as astropy_reg
+
+        # Register on dict (base class) so astropy MRO lookup succeeds.
+        astropy_reg.register_writer(
+            self._FORMAT_W, dict, _astropy_sentinel_writer
+        )
+        try:
+            fsd = FrequencySeriesDict()
+            with pytest.raises(_SentinelReached, match="astropy writer reached"):
+                fsd.write("dummy.txt", format=self._FORMAT_W)
+        finally:
+            astropy_reg.unregister_writer(self._FORMAT_W, dict)
+
+    def test_gwpy_only_format_is_NOT_reachable_via_dict_read(self):
+        """A format registered only in gwpy default_registry is invisible to
+        the collection read fallback (which uses astropy.io.registry)."""
+        from gwpy.io.registry import default_registry as gwpy_reg
+        from astropy.io.registry import IORegistryError
+
+        gwpy_format = "gwpy-only-audit-dict"
+        gwpy_reg.register_reader(gwpy_format, FrequencySeriesDict, _gwpy_registry_sentinel)
+        try:
+            with pytest.raises((IORegistryError, _SentinelReached)) as exc_info:
+                FrequencySeriesDict.read("dummy.txt", format=gwpy_format)
+            assert isinstance(exc_info.value, IORegistryError), (
+                "Expected IORegistryError (astropy fallback does not see "
+                "gwpy-only formats), but the gwpy registry reader was reached"
+            )
+        finally:
+            gwpy_reg.unregister_reader(gwpy_format, FrequencySeriesDict)
+
+
+# ---------------------------------------------------------------------------
+# FrequencySeriesList  (FrequencySeriesBaseList)
+# ---------------------------------------------------------------------------
+
+
+class TestFrequencySeriesListRegistryBackend:
+    """FrequencySeriesList.read/write fallback goes through astropy.io.registry."""
+
+    _FORMAT = "test-audit-list-read"
+    _FORMAT_W = "test-audit-list-write"
+
+    def test_read_dispatches_to_astropy_registry(self):
+        """Unknown format reaches astropy.io.registry for list read."""
+        from astropy.io import registry as astropy_reg
+
+        astropy_reg.register_reader(
+            self._FORMAT, FrequencySeriesList, _astropy_sentinel_reader
+        )
+        try:
+            with pytest.raises(_SentinelReached, match="astropy reader reached"):
+                FrequencySeriesList.read("dummy.txt", format=self._FORMAT)
+        finally:
+            astropy_reg.unregister_reader(self._FORMAT, FrequencySeriesList)
+
+    def test_write_dispatches_to_astropy_registry(self):
+        """Unknown format reaches astropy.io.registry for list write."""
+        from astropy.io import registry as astropy_reg
+
+        # Register on list (base class) for astropy MRO lookup.
+        astropy_reg.register_writer(
+            self._FORMAT_W, list, _astropy_sentinel_writer
+        )
+        try:
+            fsl = FrequencySeriesList()
+            with pytest.raises(_SentinelReached, match="astropy writer reached"):
+                fsl.write("dummy.txt", format=self._FORMAT_W)
+        finally:
+            astropy_reg.unregister_writer(self._FORMAT_W, list)
+
+    def test_gwpy_only_format_is_NOT_reachable_via_list_read(self):
+        """A format registered only in gwpy default_registry is invisible to
+        the FrequencySeriesList read fallback."""
+        from gwpy.io.registry import default_registry as gwpy_reg
+        from astropy.io.registry import IORegistryError
+
+        gwpy_format = "gwpy-only-audit-list"
+        gwpy_reg.register_reader(gwpy_format, FrequencySeriesList, _gwpy_registry_sentinel)
+        try:
+            with pytest.raises((IORegistryError, _SentinelReached)) as exc_info:
+                FrequencySeriesList.read("dummy.txt", format=gwpy_format)
+            assert isinstance(exc_info.value, IORegistryError), (
+                "Expected IORegistryError (astropy fallback does not see "
+                "gwpy-only formats), but the gwpy registry reader was reached"
+            )
+        finally:
+            gwpy_reg.unregister_reader(gwpy_format, FrequencySeriesList)
+
+
+# ---------------------------------------------------------------------------
+# FrequencySeriesMatrix — uses gwpy default_registry (different backend)
+# ---------------------------------------------------------------------------
+
+
+class TestFrequencySeriesMatrixRegistryBackend:
+    """FrequencySeriesMatrix.read/write dispatches through gwpy.io.registry,
+    not astropy.io.registry.  This confirms the split between collection
+    containers (astropy backend) and the matrix type (gwpy backend)."""
+
+    def test_matrix_write_uses_gwpy_registry(self):
+        """A format registered in gwpy default_registry is reachable from
+        FrequencySeriesMatrix.write, unlike the collection containers."""
+        from gwpy.io.registry import default_registry as gwpy_reg
+
+        gwpy_format = "gwpy-matrix-audit-write"
+        gwpy_reg.register_writer(gwpy_format, FrequencySeriesMatrix, _astropy_sentinel_writer)
+        try:
+            import numpy as np
+            fsm = FrequencySeriesMatrix(
+                np.zeros((2, 3)),
+                f0=0.0,
+                df=1.0,
+                dx=1.0,
+            )
+            with pytest.raises(_SentinelReached, match="astropy writer reached"):
+                fsm.write("dummy.txt", format=gwpy_format)
+        finally:
+            gwpy_reg.unregister_writer(gwpy_format, FrequencySeriesMatrix)
+
+    def test_matrix_read_uses_gwpy_registry(self):
+        """A format registered in gwpy default_registry is reachable from
+        FrequencySeriesMatrix.read."""
+        from gwpy.io.registry import default_registry as gwpy_reg
+
+        gwpy_format = "gwpy-matrix-audit-read"
+        gwpy_reg.register_reader(gwpy_format, FrequencySeriesMatrix, _astropy_sentinel_reader)
+        try:
+            with pytest.raises(_SentinelReached, match="astropy reader reached"):
+                FrequencySeriesMatrix.read("dummy.txt", format=gwpy_format)
+        finally:
+            gwpy_reg.unregister_reader(gwpy_format, FrequencySeriesMatrix)
+
+
+# ---------------------------------------------------------------------------
+# Subprocess-isolated tests: xml.diaggui / dttxml visible in gwpy registry
+# ---------------------------------------------------------------------------
+
+
+class TestCollectionsGwpyRegistrationSubprocess:
+    """Subprocess-isolated verification that xml.diaggui / dttxml appear in
+    gwpy.io.registry.default_registry for FrequencySeriesDict after
+    ``import gwexpy.frequencyseries``."""
+
+    def test_xml_diaggui_in_gwpy_registry_for_frequencyseriesdict(self):
+        result = _run_isolated("""\
+            from gwpy.io.registry import default_registry as reg
+            from gwexpy.frequencyseries import FrequencySeriesDict
+            fmt_names = list(reg.get_formats(FrequencySeriesDict, "Read")["Format"])
+            assert "xml.diaggui" in fmt_names, f"xml.diaggui not in {fmt_names}"
+            assert "dttxml" in fmt_names, f"dttxml not in {fmt_names}"
+        """)
+        assert result.returncode == 0, result.stderr
+
+    def test_frequencyserieslist_has_no_formats_in_gwpy_registry(self):
+        """FrequencySeriesList is NOT registered in gwpy.io.registry.default_registry.
+        Its read/write fallback goes exclusively through astropy.io.registry.
+        This documents the current behaviour: unlike FrequencySeriesDict, the list
+        type has no entries in the gwpy registry (tracked by issue #444)."""
+        result = _run_isolated("""\
+            from gwpy.io.registry import default_registry as reg
+            from gwexpy.frequencyseries import FrequencySeriesList
+            fmt_names = list(reg.get_formats(FrequencySeriesList, "Read")["Format"])
+            assert fmt_names == [], (
+                f"Expected no gwpy formats for FrequencySeriesList, got {fmt_names}"
+            )
+        """)
+        assert result.returncode == 0, result.stderr
+
+    def test_collections_fallback_backend_is_astropy_not_gwpy(self):
+        """In a fresh process, registering a format only in gwpy registry
+        does NOT make it reachable via FrequencySeriesDict.read()."""
+        result = _run_isolated("""\
+            from gwpy.io.registry import default_registry as gwpy_reg
+            from astropy.io.registry import IORegistryError
+            from gwexpy.frequencyseries import FrequencySeriesDict
+
+            def _reader(src, *a, **kw):
+                pass
+
+            gwpy_reg.register_reader("gwpy-subprocess-audit", FrequencySeriesDict, _reader)
+            try:
+                FrequencySeriesDict.read("no_such_file.txt", format="gwpy-subprocess-audit")
+                raise AssertionError("should have raised IORegistryError")
+            except IORegistryError:
+                pass  # expected: astropy fallback does not see gwpy-only formats
+            finally:
+                gwpy_reg.unregister_reader("gwpy-subprocess-audit", FrequencySeriesDict)
+        """)
+        assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

Audit/test-only implementation for #438 (no behavior change). The registry backend migration decision is tracked separately in #444.

- Add `tests/io/test_frequencyseries_collections_registry.py` (11 tests):
  - `FrequencySeriesDict`/`FrequencySeriesList` read/write fallback dispatches through `astropy.io.registry` (sentinel-based verification with cleanup)
  - gwpy-only formats are **not** reachable via collection fallback (with diagnostics distinguishing "astropy fallback miss" from "gwpy registry unexpectedly reached")
  - `FrequencySeriesMatrix` read/write uses `gwpy.io.registry.default_registry` (`SeriesMatrixIOMixin`)
  - Subprocess-isolated tests: `xml.diaggui` / `dttxml` visible in the gwpy registry after `import gwexpy.frequencyseries`; `FrequencySeriesList` has no gwpy registry entries (current state, tracked in #444)
- Add developer note `docs/developers/guides/frequencyseries_registry_backends.md` documenting the backend split and the no-behavior-change policy
- CHANGELOG entry under [Unreleased]

## Test plan

- [x] `pytest tests/io/test_frequencyseries_collections_registry.py tests/io/test_frequencyseries_io.py` — 31 passed
- [x] No diff under `gwexpy/` (audit/test-only)

Closes #438

🤖 Generated with [Claude Code](https://claude.com/claude-code)